### PR TITLE
linked_list_allocator 0.5.0 breaks backward compatibility 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-linked_list_allocator = {git = "https://github.com/phil-opp/linked-list-allocator"}
+linked_list_allocator = "0.4.3"
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
This PR specifies the version of linked-list-allocator instead of using URL

The following error is generated with version ```0.5.0```
```
error[E0599]: no method named `write` found for type `*mut hole::Hole` in the current scope
  --> /home/niklasad1/.cargo/registry/src/github.com-1ecc6299db9ec823/linked_list_allocator-0.5.0/src/hole.rs:29:13
   |
29 |         ptr.write(Hole { size: hole_size, next: None, });
   |             ^^^^^

error[E0599]: no method named `write` found for type `*mut hole::Hole` in the current scope
   --> /home/niklasad1/.cargo/registry/src/github.com-1ecc6299db9ec823/linked_list_allocator-0.5.0/src/hole.rs:286:30
    |
286 |                 unsafe { ptr.write(new_hole) };
    |                              ^^^^^

error: aborting due to 2 previous errors

error: Could not compile `linked_list_allocator`.
```