### PR TITLE
Bugfix: Extract timer into variable so subscription doesn't get dropped.

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -25,7 +25,8 @@ pub fn sleep(duration: Duration) {
     let expired = Cell::new(false);
     let mut with_callback = with_callback(|_, _| expired.set(true));
 
-    with_callback.init().unwrap().set_alarm(duration).unwrap();
+    let mut timer = with_callback.init().unwrap();
+    timer.set_alarm(duration).unwrap();
 
     syscalls::yieldk_for(|| expired.get());
 }


### PR DESCRIPTION
The latest change d233968 introduced regression in the sleep function because the subscription was dropped to early. Putting the timer into an extra variable prevents this.

Testing:
---
The "blink"-app was used to test this change and it is working properly.