### PR TITLE
Check correct formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ cache:
 
 install:
   - rustup component add rust-src
+  - rustup component add rustfmt-preview
 
 script:
+  - rustfmt --write-mode diff src/lib.rs
+  - rustfmt --write-mode diff examples/*.rs
   - export RUSTFLAGS="$RUSTFLAGS -D warnings"
   - cargo test --lib
   - ./build_examples.sh

--- a/src/ipc/ble_ess.rs
+++ b/src/ipc/ble_ess.rs
@@ -1,42 +1,47 @@
-use alloc::boxed::Box;
 use alloc::String;
+use alloc::boxed::Box;
 use ipc::Client;
 
 #[repr(u32)]
 pub enum ReadingType {
     Temperature = 0,
     Humidity = 1,
-    Light = 2
+    Light = 2,
 }
 
 pub struct BleEss {
     client: Client,
-    buffer: Box<[u8]>
+    buffer: Box<[u8]>,
 }
 
 pub fn connect() -> Result<BleEss, ()> {
-    let mut client = Client::new(
-                String::from("org.tockos.services.ble-ess"))?;
+    let mut client = Client::new(String::from("org.tockos.services.ble-ess"))?;
     let buffer = client.share(5)?;
     Ok(BleEss {
         client: client,
-        buffer: buffer
+        buffer: buffer,
     })
 }
 
 impl BleEss {
     pub fn set_reading<I>(&mut self, sensor: ReadingType, data: I) -> Result<(), ()>
-            where I: Into<i32> {
+    where
+        I: Into<i32>,
+    {
         let sensor_type = sensor as u32;
         let data = Into::<i32>::into(data) as u32;
-        self.buffer[0..4].copy_from_slice(&[(sensor_type & 0xff) as u8,
-                                        ((sensor_type >> 8) & 0xff) as u8,
-                                        ((sensor_type >> 16) & 0xff) as u8,
-                                        ((sensor_type >> 24) & 0xff) as u8]);
-        self.buffer[4..8].copy_from_slice(&[(data & 0xff) as u8,
-                                    ((data >> 8) & 0xff) as u8,
-                                    ((data >> 16) & 0xff) as u8,
-                                    ((data >> 24) & 0xff) as u8]);
+        self.buffer[0..4].copy_from_slice(&[
+            (sensor_type & 0xff) as u8,
+            ((sensor_type >> 8) & 0xff) as u8,
+            ((sensor_type >> 16) & 0xff) as u8,
+            ((sensor_type >> 24) & 0xff) as u8,
+        ]);
+        self.buffer[4..8].copy_from_slice(&[
+            (data & 0xff) as u8,
+            ((data >> 8) & 0xff) as u8,
+            ((data >> 16) & 0xff) as u8,
+            ((data >> 24) & 0xff) as u8,
+        ]);
         self.client.notify()
     }
 }


### PR DESCRIPTION
 This PR adds code formatting checking to Travis CI. The output is consistent to what VSCode produces.

Currently, the effect of the checker is only visible on https://travis-ci.org/torfmaster/libtock-rs/branches. Would it be possible that someone of the Tock core team sets up Travis CI for libtock-rs?