### PR TITLE
Added a quick-start section to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,35 @@ to use:
     you will end up with a TAB file in `target/` that you can program onto your
     Tock board.
 
+## Using libtock-rs
+
+The easiest way to start using libtock-rs is adding an example to the examples folder.
+The boiler plate code you would write is
+```rust
+#![no_std]
+
+extern crate tock;
+
+fn main() { 
+  // Your code
+}
+```
+If you want to use heap based allocation you will have to add
+```rust
+#![feature(alloc)]
+extern crate alloc;
+```
+to the preamble.
+
+To run on the code on your board you can use
+```bash
+./run_example.sh <your app>
+```
+This script does the following steps for you:
+ - cross-compile your program using xargo
+ - create a TAB (tock application bundle)
+ - if you have a nrf52-dk board connected: flash this TAB to your board (using tockloader)
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
This PR creates a "quick-start" section to Readme.md. I created this PR to satisfy #2. Currently, the build infrastructure consists of the following elements
 - Cargo.toml
 - xargo.toml
 - the target json
 - rust-toolchain
 - tockloader
 - elf2tbf
 - layout.ld
 - a short shell-script

Any of these components is subject to constant change and perspectively I expect the following could happen
 - xargo will be replaced by built-in functionality of cargo
 - elf2tbf will land (as a standalone application) on crates.io
 - the shell-script will be replaced by a build.rs
 - libtock will go to crates.io

When the way libtock is used has stabilized it would make sense to
 - set up a detailled guide how to include libtock into a "new" application
 - if this still involves lots of boilerplate code/scripts/git submodules/... propably create a quick-start-template

After this PR is merged I would close #2 for it is not clear, whether it will be completely resolved.
Any opinions?