### PR TITLE
Change design of SharedMemory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "tock"]
 	path = tock
 	url = https://github.com/helena-project/tock
-[submodule "xargo"]
-	path = xargo
-	url = https://github.com/japaric/xargo

--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -8,9 +8,7 @@ extern crate serde;
 extern crate serde_derive;
 extern crate tock;
 
-// Macro usages are not detected
-#[allow(unused_imports)]
-use alloc::*;
+use alloc::Vec;
 use tock::ble_parser;
 use tock::led;
 use tock::simple_ble::BleCallback;
@@ -26,23 +24,25 @@ struct LedCommand {
 // Prevents the compiler from dropping the subscription too early.
 #[allow(unreachable_code)]
 fn main() {
-    let mut shared_memory = BleDriver::share_memory().unwrap();
+    let mut shared_buffer = BleDriver::create_scan_buffer();
+    let mut my_buffer = BleDriver::create_scan_buffer();
+    let shared_memory = BleDriver::share_memory(&mut shared_buffer).unwrap();
 
     let mut callback = BleCallback::new(|_: usize, _: usize| {
-        match ble_parser::find(
-            shared_memory.to_bytes(),
-            tock::simple_ble::gap_data::SERVICE_DATA as u8,
-        ) {
+        shared_memory.read_bytes(&mut my_buffer);
+        match ble_parser::find(&my_buffer, tock::simple_ble::gap_data::SERVICE_DATA as u8) {
             Some(payload) => {
                 let payload: Vec<u8> = payload.into_iter().map(|x| *x).collect::<Vec<u8>>();
                 let msg: LedCommand = corepack::from_bytes(payload.as_slice()).unwrap();
                 let msg_led = led::get(msg.nr as isize);
                 match msg_led {
-                    Some(msg_led) => if msg.st {
-                        msg_led.on();
-                    } else {
-                        msg_led.off();
-                    },
+                    Some(msg_led) => {
+                        if msg.st {
+                            msg_led.on();
+                        } else {
+                            msg_led.off();
+                        }
+                    }
                     _ => (),
                 }
             }

--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -36,13 +36,10 @@ fn main() {
                 let msg: LedCommand = corepack::from_bytes(payload.as_slice()).unwrap();
                 let msg_led = led::get(msg.nr as isize);
                 match msg_led {
-                    Some(msg_led) => {
-                        if msg.st {
-                            msg_led.on();
-                        } else {
-                            msg_led.off();
-                        }
-                    }
+                    Some(msg_led) => match msg.st {
+                        true => msg_led.on(),
+                        false => msg_led.off(),
+                    },
                     _ => (),
                 }
             }

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -29,7 +29,10 @@ fn main() {
 
     let payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
 
-    let handle = BleAdvertisingDriver::initialize(100, name, uuid.to_vec(), true, payload).unwrap();
+    let mut buffer = BleAdvertisingDriver::create_advertising_buffer();
+    let handle =
+        BleAdvertisingDriver::initialize(100, name, uuid.to_vec(), true, payload, &mut buffer)
+            .unwrap();
 
     loop {
         led.on();

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -25,13 +25,13 @@ fn main() {
     let led = led::get(0).unwrap();
 
     let name = String::from("Tock!");
-    let uuid: [u16; 1] = [0x0018];
+    let mut uuid: [u8; 2] = [0x18, 0x00];
 
-    let payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
+    let mut payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
 
     let mut buffer = BleAdvertisingDriver::create_advertising_buffer();
     let handle =
-        BleAdvertisingDriver::initialize(100, name, uuid.to_vec(), true, payload, &mut buffer)
+        BleAdvertisingDriver::initialize(100, name, &mut uuid, true, &mut payload, &mut buffer)
             .unwrap();
 
     loop {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -7,8 +7,9 @@ pub fn output_number(value: u32) {
     write_u32_into_array(&mut out, value as u32, 0x10_00_00_00, 0x10);
 
     unsafe {
-        syscalls::allow_ptr(1, 1, &out);
+        let handle = syscalls::allow(1, 1, &mut out);
         syscalls::command(1, 1, 10, 0);
+        handle.unwrap();
     }
 }
 pub fn write_u32_into_array(result: &mut [u8; 11], value: u32, start: u32, base: u32) {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,12 +1,14 @@
 //! Tempoary formatting functions until format! is fixed
-use syscalls::{allow, command};
+
+use syscalls;
+use syscalls::command;
 
 pub fn output_number(value: u32) {
     let mut out: [u8; 11] = [32; 11];
     write_u32_into_array(&mut out, value as u32, 0x10_00_00_00, 0x10);
 
     unsafe {
-        allow(1, 1, &out);
+        syscalls::allow_ptr(1, 1, &out);
         command(1, 1, 10, 0);
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,7 +1,6 @@
 //! Tempoary formatting functions until format! is fixed
 
 use syscalls;
-use syscalls::command;
 
 pub fn output_number(value: u32) {
     let mut out: [u8; 11] = [32; 11];
@@ -9,7 +8,7 @@ pub fn output_number(value: u32) {
 
     unsafe {
         syscalls::allow_ptr(1, 1, &out);
-        command(1, 1, 10, 0);
+        syscalls::command(1, 1, 10, 0);
     }
 }
 pub fn write_u32_into_array(result: &mut [u8; 11], value: u32, start: u32, base: u32) {

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -75,7 +75,7 @@ impl Client {
 }
 
 unsafe fn discover(pkg_name: String) -> Result<usize, ()> {
-    let res = syscalls::allow(DRIVER_NUM, 0, pkg_name.as_bytes());
+    let res = syscalls::allow_ptr(DRIVER_NUM, 0, pkg_name.as_bytes());
     if res < 0 {
         Err(())
     } else {
@@ -85,7 +85,7 @@ unsafe fn discover(pkg_name: String) -> Result<usize, ()> {
 
 unsafe fn share(pid: usize, base: *mut u8, len: usize) -> Result<(), ()> {
     use core::slice::from_raw_parts;
-    let res = syscalls::allow(DRIVER_NUM, pid, from_raw_parts(base, len));
+    let res = syscalls::allow_ptr(DRIVER_NUM, pid, from_raw_parts(base, len));
     if res < 0 {
         Err(())
     } else {

--- a/src/ipc_cs/client.rs
+++ b/src/ipc_cs/client.rs
@@ -46,7 +46,7 @@ impl ServerHandle {
         shared_buffer.clone_from_slice(message);
 
         unsafe {
-            if syscalls::allow(DRIVER_NUMBER, self.pid as usize, &*shared_buffer) < 0 {
+            if syscalls::allow_ptr(DRIVER_NUMBER, self.pid as usize, &*shared_buffer) < 0 {
                 panic!()
             };
         }
@@ -58,7 +58,7 @@ impl ServerHandle {
 
     pub fn discover_service(name: String) -> Option<ServerHandle> {
         let pid = unsafe {
-            syscalls::allow(
+            syscalls::allow_ptr(
                 DRIVER_NUMBER,
                 ipc_commands::DISCOVER_SERVICE,
                 &name.as_bytes(),

--- a/src/ipc_cs/client.rs
+++ b/src/ipc_cs/client.rs
@@ -46,7 +46,13 @@ impl ServerHandle {
         shared_buffer.clone_from_slice(message);
 
         unsafe {
-            if syscalls::allow_ptr(DRIVER_NUMBER, self.pid as usize, &*shared_buffer) < 0 {
+            if syscalls::allow_ptr(
+                DRIVER_NUMBER,
+                self.pid as usize,
+                shared_buffer.as_mut().as_mut_ptr(),
+                32,
+            ) < 0
+            {
                 panic!()
             };
         }
@@ -56,12 +62,14 @@ impl ServerHandle {
         unsafe { syscalls::command(DRIVER_NUMBER, self.pid as usize, 0, 0) };
     }
 
-    pub fn discover_service(name: String) -> Option<ServerHandle> {
+    pub fn discover_service(mut name: String) -> Option<ServerHandle> {
+        let len = name.len();
         let pid = unsafe {
             syscalls::allow_ptr(
                 DRIVER_NUMBER,
                 ipc_commands::DISCOVER_SERVICE,
-                &name.as_bytes(),
+                name.as_bytes_mut().as_mut_ptr(),
+                len,
             )
         };
         if pid >= 0 {

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -1,5 +1,4 @@
 use core::ptr;
-use core::slice;
 use syscalls;
 
 pub struct SharedMemory<'a> {
@@ -21,26 +20,14 @@ impl<'a> SharedMemory<'a> {
 impl<'a> Drop for SharedMemory<'a> {
     fn drop(&mut self) {
         unsafe {
-            syscalls::allow_ptr(
-                self.driver_number,
-                self.allow_number,
-                slice::from_raw_parts_mut(ptr::null_mut(), 0),
-            );
+            syscalls::allow_ptr(self.driver_number, self.allow_number, ptr::null_mut(), 0);
         }
     }
 }
 
 fn safe_copy(origin: &[u8], destination: &mut [u8]) {
-    let amount = min(origin.len(), destination.len());
+    let amount = origin.len().min(destination.len());
     let origin = &origin[0..amount];
     let destination = &mut destination[0..amount];
     destination.clone_from_slice(origin);
-}
-
-fn min(a: usize, b: usize) -> usize {
-    if a < b {
-        a
-    } else {
-        b
-    }
 }

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -1,18 +1,31 @@
-pub trait ShareableMemory {
-    fn driver_number(&self) -> usize;
+use core::ptr;
+use core::slice;
+use syscalls;
 
-    fn allow_number(&self) -> usize;
-
-    fn to_bytes(&mut self) -> &mut [u8];
+pub struct SharedMemory<'a> {
+    pub driver_number: usize,
+    pub allow_number: usize,
+    pub buffer_to_share: &'a mut [u8],
 }
 
-pub struct SharedMemory<SM: ShareableMemory> {
-    #[allow(dead_code)] // Used in drop
-    pub(crate) shareable_memory: SM,
+impl<'a> SharedMemory<'a> {
+    pub fn read_bytes(&self, destination: &mut [u8]) {
+        destination.clone_from_slice(self.buffer_to_share);
+    }
+
+    pub fn write_bytes(&mut self, source: &[u8]) {
+        self.buffer_to_share.clone_from_slice(source);
+    }
 }
 
-impl<SM: ShareableMemory> SharedMemory<SM> {
-    pub fn to_bytes(&mut self) -> &mut [u8] {
-        self.shareable_memory.to_bytes()
+impl<'a> Drop for SharedMemory<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            syscalls::allow_ptr(
+                self.driver_number,
+                self.allow_number,
+                slice::from_raw_parts_mut(ptr::null_mut(), 0),
+            );
+        }
     }
 }

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -10,11 +10,11 @@ pub struct SharedMemory<'a> {
 
 impl<'a> SharedMemory<'a> {
     pub fn read_bytes(&self, destination: &mut [u8]) {
-        destination.clone_from_slice(self.buffer_to_share);
+        safe_copy(self.buffer_to_share, destination);
     }
 
     pub fn write_bytes(&mut self, source: &[u8]) {
-        self.buffer_to_share.clone_from_slice(source);
+        safe_copy(source, self.buffer_to_share);
     }
 }
 
@@ -27,5 +27,20 @@ impl<'a> Drop for SharedMemory<'a> {
                 slice::from_raw_parts_mut(ptr::null_mut(), 0),
             );
         }
+    }
+}
+
+fn safe_copy(origin: &[u8], destination: &mut [u8]) {
+    let amount = min(origin.len(), destination.len());
+    let origin = &origin[0..amount];
+    let destination = &mut destination[0..amount];
+    destination.clone_from_slice(origin);
+}
+
+fn min(a: usize, b: usize) -> usize {
+    if a < b {
+        a
+    } else {
+        b
     }
 }

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -46,7 +46,7 @@ impl BleAdvertisingDriver {
         uuid: Vec<u16>,
         stay_visible: bool,
         service_payload: Vec<u8>,
-        advertising_buffer: &mut [u8],
+        advertising_buffer: &mut [u8; BUFFER_SIZE],
     ) -> Result<SharedMemory, isize> {
         let flags: [u8; 1] = [gap_flags::ONLY_LE | (if stay_visible {
             gap_flags::BLE_DISCOVERABLE
@@ -151,7 +151,7 @@ impl BleDriver {
         [0; BUFFER_SIZE_SCAN]
     }
 
-    pub fn share_memory(scan_buffer: &mut [u8]) -> Result<SharedMemory, isize> {
+    pub fn share_memory(scan_buffer: &mut [u8; BUFFER_SIZE_SCAN]) -> Result<SharedMemory, isize> {
         syscalls::allow(DRIVER_NUMBER, ble_commands::ALLOW_SCAN_BUFFER, scan_buffer)
     }
 

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -1,7 +1,5 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use core::ptr;
-use shared_memory::ShareableMemory;
 use shared_memory::SharedMemory;
 
 pub fn yieldk() {
@@ -97,19 +95,27 @@ pub unsafe fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> i
     res
 }
 
-pub unsafe fn allow(major: usize, minor: usize, slice: &[u8]) -> isize {
+pub fn allow(
+    driver_number: usize,
+    allow_number: usize,
+    buffer_to_share: &mut [u8],
+) -> Result<SharedMemory, isize> {
+    let return_code = unsafe { allow_ptr(driver_number, allow_number, buffer_to_share) };
+    if return_code == 0 {
+        Ok(SharedMemory {
+            driver_number,
+            allow_number,
+            buffer_to_share,
+        })
+    } else {
+        Err(return_code)
+    }
+}
+
+pub unsafe fn allow_ptr(major: usize, minor: usize, slice: &[u8]) -> isize {
     let res;
     asm!("svc 3" : "={r0}"(res)
                  : "{r0}"(major) "{r1}"(minor) "{r2}"(slice.as_ptr()) "{r3}"(slice.len())
-                 : "memory"
-                 : "volatile");
-    res
-}
-
-unsafe fn unallow(major: usize, minor: usize) -> isize {
-    let res;
-    asm!("svc 3" : "={r0}"(res)
-                 : "{r0}"(major) "{r1}"(minor) "{r2}"(ptr::null::<u8>()) "{r3}" (0)
                  : "memory"
                  : "volatile");
     res
@@ -131,26 +137,4 @@ pub unsafe fn memop(major: u32, arg1: usize) -> isize {
                  : "memory"
                  : "volatile");
     res
-}
-
-pub fn allow_new<SM: ShareableMemory>(mut shareable_memory: SM) -> (isize, SharedMemory<SM>) {
-    let return_code = unsafe {
-        allow(
-            shareable_memory.driver_number(),
-            shareable_memory.allow_number(),
-            shareable_memory.to_bytes(),
-        )
-    };
-    (return_code, SharedMemory { shareable_memory })
-}
-
-impl<SM: ShareableMemory> Drop for SharedMemory<SM> {
-    fn drop(&mut self) {
-        unsafe {
-            unallow(
-                self.shareable_memory.driver_number(),
-                self.shareable_memory.allow_number(),
-            );
-        }
-    }
 }

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -1,6 +1,5 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
-use shared_memory::ShareableMemory;
 use shared_memory::SharedMemory;
 
 pub fn yieldk_for<F: Fn() -> bool>(_: F) {
@@ -28,15 +27,15 @@ pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
     unimplemented()
 }
 
-pub unsafe fn allow(_: usize, _: usize, _: &[u8]) -> isize {
+pub fn allow(_: usize, _: usize, _: &mut [u8]) -> Result<SharedMemory, isize> {
+    unimplemented()
+}
+
+pub unsafe fn allow_ptr(_: usize, _: usize, _: &[u8]) -> isize {
     unimplemented()
 }
 
 pub unsafe fn allow16(_: usize, _: usize, _: &[u16]) -> isize {
-    unimplemented()
-}
-
-pub fn allow_new<SM: ShareableMemory>(_: SM) -> (isize, SharedMemory<SM>) {
     unimplemented()
 }
 

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -31,11 +31,7 @@ pub fn allow(_: usize, _: usize, _: &mut [u8]) -> Result<SharedMemory, isize> {
     unimplemented()
 }
 
-pub unsafe fn allow_ptr(_: usize, _: usize, _: &[u8]) -> isize {
-    unimplemented()
-}
-
-pub unsafe fn allow16(_: usize, _: usize, _: &[u16]) -> isize {
+pub unsafe fn allow_ptr(_: usize, _: usize, _: *mut u8, _: usize) -> isize {
     unimplemented()
 }
 


### PR DESCRIPTION
# Content of the PR
SharedMemory now holds a mutable reference of ShareableMemory such that the latter cannot move on the stack and invalidate the pointer to the byte array passed to the kernel anymore.

# Not in this PR
- Migration of all calls of allow_ptr to the safe allow-call

# Testing
The following tests were run:
- Hardware integration tests
- Ble-Scanning and Advertising

