### PR TITLE
Reduce usages of `unsafe`

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -5,6 +5,12 @@ pub trait SubscribableCallback {
     fn call_rust(&mut self, arg0: usize, arg1: usize, arg2: usize);
 }
 
+impl<F: FnMut(usize, usize, usize)> SubscribableCallback for F {
+    fn call_rust(&mut self, arg0: usize, arg1: usize, arg2: usize) {
+        self(arg0, arg1, arg2)
+    }
+}
+
 pub struct CallbackSubscription<'a> {
     driver_number: usize,
     subscribe_number: usize,


### PR DESCRIPTION
This PR includes two measures to reduce the number of `unsafe` usages in `libtock-rs`:
- Migrate the console code to the safe subscription and allow (fixed very soon) models
- Do not consider commands as unsafe anymore. IMO this is a reasonable assumption since the command interface is based on numbers only and the kernel architecture forbids that those numbers can be mutated or used as pointers. Given the circumstances, I do not see that a command is `unsafe` in terms of Rust.

By the way, the usages of `unsafe` could be further reduced if we had another system call for read-only access, e.g. AllowRead. Is something like this under consideration and/or would it make sense to open and issue?

PS: This PR depends on #35 