### PR TITLE
Bugfix/ipc buffers

### DIFF
--- a/examples/ipcserver.rs
+++ b/examples/ipcserver.rs
@@ -15,16 +15,15 @@ fn main() {
     let mut console = Console::new();
     console.write(String::from("Start service:\n"));
 
-    let cb = &mut |pid: usize, _: usize, message: &mut [u8; 32]| {
+    #[allow(unused_variables)]
+    let server = IpcServerDriver::start(|pid: usize, _: usize, message: &mut [u8]| {
         console.write(String::from("Server: \"Payload: "));
 
         console.write(u32_as_hex(message[0] as u32));
         console.write(String::from("\"\n"));
         message[0] += 1;
         ipc_cs::notify_client(pid);
-    };
-    #[allow(unused_variables)]
-    let server = IpcServerDriver::start(cb);
+    });
 
     loop {
         tock::syscalls::yieldk();


### PR DESCRIPTION
**Description**
This pull request fixes safety-issues in the implementation of the IPC-drivers. The server driver assumed that the slice passed to a callback had a size of 32 bytes.

**Test Strategy**
The change been tested manually running the ipc-examples.

**Remark**
This pull request has to be merged after #13.
