### PR TITLE
New allow structure, de-allow and de-subscribe features

### DIFF
--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -35,7 +35,7 @@ fn main() {
 
     server.share(&mut buf, &mut payload);
 
-    server.subscribe_callback(|_: usize, _: usize| {
+    let handle = server.subscribe_callback(|_: usize, _: usize| {
         let filtered = buf.to_vec()
             .into_iter()
             .filter(|x| *x != 0)
@@ -49,4 +49,5 @@ fn main() {
     for _ in 0.. {
         timer::sleep(Duration::from_ms(500))
     }
+    handle.unwrap();
 }

--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -16,6 +16,9 @@ use tock::timer::Duration;
 fn main() {
     let mut buf: Box<[u8]> = ipc_cs::reserve_shared_buffer();
     let mut console = Console::new();
+
+    // This sleep is neccessary to assure, that during installation of
+    // the client/server pair the tests are only run once.
     timer::sleep(Duration::from_ms(3000));
 
     console.write(String::from("[test-results]\n"));
@@ -34,9 +37,8 @@ fn main() {
 
     server.subscribe_callback(|_: usize, _: usize| {
         let filtered = buf.to_vec()
-            .iter()
-            .filter(|&x| *x != 0)
-            .map(|x| *x)
+            .into_iter()
+            .filter(|x| *x != 0)
             .collect::<Vec<u8>>();
         let s = String::from_utf8_lossy(&filtered);
         console.write(String::from(s).clone());

--- a/examples/hardware_test_server.rs
+++ b/examples/hardware_test_server.rs
@@ -14,9 +14,8 @@ fn main() {
     let cb = &mut |pid: usize, _: usize, message: &mut [u8]| {
         let filtered = message
             .to_vec()
-            .iter()
-            .filter(|&x| *x != 0)
-            .map(|x| *x)
+            .into_iter()
+            .filter(|x| *x != 0)
             .collect::<Vec<u8>>();
         let s = String::from_utf8_lossy(&filtered);
         if s == String::from("client") {

--- a/examples/ipcclient.rs
+++ b/examples/ipcclient.rs
@@ -21,7 +21,7 @@ fn main() {
         let mut payload: [u8; 32] = [5; 32];
 
         server.share(&mut buf, &mut payload);
-        server.subscribe_callback(|_: usize, _: usize| {
+        let handle = server.subscribe_callback(|_: usize, _: usize| {
             let mut console = Console::new();
             console.write(String::from("Client: \"Payload: "));
             console.write(fmt::u32_as_hex(buf[0] as u32));
@@ -29,5 +29,6 @@ fn main() {
         });
         server.notify();
         timer::sleep(timer::Duration::from_ms(1000));
+        handle.unwrap();
     }
 }

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -10,7 +10,7 @@ extern crate tock;
 
 use alloc::String;
 use tock::led;
-use tock::simple_ble::BleDeviceUninitialized;
+use tock::simple_ble::BleAdvertisingDriver;
 use tock::timer;
 use tock::timer::Duration;
 
@@ -27,11 +27,9 @@ fn main() {
     let name = String::from("Tock!");
     let uuid: [u16; 1] = [0x0018];
 
-    let mut payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
+    let payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
 
-    let mut bleuninit = BleDeviceUninitialized::new(100, name, uuid.to_vec(), true, &mut payload);
-    let mut bleinit = bleuninit.initialize().unwrap();
-    let ble = bleinit.start_advertising().unwrap();
+    let handle = BleAdvertisingDriver::initialize(100, name, uuid.to_vec(), true, payload).unwrap();
 
     loop {
         led.on();

--- a/src/ble_parser.rs
+++ b/src/ble_parser.rs
@@ -1,8 +1,7 @@
 use alloc::*;
-use simple_ble::BUFFER_SIZE_SCAN;
 
-pub fn find(buffer: &[u8; BUFFER_SIZE_SCAN], kind: u8) -> Option<Vec<&u8>> {
-    let mut iter = buffer[8..BUFFER_SIZE_SCAN].iter();
+pub fn find(buffer: &[u8], kind: u8) -> Option<Vec<&u8>> {
+    let mut iter = buffer[8..].iter();
 
     loop {
         match iter.next() {
@@ -27,6 +26,7 @@ pub fn find(buffer: &[u8; BUFFER_SIZE_SCAN], kind: u8) -> Option<Vec<&u8>> {
 #[cfg(test)]
 mod test {
     use ble_parser::*;
+    use simple_ble::BUFFER_SIZE_SCAN;
 
     #[test]
     pub fn extracts_data_for_ids_correctly() {

--- a/src/ipc_cs/client.rs
+++ b/src/ipc_cs/client.rs
@@ -3,7 +3,10 @@ use alloc::allocator::{Alloc, Layout};
 use alloc::boxed::Box;
 use alloc::heap::Heap;
 use alloc::raw_vec::RawVec;
-use syscalls::{allow, command, subscribe};
+use callback::CallbackSubscription;
+use callback::SubscribableCallback;
+use result::TockResult;
+use syscalls;
 
 const DRIVER_NUMBER: usize = 0x10000;
 
@@ -11,17 +14,26 @@ mod ipc_commands {
     pub const DISCOVER_SERVICE: usize = 0;
 }
 
-pub struct ServerHandle<CB: IPCCallback> {
+pub struct ServerHandle {
     pid: isize,
-    callback: Option<CB>,
 }
 
-pub trait IPCCallback {
-    fn callback(&mut self, usize, usize);
+pub struct IpcClientCallback<CB> {
+    callback: CB,
+    pid: isize,
 }
-impl<F: FnMut(usize, usize)> IPCCallback for F {
-    fn callback(&mut self, pid: usize, len: usize) {
-        self(pid, len);
+
+impl<CB: FnMut(usize, usize)> SubscribableCallback for IpcClientCallback<CB> {
+    fn driver_number(&self) -> usize {
+        DRIVER_NUMBER
+    }
+
+    fn subscribe_number(&self) -> usize {
+        self.pid as usize
+    }
+
+    fn call_rust(&mut self, pid: usize, len: usize, _: usize) {
+        (self.callback)(pid, len);
     }
 }
 
@@ -34,52 +46,44 @@ pub fn reserve_shared_buffer() -> Box<[u8]> {
     v
 }
 
-impl<CB: IPCCallback> ServerHandle<CB> {
+impl ServerHandle {
     pub fn share(&mut self, shared_buffer: &mut Box<[u8]>, message: &[u8; 32]) {
         shared_buffer.clone_from_slice(message);
 
         unsafe {
-            if allow(DRIVER_NUMBER, self.pid as usize, &*shared_buffer) < 0 {
+            if syscalls::allow(DRIVER_NUMBER, self.pid as usize, &*shared_buffer) < 0 {
                 panic!()
             };
         }
     }
 
     pub fn notify(&mut self) {
-        unsafe { command(DRIVER_NUMBER, self.pid as usize, 0, 0) };
+        unsafe { syscalls::command(DRIVER_NUMBER, self.pid as usize, 0, 0) };
     }
 
-    pub fn discover_service(name: String) -> Option<ServerHandle<CB>> {
+    pub fn discover_service(name: String) -> Option<ServerHandle> {
         let pid = unsafe {
-            allow(
+            syscalls::allow(
                 DRIVER_NUMBER,
                 ipc_commands::DISCOVER_SERVICE,
                 &name.as_bytes(),
             )
         };
         if pid >= 0 {
-            Some(ServerHandle {
-                callback: None,
-                pid: pid,
-            })
+            Some(ServerHandle { pid: pid })
         } else {
             None
         }
     }
 
-    pub fn subscribe_callback(&mut self, mut callback: CB) {
-        extern "C" fn cb<CB: IPCCallback>(result: usize, len: usize, _: usize, ud: usize) {
-            let callback = unsafe { &mut *(ud as *mut CB) };
-            callback.callback(result, len);
-        }
-        unsafe {
-            subscribe(
-                DRIVER_NUMBER,
-                self.pid as usize,
-                cb::<CB>,
-                &mut callback as *mut _ as usize,
-            );
-        }
-        self.callback = Some(callback);
+    pub fn subscribe_callback<CB: FnMut(usize, usize)>(
+        &self,
+        callback: CB,
+    ) -> TockResult<CallbackSubscription<IpcClientCallback<CB>>, isize> {
+        let (_, handle) = syscalls::subscribe_new(IpcClientCallback {
+            callback: callback,
+            pid: self.pid,
+        });
+        Ok(handle)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod simple_ble;
 pub mod temperature;
 pub mod timer;
 pub mod util;
+pub mod shared_memory;
 
 #[cfg(target_os = "tock")]
 pub mod entry_point;

--- a/src/result.rs
+++ b/src/result.rs
@@ -22,4 +22,6 @@ impl<T, E> TockResultExt<T, E> for TockResult<T, E> {
 
 pub const SUCCESS: isize = 0;
 pub const EALREADY: isize = -3;
+pub const EINVAL: isize = -6;
+pub const ESIZE: isize = -7;
 pub const ENOMEM: isize = -9;

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -1,0 +1,18 @@
+pub trait ShareableMemory {
+    fn driver_number(&self) -> usize;
+
+    fn allow_number(&self) -> usize;
+
+    fn to_bytes(&mut self) -> &mut [u8];
+}
+
+pub struct SharedMemory<SM: ShareableMemory> {
+    #[allow(dead_code)] // Used in drop
+    pub(crate) shareable_memory: SM,
+}
+
+impl<SM: ShareableMemory> SharedMemory<SM> {
+    pub fn to_bytes(&mut self) -> &mut [u8] {
+        self.shareable_memory.to_bytes()
+    }
+}

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -2,6 +2,11 @@ use alloc::String;
 use alloc::Vec;
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use result;
+use result::TockResult;
+use result::TockValue;
+use shared_memory::ShareableMemory;
+use shared_memory::SharedMemory;
 use syscalls;
 
 const DRIVER_NUMBER: usize = 0x30000;
@@ -32,45 +37,32 @@ pub mod gap_data {
     pub const SERVICE_DATA: usize = 0x16;
 }
 
-#[allow(dead_code)]
-pub struct BleDeviceUninitialized<'a> {
-    interval: u16,
-    name: String,
-    uuid: Vec<u16>,
-    flags: Vec<u8>,
-    buffer: [u8; BUFFER_SIZE],
-    service_payload: &'a mut Vec<u8>,
+pub struct AdvertisingBuffer {
+    shared_memory: [u8; BUFFER_SIZE],
 }
 
-#[allow(dead_code)]
-pub struct BleDeviceInitialized<'a> {
-    interval: &'a mut u16,
-    name: &'a mut String,
-    uuid: &'a mut Vec<u16>,
-    flags: &'a mut Vec<u8>,
-    buffer: &'a mut [u8; 39],
-    service_payload: &'a mut Vec<u8>,
+impl<'a> ShareableMemory for AdvertisingBuffer {
+    fn driver_number(&self) -> usize {
+        DRIVER_NUMBER
+    }
+    fn allow_number(&self) -> usize {
+        ble_commands::ALLOW_ADVERTISMENT_BUFFER
+    }
+    fn to_bytes(&mut self) -> &mut [u8] {
+        &mut self.shared_memory
+    }
 }
 
-#[allow(dead_code)]
-pub struct BleDeviceAdvertising<'a> {
-    interval: &'a mut u16,
-    name: &'a mut String,
-    uuid: &'a mut Vec<u16>,
-    flags: &'a mut Vec<u8>,
-    buffer: &'a mut [u8; 39],
-    service_payload: &'a mut Vec<u8>,
-}
+pub struct BleAdvertisingDriver;
 
-#[allow(dead_code)]
-impl<'a> BleDeviceUninitialized<'a> {
-    pub fn new(
+impl BleAdvertisingDriver {
+    pub fn initialize(
         interval: u16,
         name: String,
         uuid: Vec<u16>,
         stay_visible: bool,
-        service_payload: &'a mut Vec<u8>,
-    ) -> BleDeviceUninitialized {
+        service_payload: Vec<u8>,
+    ) -> TockResult<SharedMemory<AdvertisingBuffer>, isize> {
         let flags: [u8; 1] = [
             gap_flags::ONLY_LE | (if stay_visible {
                 gap_flags::BLE_DISCOVERABLE
@@ -78,127 +70,77 @@ impl<'a> BleDeviceUninitialized<'a> {
                 gap_flags::BLE_NOT_DISCOVERABLE
             }),
         ];
-
-        BleDeviceUninitialized {
-            interval: interval,
-            name: name,
-            uuid: uuid,
-            flags: flags.to_vec(),
-            buffer: [0; 39],
-            service_payload: service_payload,
-        }
-    }
-    pub fn initialize(&'a mut self) -> Result<BleDeviceInitialized<'a>, &'static str> {
-        Ok(self)
-            .and_then(|ble| ble.set_advertising_buffer())
-            .and_then(|ble| ble.request_address())
-            .and_then(|ble| ble.set_advertising_interval())
-            .and_then(|ble| ble.set_advertising_flags())
-            .and_then(|ble| ble.set_advertising_name())
-            .and_then(|ble| ble.set_advertsing_uuid())
-            .and_then(|ble| ble.set_service_payload())
-            .and_then(|ble| {
-                Ok(BleDeviceInitialized {
-                    interval: &mut ble.interval,
-                    name: &mut ble.name,
-                    uuid: &mut ble.uuid,
-                    flags: &mut ble.flags,
-                    buffer: &mut ble.buffer,
-                    service_payload: &mut ble.service_payload,
-                })
-            })
+        let buffer = AdvertisingBuffer {
+            shared_memory: [0; BUFFER_SIZE],
+        };
+        let (_, shared_memory) = syscalls::allow_new(buffer);
+        Self::set_advertising_interval(interval)?;
+        Self::request_adv_address()?;
+        Self::set_local_name(name)?;
+        Self::set_uuid(uuid)?;
+        Self::set_flags(flags)?;
+        Self::set_service_payload(service_payload)?;
+        Self::start_advertising()?;
+        Ok(shared_memory)
     }
 
-    fn set_advertising_interval(&mut self) -> Result<&mut Self, &'static str> {
-        match unsafe {
+    // TODO: Write generic error converter
+
+    fn set_advertising_interval(interval: u16) -> TockResult<(), isize> {
+        let result = unsafe {
             syscalls::command(
                 DRIVER_NUMBER,
                 ble_commands::SET_ADVERTISING_INTERVAL,
-                self.interval as usize,
+                interval as usize,
                 0,
             )
-        } {
-            0 => Ok(self),
-            _ => Err(""),
-        }
+        };
+        convert_result(result)
     }
 
-    fn request_address(&mut self) -> Result<&mut Self, &'static str> {
-        match unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::REQ_ADV_ADDRESS, 0, 0) } {
-            0 => Ok(self),
-            _ => Err(""),
-        }
+    fn request_adv_address() -> TockResult<(), isize> {
+        let result =
+            unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::REQ_ADV_ADDRESS, 0, 0) };
+        convert_result(result)
     }
 
-    fn set_advertising_name(&mut self) -> Result<&mut Self, &'static str> {
-        match unsafe {
+    fn set_local_name(name: String) -> TockResult<(), isize> {
+        let result = unsafe {
             syscalls::allow(
                 DRIVER_NUMBER,
                 gap_data::COMPLETE_LOCAL_NAME,
-                self.name.as_bytes(),
+                name.as_bytes(),
             )
-        } {
-            0 => Ok(self),
-            _ => Err(""),
-        }
+        };
+        convert_result(result)
     }
 
-    fn set_advertsing_uuid(&mut self) -> Result<&mut Self, &'static str> {
-        match unsafe {
+    fn set_uuid(uuid: Vec<u16>) -> TockResult<(), isize> {
+        let result = unsafe {
             syscalls::allow16(
                 DRIVER_NUMBER,
                 gap_data::COMPLETE_LIST_16BIT_SERVICE_IDS,
-                &self.uuid,
+                &uuid.to_vec(),
             )
-        } {
-            0 => Ok(self),
-            _ => Err(""),
-        }
+        };
+        convert_result(result)
     }
 
-    fn set_advertising_flags(&mut self) -> Result<&mut Self, &'static str> {
-        match unsafe { syscalls::allow(DRIVER_NUMBER, gap_data::SET_FLAGS, &self.flags) } {
-            0 => Ok(self),
-            _ => Err(""),
-        }
+    fn set_flags(flags: [u8; 1]) -> TockResult<(), isize> {
+        let result = unsafe { syscalls::allow(DRIVER_NUMBER, gap_data::SET_FLAGS, &flags) };
+        convert_result(result)
     }
 
-    fn set_advertising_buffer(&mut self) -> Result<&mut Self, &'static str> {
-        match unsafe {
-            syscalls::allow(
-                DRIVER_NUMBER,
-                ble_commands::ALLOW_ADVERTISMENT_BUFFER,
-                &self.buffer,
-            )
-        } {
-            0 => Ok(self),
-            _ => Err(""),
-        }
+    fn set_service_payload(service_payload: Vec<u8>) -> TockResult<(), isize> {
+        let result =
+            unsafe { syscalls::allow(DRIVER_NUMBER, gap_data::SERVICE_DATA, &service_payload) };
+        convert_result(result)
     }
 
-    fn set_service_payload(&mut self) -> Result<&mut Self, &'static str> {
-        match unsafe {
-            syscalls::allow(DRIVER_NUMBER, gap_data::SERVICE_DATA, self.service_payload)
-        } {
-            0 => Ok(self),
-            _ => Err(""),
-        }
-    }
-}
-
-impl<'a> BleDeviceInitialized<'a> {
-    pub fn start_advertising(&mut self) -> Result<BleDeviceAdvertising, &'static str> {
-        match unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::START_ADVERTISING, 0, 0) } {
-            0 => Ok(BleDeviceAdvertising {
-                interval: &mut self.interval,
-                name: &mut self.name,
-                uuid: &mut self.uuid,
-                flags: &mut self.flags,
-                buffer: &mut self.buffer,
-                service_payload: &mut self.service_payload,
-            }),
-            _ => Err(""),
-        }
+    fn start_advertising() -> TockResult<(), isize> {
+        let result =
+            unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::START_ADVERTISING, 0, 0) };
+        convert_result(result)
     }
 }
 
@@ -220,18 +162,50 @@ impl<CB: FnMut(usize, usize)> SubscribableCallback for BleCallback<CB> {
     }
 }
 
+pub struct ScanBuffer {
+    shared_memory: [u8; BUFFER_SIZE_SCAN],
+}
+
+impl<'a> ShareableMemory for ScanBuffer {
+    fn driver_number(&self) -> usize {
+        DRIVER_NUMBER
+    }
+    fn allow_number(&self) -> usize {
+        ble_commands::ALLOW_SCAN_BUFFER
+    }
+    fn to_bytes(&mut self) -> &mut [u8] {
+        &mut self.shared_memory
+    }
+}
+
 pub struct BleDriver;
 
 impl BleDriver {
+    pub fn share_memory() -> TockResult<SharedMemory<ScanBuffer>, isize> {
+        let (result, shared_memory) = syscalls::allow_new(ScanBuffer {
+            shared_memory: [0; BUFFER_SIZE_SCAN],
+        });
+        convert_result(result)?;
+        Ok(shared_memory)
+    }
+
     pub fn start<CB: FnMut(usize, usize)>(
-        buffer: &[u8; BUFFER_SIZE_SCAN],
         callback: CB,
-    ) -> Result<CallbackSubscription<BleCallback<CB>>, ()> {
-        let (_, subscription) = syscalls::subscribe_new(BleCallback { callback });
-        unsafe {
-            syscalls::allow(DRIVER_NUMBER, ble_commands::ALLOW_SCAN_BUFFER, buffer);
-            syscalls::command(DRIVER_NUMBER, ble_commands::PASSIVE_SCAN, 1, 0);
-        }
+    ) -> TockResult<CallbackSubscription<BleCallback<CB>>, isize> {
+        let (result, subscription) = syscalls::subscribe_new(BleCallback { callback });
+        convert_result(result)?;
+
+        let result = unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::PASSIVE_SCAN, 1, 0) };
+        convert_result(result)?;
         Ok(subscription)
+    }
+}
+
+fn convert_result(code: isize) -> TockResult<(), isize> {
+    match code {
+        result::SUCCESS => Ok(()),
+        result::ESIZE => Err(TockValue::Expected(result::ESIZE)),
+        result::EINVAL => Err(TockValue::Expected(result::EINVAL)),
+        _ => Err(TockValue::Unexpected(code)),
     }
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -1,5 +1,6 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use core::ptr;
 use shared_memory::ShareableMemory;
 use shared_memory::SharedMemory;
 
@@ -51,6 +52,15 @@ pub unsafe fn allow(major: usize, minor: usize, slice: &[u8]) -> isize {
     res
 }
 
+unsafe fn unallow(major: usize, minor: usize) -> isize {
+    let res;
+    asm!("svc 3" : "={r0}"(res)
+                 : "{r0}"(major) "{r1}"(minor) "{r2}"(ptr::null::<u8>()) "{r3}" (0)
+                 : "memory"
+                 : "volatile");
+    res
+}
+
 pub unsafe fn allow16(major: usize, minor: usize, slice: &[u16]) -> isize {
     let res;
     asm!("svc 3" : "={r0}"(res)
@@ -69,6 +79,15 @@ pub unsafe fn subscribe(
     let res;
     asm!("svc 1" : "={r0}"(res)
                  : "{r0}"(major) "{r1}"(minor) "{r2}"(cb) "{r3}"(ud)
+                 : "memory"
+                 : "volatile");
+    res
+}
+
+pub unsafe fn unsubscribe(major: usize, minor: usize) -> isize {
+    let res;
+    asm!("svc 1" : "={r0}"(res)
+                 : "{r0}"(major) "{r1}"(minor) "{r2}"(ptr::null::<unsafe extern "C" fn(usize, usize, usize, usize)>()) "{r3}"(0)
                  : "memory"
                  : "volatile");
     res
@@ -117,14 +136,10 @@ pub fn subscribe_new<CB: SubscribableCallback>(
 }
 impl<CB: SubscribableCallback> Drop for CallbackSubscription<CB> {
     fn drop(&mut self) {
-        extern "C" fn noop_callback(_: usize, _: usize, _: usize, _: usize) {}
-
         unsafe {
-            subscribe(
+            unsubscribe(
                 self.callback.driver_number(),
                 self.callback.subscribe_number(),
-                noop_callback,
-                0,
             );
         }
     }
@@ -144,10 +159,9 @@ pub fn allow_new<SM: ShareableMemory>(mut shareable_memory: SM) -> (isize, Share
 impl<SM: ShareableMemory> Drop for SharedMemory<SM> {
     fn drop(&mut self) {
         unsafe {
-            allow(
+            unallow(
                 self.shareable_memory.driver_number(),
                 self.shareable_memory.allow_number(),
-                &[],
             );
         }
     }

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -1,5 +1,7 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use shared_memory::ShareableMemory;
+use shared_memory::SharedMemory;
 
 pub fn yieldk_for<F: Fn() -> bool>(_: F) {
     unimplemented()
@@ -27,6 +29,10 @@ pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
 }
 
 pub fn subscribe_new<CB: SubscribableCallback>(_: CB) -> (isize, CallbackSubscription<CB>) {
+    unimplemented()
+}
+
+pub fn allow_new<SM: ShareableMemory>(_: SM) -> (isize, SharedMemory<SM>) {
     unimplemented()
 }
 


### PR DESCRIPTION
**Overview**
This pull request contains the following changes:
- establish a new allow structure to be able to automatically take away shared resources from the kernel when the shared object goes out of scope.
- change the unsubscribe method to the new "subscribe" interface introduced to the kernel by #746.
- change the ble-driver to use the new subscriptions/allowances

** Remark **
The unsubscribe/unallow-changes break compatibility with older kernel versions.

** Testing **
The automatic hardware tests have been run. Manual tests to test unsubscribe/unallow functionality have been run.

** Todos **
Transition to new callbacks / shared resource handling in libtock is not complete.