### PR TITLE
Fix subscription part of #33

### DIFF
--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -13,6 +13,7 @@ extern crate tock;
 use alloc::*;
 use tock::ble_parser;
 use tock::led;
+use tock::simple_ble::BleCallback;
 use tock::simple_ble::BleDriver;
 use tock::syscalls;
 
@@ -26,7 +27,8 @@ struct LedCommand {
 #[allow(unreachable_code)]
 fn main() {
     let mut shared_memory = BleDriver::share_memory().unwrap();
-    let _subscription = BleDriver::start(|_: usize, _: usize| {
+
+    let mut callback = BleCallback::new(|_: usize, _: usize| {
         match ble_parser::find(
             shared_memory.to_bytes(),
             tock::simple_ble::gap_data::SERVICE_DATA as u8,
@@ -48,8 +50,11 @@ fn main() {
         }
     });
 
+    let _subscription = BleDriver::start(&mut callback);
+
     loop {
         syscalls::yieldk();
     }
+
     _subscription.unwrap();
 }

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -7,15 +7,14 @@ extern crate tock;
 use alloc::string::String;
 use tock::buttons;
 use tock::buttons::ButtonState;
-use tock::buttons::ButtonsCallback;
 use tock::console::Console;
 use tock::timer;
 use tock::timer::Duration;
 
 fn main() {
     let mut console = Console::new();
-    let mut callback = ButtonsCallback::new(|_, _| {});
-    let mut buttons = buttons::with_callback(&mut callback).unwrap();
+    let mut with_callback = buttons::with_callback(|_, _| {});
+    let mut buttons = with_callback.init().unwrap();
     let mut button = buttons.iter_mut().next().unwrap();
     let button = button.enable().unwrap();
 

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -7,13 +7,15 @@ extern crate tock;
 use alloc::string::String;
 use tock::buttons;
 use tock::buttons::ButtonState;
+use tock::buttons::ButtonsCallback;
 use tock::console::Console;
 use tock::timer;
 use tock::timer::Duration;
 
 fn main() {
     let mut console = Console::new();
-    let mut buttons = buttons::with_callback(|_, _| {}).unwrap();
+    let mut callback = ButtonsCallback::new(|_, _| {});
+    let mut buttons = buttons::with_callback(&mut callback).unwrap();
     let mut button = buttons.iter_mut().next().unwrap();
     let button = button.enable().unwrap();
 

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -7,6 +7,7 @@ extern crate tock;
 use alloc::string::String;
 use tock::buttons;
 use tock::buttons::ButtonState;
+use tock::buttons::ButtonsCallback;
 use tock::console::Console;
 use tock::fmt;
 use tock::timer;
@@ -16,7 +17,7 @@ use tock::timer::Duration;
 fn main() {
     let mut console = Console::new();
 
-    let mut buttons = buttons::with_callback(|button_num: usize, state| {
+    let mut callback = ButtonsCallback::new(|button_num: usize, state| {
         console.write(String::from("\nButton: "));
         console.write(fmt::u32_as_hex(button_num as u32));
         console.write(String::from(" - State: "));
@@ -24,7 +25,9 @@ fn main() {
             ButtonState::Pressed => "pressed",
             ButtonState::Released => "released",
         }));
-    }).unwrap();
+    });
+
+    let mut buttons = buttons::with_callback(&mut callback).unwrap();
 
     for mut button in &mut buttons {
         button.enable().unwrap();

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -7,7 +7,6 @@ extern crate tock;
 use alloc::string::String;
 use tock::buttons;
 use tock::buttons::ButtonState;
-use tock::buttons::ButtonsCallback;
 use tock::console::Console;
 use tock::fmt;
 use tock::timer;
@@ -17,7 +16,7 @@ use tock::timer::Duration;
 fn main() {
     let mut console = Console::new();
 
-    let mut callback = ButtonsCallback::new(|button_num: usize, state| {
+    let mut with_callback = buttons::with_callback(|button_num: usize, state| {
         console.write(String::from("\nButton: "));
         console.write(fmt::u32_as_hex(button_num as u32));
         console.write(String::from(" - State: "));
@@ -27,7 +26,7 @@ fn main() {
         }));
     });
 
-    let mut buttons = buttons::with_callback(&mut callback).unwrap();
+    let mut buttons = with_callback.init().unwrap();
 
     for mut button in &mut buttons {
         button.enable().unwrap();

--- a/examples/hardware_test_server.rs
+++ b/examples/hardware_test_server.rs
@@ -6,16 +6,17 @@ extern crate tock;
 use alloc::string::String;
 use alloc::vec::Vec;
 use tock::ipc_cs;
+use tock::ipc_cs::IpcServerCallback;
 use tock::ipc_cs::IpcServerDriver;
 
 #[allow(unreachable_code)]
 // Prints the payload and adds one to the first byte.
 fn main() {
-    let cb = &mut |pid: usize, _: usize, message: &mut [u8]| {
+    let mut callback = IpcServerCallback::new(|pid: usize, _: usize, message: &mut [u8]| {
         let filtered = message
-            .to_vec()
-            .into_iter()
-            .filter(|x| *x != 0)
+            .iter()
+            .cloned()
+            .filter(|&x| x != 0)
             .collect::<Vec<u8>>();
         let s = String::from_utf8_lossy(&filtered);
         if s == String::from("client") {
@@ -25,12 +26,13 @@ fn main() {
             message[..l].clone_from_slice(b);
             ipc_cs::notify_client(pid);
         }
-    };
-    #[allow(unused_variables)]
-    let server = IpcServerDriver::start(cb);
+    });
+
+    let _server = IpcServerDriver::start(&mut callback);
 
     loop {
         tock::syscalls::yieldk();
     }
-    server.unwrap();
+
+    _server.unwrap();
 }

--- a/examples/ipcclient.rs
+++ b/examples/ipcclient.rs
@@ -7,13 +7,14 @@ use alloc::boxed::Box;
 use alloc::string::String;
 use tock::console::Console;
 use tock::fmt;
-use tock::ipc_cs::*;
+use tock::ipc_cs;
+use tock::ipc_cs::IpcClientCallback;
+use tock::ipc_cs::ServerHandle;
 use tock::timer;
 
-#[allow(unreachable_code)]
 // Calls the ipc_server and prints result
 fn main() {
-    let mut buf: Box<[u8]> = reserve_shared_buffer();
+    let mut buf: Box<[u8]> = ipc_cs::reserve_shared_buffer();
     timer::sleep(timer::Duration::from_ms(1000));
 
     loop {
@@ -21,12 +22,16 @@ fn main() {
         let mut payload: [u8; 32] = [5; 32];
 
         server.share(&mut buf, &mut payload);
-        let handle = server.subscribe_callback(|_: usize, _: usize| {
+
+        let mut callback = IpcClientCallback::new(|_: usize, _: usize| {
             let mut console = Console::new();
             console.write(String::from("Client: \"Payload: "));
             console.write(fmt::u32_as_hex(buf[0] as u32));
             console.write(String::from("\"\n"));
         });
+
+        let handle = server.subscribe_callback(&mut callback);
+
         server.notify();
         timer::sleep(timer::Duration::from_ms(1000));
         handle.unwrap();

--- a/examples/ipcserver.rs
+++ b/examples/ipcserver.rs
@@ -7,6 +7,7 @@ use alloc::string::String;
 use tock::console::Console;
 use tock::fmt::*;
 use tock::ipc_cs;
+use tock::ipc_cs::IpcServerCallback;
 use tock::ipc_cs::IpcServerDriver;
 
 #[allow(unreachable_code)]
@@ -15,8 +16,7 @@ fn main() {
     let mut console = Console::new();
     console.write(String::from("Start service:\n"));
 
-    #[allow(unused_variables)]
-    let server = IpcServerDriver::start(|pid: usize, _: usize, message: &mut [u8]| {
+    let mut callback = IpcServerCallback::new(|pid: usize, _: usize, message: &mut [u8]| {
         console.write(String::from("Server: \"Payload: "));
 
         console.write(u32_as_hex(message[0] as u32));
@@ -25,8 +25,11 @@ fn main() {
         ipc_cs::notify_client(pid);
     });
 
+    let _server = IpcServerDriver::start(&mut callback);
+
     loop {
         tock::syscalls::yieldk();
     }
-    server.unwrap();
+
+    _server.unwrap();
 }

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -5,21 +5,24 @@ extern crate tock;
 
 use alloc::string::String;
 use tock::console::Console;
+use tock::temperature::TemperatureCallback;
 use tock::temperature::TemperatureDriver;
 
 #[allow(unreachable_code)]
 fn main() {
     let mut console = Console::new();
-    #[allow(unused_variables)]
-    let temperature = TemperatureDriver::start_measurement(|result: isize| {
+
+    let mut callback = TemperatureCallback::new(|result: isize| {
         console.write(String::from("Temperature:"));
         console.write(tock::fmt::i32_as_decimal(result as i32));
         console.write(String::from("\n"));
     });
 
+    let _temperature = TemperatureDriver::start_measurement(&mut callback);
+
     loop {
         tock::syscalls::yieldk();
     }
     // FIXME: Find another solution to prevent the compiler from calling drop too early.
-    temperature.unwrap();
+    _temperature.unwrap();
 }

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -5,24 +5,20 @@ extern crate tock;
 
 use alloc::string::String;
 use tock::console::Console;
-use tock::temperature::TemperatureCallback;
-use tock::temperature::TemperatureDriver;
+use tock::temperature;
 
-#[allow(unreachable_code)]
 fn main() {
     let mut console = Console::new();
 
-    let mut callback = TemperatureCallback::new(|result: isize| {
-        console.write(String::from("Temperature:"));
+    let mut with_callback = temperature::with_callback(|result: isize| {
+        console.write(String::from("Temperature: "));
         console.write(tock::fmt::i32_as_decimal(result as i32));
         console.write(String::from("\n"));
     });
 
-    let _temperature = TemperatureDriver::start_measurement(&mut callback);
+    let _temperature = with_callback.start_measurement();
 
     loop {
         tock::syscalls::yieldk();
     }
-    // FIXME: Find another solution to prevent the compiler from calling drop too early.
-    _temperature.unwrap();
 }

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -9,14 +9,18 @@ use tock::console::Console;
 use tock::syscalls;
 use tock::timer;
 use tock::timer::Duration;
+use tock::timer::TimerCallback;
 
 fn main() {
     let mut console = Console::new();
-    let timer = timer::with_callback(|_, _| {
+
+    let mut callback = TimerCallback::new(|_, _| {
         console.write(String::from(
             "This line is printed 2 seconds after the start of the program.",
         ))
-    }).unwrap();
+    });
+
+    let mut timer = timer::with_callback(&mut callback).unwrap();
 
     timer.set_alarm(Duration::from_ms(2000)).unwrap();
     loop {

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -9,18 +9,17 @@ use tock::console::Console;
 use tock::syscalls;
 use tock::timer;
 use tock::timer::Duration;
-use tock::timer::TimerCallback;
 
 fn main() {
     let mut console = Console::new();
 
-    let mut callback = TimerCallback::new(|_, _| {
+    let mut with_callback = timer::with_callback(|_, _| {
         console.write(String::from(
             "This line is printed 2 seconds after the start of the program.",
         ))
     });
 
-    let mut timer = timer::with_callback(&mut callback).unwrap();
+    let mut timer = with_callback.init().unwrap();
 
     timer.set_alarm(Duration::from_ms(2000)).unwrap();
     loop {

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -1,6 +1,5 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use callback::SubscribeInfo;
 use result;
 use result::TockResult;
 use result::TockValue;
@@ -27,7 +26,8 @@ pub fn with_callback<CB: FnMut(usize, ButtonState)>(
         return Err(TockValue::Expected(ButtonsError::NotSupported));
     }
 
-    let subscription = syscalls::subscribe(ButtonsSubscribeInfo, callback);
+    let subscription =
+        syscalls::subscribe(DRIVER_NUMBER, subscribe_nr::SUBSCRIBE_CALLBACK, callback);
 
     match subscription {
         Ok(subscription) => Ok(Buttons {
@@ -42,7 +42,7 @@ pub fn with_callback<CB: FnMut(usize, ButtonState)>(
 pub struct Buttons<'a> {
     count: usize,
     #[allow(dead_code)] // Used in drop
-    subscription: CallbackSubscription<'a, ButtonsSubscribeInfo>,
+    subscription: CallbackSubscription<'a>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -58,18 +58,6 @@ impl<'a> Buttons<'a> {
             button_count: self.count,
             _lifetime: &(),
         }
-    }
-}
-
-struct ButtonsSubscribeInfo;
-
-impl SubscribeInfo for ButtonsSubscribeInfo {
-    fn driver_number(&self) -> usize {
-        DRIVER_NUMBER
-    }
-
-    fn subscribe_number(&self) -> usize {
-        subscribe_nr::SUBSCRIBE_CALLBACK
     }
 }
 

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,12 +1,40 @@
-pub trait SubscribableCallback {
+use core::ptr;
+use syscalls;
+
+pub trait SubscribeInfo {
     fn driver_number(&self) -> usize;
 
     fn subscribe_number(&self) -> usize;
+}
 
+pub trait SubscribableCallback {
     fn call_rust(&mut self, arg0: usize, arg1: usize, arg2: usize);
 }
 
-pub struct CallbackSubscription<CB: SubscribableCallback> {
+pub struct CallbackSubscription<'a, I: SubscribeInfo> {
     #[allow(dead_code)] // Used in drop
-    pub(crate) callback: CB,
+    subscribe_info: I,
+    _lifetime: &'a (),
+}
+
+impl<'a, I: SubscribeInfo> CallbackSubscription<'a, I> {
+    pub fn new(subscribe_info: I) -> CallbackSubscription<'a, I> {
+        CallbackSubscription {
+            subscribe_info,
+            _lifetime: &(),
+        }
+    }
+}
+
+impl<'a, I: SubscribeInfo> Drop for CallbackSubscription<'a, I> {
+    fn drop(&mut self) {
+        unsafe {
+            syscalls::subscribe_ptr(
+                self.subscribe_info.driver_number(),
+                self.subscribe_info.subscribe_number(),
+                ptr::null(),
+                0,
+            );
+        }
+    }
 }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -1,40 +1,30 @@
 use core::ptr;
 use syscalls;
 
-pub trait SubscribeInfo {
-    fn driver_number(&self) -> usize;
-
-    fn subscribe_number(&self) -> usize;
-}
-
 pub trait SubscribableCallback {
     fn call_rust(&mut self, arg0: usize, arg1: usize, arg2: usize);
 }
 
-pub struct CallbackSubscription<'a, I: SubscribeInfo> {
-    #[allow(dead_code)] // Used in drop
-    subscribe_info: I,
+pub struct CallbackSubscription<'a> {
+    driver_number: usize,
+    subscribe_number: usize,
     _lifetime: &'a (),
 }
 
-impl<'a, I: SubscribeInfo> CallbackSubscription<'a, I> {
-    pub fn new(subscribe_info: I) -> CallbackSubscription<'a, I> {
+impl<'a> CallbackSubscription<'a> {
+    pub fn new(driver_number: usize, subscribe_number: usize) -> CallbackSubscription<'a> {
         CallbackSubscription {
-            subscribe_info,
+            driver_number,
+            subscribe_number,
             _lifetime: &(),
         }
     }
 }
 
-impl<'a, I: SubscribeInfo> Drop for CallbackSubscription<'a, I> {
+impl<'a> Drop for CallbackSubscription<'a> {
     fn drop(&mut self) {
         unsafe {
-            syscalls::subscribe_ptr(
-                self.subscribe_info.driver_number(),
-                self.subscribe_info.subscribe_number(),
-                ptr::null(),
-                0,
-            );
+            syscalls::subscribe_ptr(self.driver_number, self.subscribe_number, ptr::null(), 0);
         }
     }
 }

--- a/src/ipc_cs/client.rs
+++ b/src/ipc_cs/client.rs
@@ -5,7 +5,6 @@ use alloc::heap::Heap;
 use alloc::raw_vec::RawVec;
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use callback::SubscribeInfo;
 use syscalls;
 
 const DRIVER_NUMBER: usize = 0x10000;
@@ -15,21 +14,7 @@ mod ipc_commands {
 }
 
 pub struct ServerHandle {
-    pid: isize,
-}
-
-pub struct IpcClientSubscribeInfo {
-    pid: isize,
-}
-
-impl SubscribeInfo for IpcClientSubscribeInfo {
-    fn driver_number(&self) -> usize {
-        DRIVER_NUMBER
-    }
-
-    fn subscribe_number(&self) -> usize {
-        self.pid as usize
-    }
+    pid: usize,
 }
 
 pub struct IpcClientCallback<CB> {
@@ -80,7 +65,7 @@ impl ServerHandle {
             )
         };
         if pid >= 0 {
-            Some(ServerHandle { pid })
+            Some(ServerHandle { pid: pid as usize })
         } else {
             None
         }
@@ -89,7 +74,7 @@ impl ServerHandle {
     pub fn subscribe_callback<'a, CB: FnMut(usize, usize)>(
         &self,
         callback: &'a mut IpcClientCallback<CB>,
-    ) -> Result<CallbackSubscription<'a, IpcClientSubscribeInfo>, isize> {
-        syscalls::subscribe(IpcClientSubscribeInfo { pid: self.pid }, callback)
+    ) -> Result<CallbackSubscription<'a>, isize> {
+        syscalls::subscribe(DRIVER_NUMBER, self.pid, callback)
     }
 }

--- a/src/ipc_cs/client.rs
+++ b/src/ipc_cs/client.rs
@@ -71,10 +71,13 @@ impl ServerHandle {
         }
     }
 
-    pub fn subscribe_callback<'a, CB: FnMut(usize, usize)>(
+    pub fn subscribe_callback<'a, CB>(
         &self,
         callback: &'a mut IpcClientCallback<CB>,
-    ) -> Result<CallbackSubscription<'a>, isize> {
+    ) -> Result<CallbackSubscription<'a>, isize>
+    where
+        IpcClientCallback<CB>: SubscribableCallback,
+    {
         syscalls::subscribe(DRIVER_NUMBER, self.pid, callback)
     }
 }

--- a/src/ipc_cs/server.rs
+++ b/src/ipc_cs/server.rs
@@ -34,9 +34,10 @@ pub fn notify_client(pid: usize) {
 pub struct IpcServerDriver;
 
 impl IpcServerDriver {
-    pub fn start<CB: FnMut(usize, usize, &mut [u8])>(
-        callback: &mut IpcServerCallback<CB>,
-    ) -> Result<CallbackSubscription, isize> {
+    pub fn start<CB>(callback: &mut IpcServerCallback<CB>) -> Result<CallbackSubscription, isize>
+    where
+        IpcServerCallback<CB>: SubscribableCallback,
+    {
         syscalls::subscribe(DRIVER_NUMBER, ipc_commands::REGISTER_SERVICE, callback)
     }
 }

--- a/src/ipc_cs/server.rs
+++ b/src/ipc_cs/server.rs
@@ -1,6 +1,5 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use callback::SubscribeInfo;
 use core::slice;
 use syscalls;
 
@@ -9,18 +8,6 @@ const DRIVER_NUMBER: usize = 0x10000;
 mod ipc_commands {
     pub const REGISTER_SERVICE: usize = 0;
     pub const NOTIFY_CLIENT: usize = 1;
-}
-
-pub struct IpcServerSubscribeInfo;
-
-impl SubscribeInfo for IpcServerSubscribeInfo {
-    fn driver_number(&self) -> usize {
-        DRIVER_NUMBER
-    }
-
-    fn subscribe_number(&self) -> usize {
-        ipc_commands::REGISTER_SERVICE
-    }
 }
 
 pub struct IpcServerCallback<CB> {
@@ -49,7 +36,7 @@ pub struct IpcServerDriver;
 impl IpcServerDriver {
     pub fn start<CB: FnMut(usize, usize, &mut [u8])>(
         callback: &mut IpcServerCallback<CB>,
-    ) -> Result<CallbackSubscription<IpcServerSubscribeInfo>, isize> {
-        syscalls::subscribe(IpcServerSubscribeInfo, callback)
+    ) -> Result<CallbackSubscription, isize> {
+        syscalls::subscribe(DRIVER_NUMBER, ipc_commands::REGISTER_SERVICE, callback)
     }
 }

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -2,7 +2,6 @@ use alloc::String;
 use alloc::Vec;
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use callback::SubscribeInfo;
 use result;
 use shared_memory::ShareableMemory;
 use shared_memory::SharedMemory;
@@ -143,18 +142,6 @@ impl BleAdvertisingDriver {
     }
 }
 
-pub struct BleSubscribeInfo;
-
-impl SubscribeInfo for BleSubscribeInfo {
-    fn driver_number(&self) -> usize {
-        DRIVER_NUMBER
-    }
-
-    fn subscribe_number(&self) -> usize {
-        ble_commands::BLE_PASSIVE_SCAN_SUB
-    }
-}
-
 pub struct BleCallback<CB> {
     callback: CB,
 }
@@ -200,8 +187,9 @@ impl BleDriver {
 
     pub fn start<CB: FnMut(usize, usize)>(
         callback: &mut BleCallback<CB>,
-    ) -> Result<CallbackSubscription<BleSubscribeInfo>, isize> {
-        let subscription = syscalls::subscribe(BleSubscribeInfo, callback)?;
+    ) -> Result<CallbackSubscription, isize> {
+        let subscription =
+            syscalls::subscribe(DRIVER_NUMBER, ble_commands::BLE_PASSIVE_SCAN_SUB, callback)?;
 
         let result = unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::PASSIVE_SCAN, 1, 0) };
         convert_result(result)?;

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -185,9 +185,10 @@ impl BleDriver {
         Ok(shared_memory)
     }
 
-    pub fn start<CB: FnMut(usize, usize)>(
-        callback: &mut BleCallback<CB>,
-    ) -> Result<CallbackSubscription, isize> {
+    pub fn start<CB>(callback: &mut BleCallback<CB>) -> Result<CallbackSubscription, isize>
+    where
+        BleCallback<CB>: SubscribableCallback,
+    {
         let subscription =
             syscalls::subscribe(DRIVER_NUMBER, ble_commands::BLE_PASSIVE_SCAN_SUB, callback)?;
 

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -2,9 +2,8 @@ use alloc::String;
 use alloc::Vec;
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use callback::SubscribeInfo;
 use result;
-use result::TockResult;
-use result::TockValue;
 use shared_memory::ShareableMemory;
 use shared_memory::SharedMemory;
 use syscalls;
@@ -41,7 +40,7 @@ pub struct AdvertisingBuffer {
     shared_memory: [u8; BUFFER_SIZE],
 }
 
-impl<'a> ShareableMemory for AdvertisingBuffer {
+impl ShareableMemory for AdvertisingBuffer {
     fn driver_number(&self) -> usize {
         DRIVER_NUMBER
     }
@@ -62,7 +61,7 @@ impl BleAdvertisingDriver {
         uuid: Vec<u16>,
         stay_visible: bool,
         service_payload: Vec<u8>,
-    ) -> TockResult<SharedMemory<AdvertisingBuffer>, isize> {
+    ) -> Result<SharedMemory<AdvertisingBuffer>, isize> {
         let flags: [u8; 1] = [
             gap_flags::ONLY_LE | (if stay_visible {
                 gap_flags::BLE_DISCOVERABLE
@@ -86,7 +85,7 @@ impl BleAdvertisingDriver {
 
     // TODO: Write generic error converter
 
-    fn set_advertising_interval(interval: u16) -> TockResult<(), isize> {
+    fn set_advertising_interval(interval: u16) -> Result<(), isize> {
         let result = unsafe {
             syscalls::command(
                 DRIVER_NUMBER,
@@ -98,13 +97,13 @@ impl BleAdvertisingDriver {
         convert_result(result)
     }
 
-    fn request_adv_address() -> TockResult<(), isize> {
+    fn request_adv_address() -> Result<(), isize> {
         let result =
             unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::REQ_ADV_ADDRESS, 0, 0) };
         convert_result(result)
     }
 
-    fn set_local_name(name: String) -> TockResult<(), isize> {
+    fn set_local_name(name: String) -> Result<(), isize> {
         let result = unsafe {
             syscalls::allow(
                 DRIVER_NUMBER,
@@ -115,7 +114,7 @@ impl BleAdvertisingDriver {
         convert_result(result)
     }
 
-    fn set_uuid(uuid: Vec<u16>) -> TockResult<(), isize> {
+    fn set_uuid(uuid: Vec<u16>) -> Result<(), isize> {
         let result = unsafe {
             syscalls::allow16(
                 DRIVER_NUMBER,
@@ -126,29 +125,27 @@ impl BleAdvertisingDriver {
         convert_result(result)
     }
 
-    fn set_flags(flags: [u8; 1]) -> TockResult<(), isize> {
+    fn set_flags(flags: [u8; 1]) -> Result<(), isize> {
         let result = unsafe { syscalls::allow(DRIVER_NUMBER, gap_data::SET_FLAGS, &flags) };
         convert_result(result)
     }
 
-    fn set_service_payload(service_payload: Vec<u8>) -> TockResult<(), isize> {
+    fn set_service_payload(service_payload: Vec<u8>) -> Result<(), isize> {
         let result =
             unsafe { syscalls::allow(DRIVER_NUMBER, gap_data::SERVICE_DATA, &service_payload) };
         convert_result(result)
     }
 
-    fn start_advertising() -> TockResult<(), isize> {
+    fn start_advertising() -> Result<(), isize> {
         let result =
             unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::START_ADVERTISING, 0, 0) };
         convert_result(result)
     }
 }
 
-pub struct BleCallback<CB> {
-    callback: CB,
-}
+pub struct BleSubscribeInfo;
 
-impl<CB: FnMut(usize, usize)> SubscribableCallback for BleCallback<CB> {
+impl SubscribeInfo for BleSubscribeInfo {
     fn driver_number(&self) -> usize {
         DRIVER_NUMBER
     }
@@ -156,7 +153,19 @@ impl<CB: FnMut(usize, usize)> SubscribableCallback for BleCallback<CB> {
     fn subscribe_number(&self) -> usize {
         ble_commands::BLE_PASSIVE_SCAN_SUB
     }
+}
 
+pub struct BleCallback<CB> {
+    callback: CB,
+}
+
+impl<CB> BleCallback<CB> {
+    pub fn new(callback: CB) -> Self {
+        BleCallback { callback }
+    }
+}
+
+impl<CB: FnMut(usize, usize)> SubscribableCallback for BleCallback<CB> {
     fn call_rust(&mut self, arg0: usize, arg1: usize, _: usize) {
         (self.callback)(arg0, arg1);
     }
@@ -181,7 +190,7 @@ impl<'a> ShareableMemory for ScanBuffer {
 pub struct BleDriver;
 
 impl BleDriver {
-    pub fn share_memory() -> TockResult<SharedMemory<ScanBuffer>, isize> {
+    pub fn share_memory() -> Result<SharedMemory<ScanBuffer>, isize> {
         let (result, shared_memory) = syscalls::allow_new(ScanBuffer {
             shared_memory: [0; BUFFER_SIZE_SCAN],
         });
@@ -190,10 +199,9 @@ impl BleDriver {
     }
 
     pub fn start<CB: FnMut(usize, usize)>(
-        callback: CB,
-    ) -> TockResult<CallbackSubscription<BleCallback<CB>>, isize> {
-        let (result, subscription) = syscalls::subscribe(BleCallback { callback });
-        convert_result(result)?;
+        callback: &mut BleCallback<CB>,
+    ) -> Result<CallbackSubscription<BleSubscribeInfo>, isize> {
+        let subscription = syscalls::subscribe(BleSubscribeInfo, callback)?;
 
         let result = unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::PASSIVE_SCAN, 1, 0) };
         convert_result(result)?;
@@ -201,11 +209,9 @@ impl BleDriver {
     }
 }
 
-fn convert_result(code: isize) -> TockResult<(), isize> {
+fn convert_result(code: isize) -> Result<(), isize> {
     match code {
         result::SUCCESS => Ok(()),
-        result::ESIZE => Err(TockValue::Expected(result::ESIZE)),
-        result::EINVAL => Err(TockValue::Expected(result::EINVAL)),
-        _ => Err(TockValue::Unexpected(code)),
+        code => Err(code),
     }
 }

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -48,16 +48,6 @@ pub fn subscribe<CB: SubscribableCallback>(
     subscribe_number: usize,
     callback: &mut CB,
 ) -> Result<CallbackSubscription, isize> {
-    extern "C" fn c_callback<CB: SubscribableCallback>(
-        arg0: usize,
-        arg1: usize,
-        arg2: usize,
-        userdata: usize,
-    ) {
-        let callback = unsafe { &mut *(userdata as *mut CB) };
-        callback.call_rust(arg0, arg1, arg2);
-    }
-
     let return_code = unsafe {
         subscribe_ptr(
             driver_number,
@@ -72,6 +62,16 @@ pub fn subscribe<CB: SubscribableCallback>(
     } else {
         Err(return_code)
     }
+}
+
+extern "C" fn c_callback<CB: SubscribableCallback>(
+    arg0: usize,
+    arg1: usize,
+    arg2: usize,
+    userdata: usize,
+) {
+    let callback = unsafe { &mut *(userdata as *mut CB) };
+    callback.call_rust(arg0, arg1, arg2);
 }
 
 pub unsafe fn subscribe_ptr(

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -1,5 +1,6 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use callback::SubscribeInfo;
 use shared_memory::ShareableMemory;
 use shared_memory::SharedMemory;
 
@@ -7,7 +8,10 @@ pub fn yieldk_for<F: Fn() -> bool>(_: F) {
     unimplemented()
 }
 
-pub fn subscribe<CB: SubscribableCallback>(_: CB) -> (isize, CallbackSubscription<CB>) {
+pub fn subscribe<I: SubscribeInfo, CB: SubscribableCallback>(
+    _: I,
+    _: &mut CB,
+) -> Result<CallbackSubscription<I>, isize> {
     unimplemented()
 }
 

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -1,6 +1,5 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use callback::SubscribeInfo;
 use shared_memory::ShareableMemory;
 use shared_memory::SharedMemory;
 
@@ -8,10 +7,11 @@ pub fn yieldk_for<F: Fn() -> bool>(_: F) {
     unimplemented()
 }
 
-pub fn subscribe<I: SubscribeInfo, CB: SubscribableCallback>(
-    _: I,
+pub fn subscribe<CB: SubscribableCallback>(
+    _: usize,
+    _: usize,
     _: &mut CB,
-) -> Result<CallbackSubscription<I>, isize> {
+) -> Result<CallbackSubscription, isize> {
     unimplemented()
 }
 

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,23 +1,10 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use callback::SubscribeInfo;
 use syscalls;
 
 const DRIVER_NUMBER: usize = 0x60000;
 const SUBSCRIBE_CALLBACK: usize = 0;
 const START_MEASUREMENT: usize = 1;
-
-pub struct TemperatureSubscribeInfo;
-
-impl SubscribeInfo for TemperatureSubscribeInfo {
-    fn driver_number(&self) -> usize {
-        DRIVER_NUMBER
-    }
-
-    fn subscribe_number(&self) -> usize {
-        SUBSCRIBE_CALLBACK
-    }
-}
 
 pub struct TemperatureCallback<CB> {
     callback: CB,
@@ -40,8 +27,8 @@ pub struct TemperatureDriver;
 impl TemperatureDriver {
     pub fn start_measurement<CB: FnMut(isize)>(
         callback: &mut TemperatureCallback<CB>,
-    ) -> Result<CallbackSubscription<TemperatureSubscribeInfo>, isize> {
-        let subscription = syscalls::subscribe(TemperatureSubscribeInfo, callback)?;
+    ) -> Result<CallbackSubscription, isize> {
+        let subscription = syscalls::subscribe(DRIVER_NUMBER, SUBSCRIBE_CALLBACK, callback)?;
         unsafe { syscalls::command(DRIVER_NUMBER, START_MEASUREMENT, 0, 0) };
         Ok(subscription)
     }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -6,29 +6,26 @@ const DRIVER_NUMBER: usize = 0x60000;
 const SUBSCRIBE_CALLBACK: usize = 0;
 const START_MEASUREMENT: usize = 1;
 
-pub struct TemperatureCallback<CB> {
+pub fn with_callback<CB>(callback: CB) -> WithCallback<CB> {
+    WithCallback { callback }
+}
+
+pub struct WithCallback<CB> {
     callback: CB,
 }
 
-impl<CB> TemperatureCallback<CB> {
-    pub fn new(callback: CB) -> Self {
-        TemperatureCallback { callback }
-    }
-}
-
-impl<CB: FnMut(isize)> SubscribableCallback for TemperatureCallback<CB> {
+impl<CB: FnMut(isize)> SubscribableCallback for WithCallback<CB> {
     fn call_rust(&mut self, arg0: usize, _: usize, _: usize) {
         (self.callback)(arg0 as isize);
     }
 }
 
-pub struct TemperatureDriver;
-
-impl TemperatureDriver {
-    pub fn start_measurement<CB: FnMut(isize)>(
-        callback: &mut TemperatureCallback<CB>,
-    ) -> Result<CallbackSubscription, isize> {
-        let subscription = syscalls::subscribe(DRIVER_NUMBER, SUBSCRIBE_CALLBACK, callback)?;
+impl<CB> WithCallback<CB>
+where
+    Self: SubscribableCallback,
+{
+    pub fn start_measurement(&mut self) -> Result<CallbackSubscription, isize> {
+        let subscription = syscalls::subscribe(DRIVER_NUMBER, SUBSCRIBE_CALLBACK, self)?;
         unsafe { syscalls::command(DRIVER_NUMBER, START_MEASUREMENT, 0, 0) };
         Ok(subscription)
     }

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,16 +1,15 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use callback::SubscribeInfo;
 use syscalls;
 
 const DRIVER_NUMBER: usize = 0x60000;
 const SUBSCRIBE_CALLBACK: usize = 0;
 const START_MEASUREMENT: usize = 1;
 
-pub struct TemperatureCallback<CB> {
-    callback: CB,
-}
+pub struct TemperatureSubscribeInfo;
 
-impl<CB: FnMut(isize)> SubscribableCallback for TemperatureCallback<CB> {
+impl SubscribeInfo for TemperatureSubscribeInfo {
     fn driver_number(&self) -> usize {
         DRIVER_NUMBER
     }
@@ -18,7 +17,19 @@ impl<CB: FnMut(isize)> SubscribableCallback for TemperatureCallback<CB> {
     fn subscribe_number(&self) -> usize {
         SUBSCRIBE_CALLBACK
     }
+}
 
+pub struct TemperatureCallback<CB> {
+    callback: CB,
+}
+
+impl<CB> TemperatureCallback<CB> {
+    pub fn new(callback: CB) -> Self {
+        TemperatureCallback { callback }
+    }
+}
+
+impl<CB: FnMut(isize)> SubscribableCallback for TemperatureCallback<CB> {
     fn call_rust(&mut self, arg0: usize, _: usize, _: usize) {
         (self.callback)(arg0 as isize);
     }
@@ -28,12 +39,10 @@ pub struct TemperatureDriver;
 
 impl TemperatureDriver {
     pub fn start_measurement<CB: FnMut(isize)>(
-        callback: CB,
-    ) -> Result<CallbackSubscription<TemperatureCallback<CB>>, ()> {
-        let (_, subscription) = syscalls::subscribe(TemperatureCallback { callback });
-        unsafe {
-            syscalls::command(DRIVER_NUMBER, START_MEASUREMENT, 0, 0);
-        }
+        callback: &mut TemperatureCallback<CB>,
+    ) -> Result<CallbackSubscription<TemperatureSubscribeInfo>, isize> {
+        let subscription = syscalls::subscribe(TemperatureSubscribeInfo, callback)?;
+        unsafe { syscalls::command(DRIVER_NUMBER, START_MEASUREMENT, 0, 0) };
         Ok(subscription)
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,6 +1,5 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use callback::SubscribeInfo;
 use core::cell::Cell;
 use core::isize;
 use result;
@@ -56,7 +55,8 @@ pub fn with_callback<CB: FnMut(ClockValue, Alarm)>(
     };
     callback.clock_frequency = clock_frequency;
 
-    let subscription = syscalls::subscribe(TimerSubscribeInfo, callback);
+    let subscription =
+        syscalls::subscribe(DRIVER_NUMBER, subscribe_nr::SUBSCRIBE_CALLBACK, callback);
 
     match subscription {
         Ok(subscription) => Ok(Timer {
@@ -73,7 +73,7 @@ pub struct Timer<'a> {
     num_notifications: usize,
     clock_frequency: ClockFrequency,
     #[allow(dead_code)] // Used in drop
-    subscription: CallbackSubscription<'a, TimerSubscribeInfo>,
+    subscription: CallbackSubscription<'a>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -128,18 +128,6 @@ impl<'a> Timer<'a> {
             result::ENOMEM => Err(TockValue::Expected(SetAlarmError::NoMemoryAvailable)),
             unexpected => Err(TockValue::Unexpected(unexpected)),
         }
-    }
-}
-
-struct TimerSubscribeInfo;
-
-impl SubscribeInfo for TimerSubscribeInfo {
-    fn driver_number(&self) -> usize {
-        DRIVER_NUMBER
-    }
-
-    fn subscribe_number(&self) -> usize {
-        subscribe_nr::SUBSCRIBE_CALLBACK
     }
 }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -23,49 +23,75 @@ mod subscribe_nr {
 
 pub fn sleep(duration: Duration) {
     let expired = Cell::new(false);
+    let mut with_callback = with_callback(|_, _| expired.set(true));
 
-    let mut callback = TimerCallback::new(|_, _| expired.set(true));
-    let mut timer = with_callback(&mut callback).unwrap();
+    with_callback.init().unwrap().set_alarm(duration).unwrap();
 
-    timer.set_alarm(duration).unwrap();
     syscalls::yieldk_for(|| expired.get());
 }
 
-pub fn with_callback<CB: FnMut(ClockValue, Alarm)>(
-    callback: &mut TimerCallback<CB>,
-) -> TockResult<Timer, TimerError> {
-    let num_notifications =
-        unsafe { syscalls::command(DRIVER_NUMBER, command_nr::IS_DRIVER_AVAILABLE, 0, 0) };
-
-    if num_notifications < 1 {
-        return Err(TockValue::Expected(TimerError::NotSupported));
+pub fn with_callback<CB>(callback: CB) -> WithCallback<CB> {
+    WithCallback {
+        callback,
+        clock_frequency: ClockFrequency { hz: 0 },
     }
+}
 
-    let clock_frequency =
-        unsafe { syscalls::command(DRIVER_NUMBER, command_nr::GET_CLOCK_FREQUENCY, 0, 0) };
+pub struct WithCallback<CB> {
+    callback: CB,
+    clock_frequency: ClockFrequency,
+}
 
-    if clock_frequency < 1 {
-        return Err(TockValue::Expected(TimerError::ErroneousClockFrequency(
-            clock_frequency,
-        )));
+impl<CB: FnMut(ClockValue, Alarm)> SubscribableCallback for WithCallback<CB> {
+    fn call_rust(&mut self, clock_value: usize, alarm_id: usize, _: usize) {
+        (self.callback)(
+            ClockValue {
+                num_ticks: clock_value as isize,
+                clock_frequency: self.clock_frequency,
+            },
+            Alarm { alarm_id },
+        );
     }
+}
 
-    let clock_frequency = ClockFrequency {
-        hz: clock_frequency as usize,
-    };
-    callback.clock_frequency = clock_frequency;
+impl<CB> WithCallback<CB>
+where
+    Self: SubscribableCallback,
+{
+    pub fn init(&mut self) -> TockResult<Timer, TimerError> {
+        let num_notifications =
+            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::IS_DRIVER_AVAILABLE, 0, 0) };
 
-    let subscription =
-        syscalls::subscribe(DRIVER_NUMBER, subscribe_nr::SUBSCRIBE_CALLBACK, callback);
+        if num_notifications < 1 {
+            return Err(TockValue::Expected(TimerError::NotSupported));
+        }
 
-    match subscription {
-        Ok(subscription) => Ok(Timer {
-            num_notifications: num_notifications as usize,
-            clock_frequency,
-            subscription,
-        }),
-        Err(result::ENOMEM) => Err(TockValue::Expected(TimerError::SubscriptionFailed)),
-        Err(unexpected) => Err(TockValue::Unexpected(unexpected)),
+        let clock_frequency =
+            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::GET_CLOCK_FREQUENCY, 0, 0) };
+
+        if clock_frequency < 1 {
+            return Err(TockValue::Expected(TimerError::ErroneousClockFrequency(
+                clock_frequency,
+            )));
+        }
+
+        let clock_frequency = ClockFrequency {
+            hz: clock_frequency as usize,
+        };
+        self.clock_frequency = clock_frequency;
+
+        let subscription =
+            syscalls::subscribe(DRIVER_NUMBER, subscribe_nr::SUBSCRIBE_CALLBACK, self);
+
+        match subscription {
+            Ok(subscription) => Ok(Timer {
+                num_notifications: num_notifications as usize,
+                clock_frequency,
+                subscription,
+            }),
+            Err(result::ENOMEM) => Err(TockValue::Expected(TimerError::SubscriptionFailed)),
+            Err(unexpected) => Err(TockValue::Unexpected(unexpected)),
+        }
     }
 }
 
@@ -128,32 +154,6 @@ impl<'a> Timer<'a> {
             result::ENOMEM => Err(TockValue::Expected(SetAlarmError::NoMemoryAvailable)),
             unexpected => Err(TockValue::Unexpected(unexpected)),
         }
-    }
-}
-
-pub struct TimerCallback<CB> {
-    callback: CB,
-    clock_frequency: ClockFrequency,
-}
-
-impl<CB> TimerCallback<CB> {
-    pub fn new(callback: CB) -> Self {
-        TimerCallback {
-            callback,
-            clock_frequency: ClockFrequency { hz: 0 },
-        }
-    }
-}
-
-impl<CB: FnMut(ClockValue, Alarm)> SubscribableCallback for TimerCallback<CB> {
-    fn call_rust(&mut self, clock_value: usize, alarm_id: usize, _: usize) {
-        (self.callback)(
-            ClockValue {
-                num_ticks: clock_value as isize,
-                clock_frequency: self.clock_frequency,
-            },
-            Alarm { alarm_id },
-        );
     }
 }
 


### PR DESCRIPTION
This PR changes `syscalls::subscribe` to consume `&mut CB` instead of `CB`. For more details see #33.