### PR TITLE
More rustic error handling

### DIFF
--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -34,7 +34,7 @@ fn main() {
             Some(payload) => {
                 let payload: Vec<u8> = payload.into_iter().map(|x| *x).collect::<Vec<u8>>();
                 let msg: LedCommand = corepack::from_bytes(payload.as_slice()).unwrap();
-                let msg_led = led::get(msg.nr as isize);
+                let msg_led = led::get(msg.nr as usize);
                 match msg_led {
                     Some(msg_led) => match msg.st {
                         true => msg_led.on(),

--- a/examples/button_leds.rs
+++ b/examples/button_leds.rs
@@ -9,8 +9,8 @@ use tock::timer;
 use tock::timer::Duration;
 
 fn main() {
-    let mut with_callback = buttons::with_callback(|button_num: usize, state| {
-        let i = button_num as isize;
+    let mut with_callback = buttons::with_callback(|button_num, state| {
+        let i = button_num;
         match state {
             ButtonState::Pressed => led::get(i).unwrap().toggle(),
             ButtonState::Released => (),

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -19,9 +19,9 @@ fn main() {
     let button = button.enable().unwrap();
 
     loop {
-        match button.read() {
-            ButtonState::Pressed => console.write(String::from("pressed\n")),
-            ButtonState::Released => console.write(String::from("released\n")),
+        match button.read().unwrap() {
+            ButtonState::Pressed => console.write(String::from("pressed\n")).unwrap(),
+            ButtonState::Released => console.write(String::from("released\n")).unwrap(),
         }
         timer::sleep(Duration::from_ms(500));
     }

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -17,13 +17,15 @@ fn main() {
     let mut console = Console::new();
 
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {
-        console.write(String::from("\nButton: "));
-        console.write(fmt::u32_as_hex(button_num as u32));
-        console.write(String::from(" - State: "));
-        console.write(String::from(match state {
-            ButtonState::Pressed => "pressed",
-            ButtonState::Released => "released",
-        }));
+        console.write(String::from("\nButton: ")).unwrap();
+        console.write(fmt::u32_as_hex(button_num as u32)).unwrap();
+        console.write(String::from(" - State: ")).unwrap();
+        console
+            .write(String::from(match state {
+                ButtonState::Pressed => "pressed",
+                ButtonState::Released => "released",
+            }))
+            .unwrap();
     });
 
     let mut buttons = with_callback.init().unwrap();

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -18,9 +18,9 @@ fn main() {
 
     loop {
         if pin.read() {
-            console.write(String::from("true\n"));
+            console.write(String::from("true\n")).unwrap();
         } else {
-            console.write(String::from("false\n"));
+            console.write(String::from("false\n")).unwrap();
         }
         timer::sleep(Duration::from_ms(500));
     }

--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -23,10 +23,10 @@ fn main() {
     // the client/server pair the tests are only run once.
     timer::sleep(Duration::from_ms(3000));
 
-    console.write(String::from("[test-results]\n"));
+    console.write(String::from("[test-results]\n")).unwrap();
     let mut string = String::from("heap_test = \"Heap ");
     string.push_str("works.\"\n");
-    console.write(string);
+    console.write(string).unwrap();
 
     let mut server = ServerHandle::discover_service(String::from("hardware_test_server")).unwrap();
     let mut payload: [u8; 32] = [0; 32];
@@ -47,8 +47,8 @@ fn main() {
             .filter(|&x| x != 0)
             .collect::<Vec<_>>();
         let s = String::from_utf8_lossy(&filtered);
-        console.write(String::from(s).clone());
-        console.write(String::from("test=\"done\"\n"));
+        console.write(String::from(s).clone()).unwrap();
+        console.write(String::from("test=\"done\"\n")).unwrap();
     });
 
     let handle = server.subscribe_callback(&mut callback);

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -14,9 +14,9 @@ fn main() {
     let mut console = Console::new();
 
     for i in 0.. {
-        console.write(String::from("Hello world! "));
-        console.write(tock::fmt::u32_as_decimal(i));
-        console.write(String::from("\n"));
+        console.write(String::from("Hello world! ")).unwrap();
+        console.write(tock::fmt::u32_as_decimal(i)).unwrap();
+        console.write(String::from("\n")).unwrap();
         timer::sleep(Duration::from_ms(500))
     }
 }

--- a/examples/ipcclient.rs
+++ b/examples/ipcclient.rs
@@ -27,9 +27,11 @@ fn main() {
         let mut callback = IpcClientCallback::new(|_: usize, _: usize| {
             let mut console = Console::new();
             handle.read_bytes(&mut my_buf.buffer);
-            console.write(String::from("Client: \"Payload: "));
-            console.write(fmt::u32_as_decimal(my_buf.buffer[0] as u32));
-            console.write(String::from("\"\n"));
+            console.write(String::from("Client: \"Payload: ")).unwrap();
+            console
+                .write(fmt::u32_as_decimal(my_buf.buffer[0] as u32))
+                .unwrap();
+            console.write(String::from("\"\n")).unwrap();
         });
 
         let handle = server.subscribe_callback(&mut callback);

--- a/examples/ipcserver.rs
+++ b/examples/ipcserver.rs
@@ -14,13 +14,13 @@ use tock::ipc::IpcServerDriver;
 // Prints the payload and adds one to the first byte.
 fn main() {
     let mut console = Console::new();
-    console.write(String::from("Start service:\n"));
+    console.write(String::from("Start service:\n")).unwrap();
 
     let mut callback = IpcServerCallback::new(|pid: usize, _: usize, message: &mut [u8]| {
-        console.write(String::from("Server: \"Payload: "));
+        console.write(String::from("Server: \"Payload: ")).unwrap();
 
-        console.write(u32_as_hex(message[0] as u32));
-        console.write(String::from("\"\n"));
+        console.write(u32_as_hex(message[0] as u32)).unwrap();
+        console.write(String::from("\"\n")).unwrap();
         message[0] += 1;
         ipc::notify_client(pid);
     });

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -11,9 +11,11 @@ fn main() {
     let mut console = Console::new();
 
     let mut with_callback = temperature::with_callback(|result: isize| {
-        console.write(String::from("Temperature: "));
-        console.write(tock::fmt::i32_as_decimal(result as i32));
-        console.write(String::from("\n"));
+        console.write(String::from("Temperature: ")).unwrap();
+        console
+            .write(tock::fmt::i32_as_decimal(result as i32))
+            .unwrap();
+        console.write(String::from("\n")).unwrap();
     });
 
     let _temperature = with_callback.start_measurement();

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -14,9 +14,11 @@ fn main() {
     let mut console = Console::new();
 
     let mut with_callback = timer::with_callback(|_, _| {
-        console.write(String::from(
-            "This line is printed 2 seconds after the start of the program.",
-        ))
+        console
+            .write(String::from(
+                "This line is printed 2 seconds after the start of the program.",
+            ))
+            .unwrap();
     });
 
     let mut timer = with_callback.init().unwrap();

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,7 +1,9 @@
 use alloc::String;
 use core::cell::Cell;
 use core::fmt;
+use core::fmt::Error;
 use core::result::Result;
+use result::TockResult;
 use syscalls;
 
 const DRIVER_NUMBER: usize = 1;
@@ -26,40 +28,32 @@ impl Console {
     }
 
     // TODO: Use &str after relocation is fixed
-    pub fn write(&mut self, mut text: String) {
+    pub fn write(&mut self, mut text: String) -> TockResult<()> {
         let num_bytes = text.as_bytes().len();
 
-        let result = syscalls::allow(DRIVER_NUMBER, allow_nr::SHARE_BUFFER, unsafe {
+        let _result = syscalls::allow(DRIVER_NUMBER, allow_nr::SHARE_BUFFER, unsafe {
             text.as_bytes_mut()
-        });
-        if result.is_err() {
-            return;
-        }
+        })?;
 
         let is_written = Cell::new(false);
         let mut is_written_alarm = |_, _, _| is_written.set(true);
-        let subscription = syscalls::subscribe(
+
+        let _subscription = syscalls::subscribe(
             DRIVER_NUMBER,
             subscribe_nr::SET_ALARM,
             &mut is_written_alarm,
-        );
-        if subscription.is_err() {
-            return;
-        }
+        )?;
 
-        let result_code =
-            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::WRITE, num_bytes, 0) };
-        if result_code < 0 {
-            return;
-        }
+        unsafe { syscalls::command(DRIVER_NUMBER, command_nr::WRITE, num_bytes, 0) }?;
 
         syscalls::yieldk_for(|| is_written.get());
+
+        Ok(())
     }
 }
 
 impl fmt::Write for Console {
-    fn write_str(&mut self, string: &str) -> Result<(), fmt::Error> {
-        self.write(String::from(string));
-        Ok(())
+    fn write_str(&mut self, string: &str) -> Result<(), Error> {
+        self.write(String::from(string)).map_err(|_| Error)
     }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -8,7 +8,7 @@ pub fn output_number(value: u32) {
 
     unsafe {
         let handle = syscalls::allow(1, 1, &mut out);
-        syscalls::command(1, 1, 10, 0);
+        syscalls::command(1, 1, 10, 0).unwrap();
         handle.unwrap();
     }
 }

--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -80,11 +80,15 @@ unsafe fn run_with_new_stack() -> ! {
     StackOwnedHeap.init(&mut heap);
 
     let mut console = Console::new();
-    console.write(String::from(
-        "\nProcess started\n===============\nHeap position: ",
-    ));
-    console.write(fmt::u32_as_hex(heap.as_ptr() as u32));
-    console.write(String::from("\n\n"));
+    console
+        .write(String::from(
+            "\nProcess started\n===============\nHeap position: ",
+        ))
+        .unwrap();
+    console
+        .write(fmt::u32_as_hex(heap.as_ptr() as u32))
+        .unwrap();
+    console.write(String::from("\n\n")).unwrap();
 
     main(0, ptr::null());
 

--- a/src/ipc/ble_ess.rs
+++ b/src/ipc/ble_ess.rs
@@ -1,6 +1,7 @@
 use alloc::String;
 use ipc::IPCBuffer;
 use ipc::ServerHandle;
+use result::TockResult;
 use shared_memory::SharedMemory;
 
 #[repr(u32)]
@@ -23,7 +24,7 @@ pub fn connect(buffer: &mut IPCBuffer) -> Result<BleEss, ()> {
 }
 
 impl<'a> BleEss<'a> {
-    pub fn set_reading<I>(&mut self, sensor: ReadingType, data: I) -> Result<(), isize>
+    pub fn set_reading<I>(&mut self, sensor: ReadingType, data: I) -> TockResult<usize>
     where
         I: Into<i32>,
     {

--- a/src/ipc/server.rs
+++ b/src/ipc/server.rs
@@ -1,6 +1,7 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
 use core::slice;
+use result::TockResult;
 use syscalls;
 
 const DRIVER_NUMBER: usize = 0x10000;
@@ -28,13 +29,13 @@ impl<CB: FnMut(usize, usize, &mut [u8])> SubscribableCallback for IpcServerCallb
 }
 
 pub fn notify_client(pid: usize) {
-    unsafe { syscalls::command(DRIVER_NUMBER, pid, ipc_commands::NOTIFY_CLIENT, 0) };
+    unsafe { syscalls::command(DRIVER_NUMBER, pid, ipc_commands::NOTIFY_CLIENT, 0) }.unwrap();
 }
 
 pub struct IpcServerDriver;
 
 impl IpcServerDriver {
-    pub fn start<CB>(callback: &mut IpcServerCallback<CB>) -> Result<CallbackSubscription, isize>
+    pub fn start<CB>(callback: &mut IpcServerCallback<CB>) -> TockResult<CallbackSubscription>
     where
         IpcServerCallback<CB>: SubscribableCallback,
     {

--- a/src/led.rs
+++ b/src/led.rs
@@ -13,15 +13,13 @@ pub struct Led {
     led_num: usize,
 }
 
-pub fn count() -> isize {
-    unsafe { command(DRIVER_NUMBER, command_nr::COUNT, 0, 0) }
+pub fn count() -> usize {
+    unsafe { command(DRIVER_NUMBER, command_nr::COUNT, 0, 0) }.unwrap_or(0)
 }
 
-pub fn get(led_num: isize) -> Option<Led> {
-    if led_num >= 0 && led_num < count() {
-        Some(Led {
-            led_num: led_num as usize,
-        })
+pub fn get(led_num: usize) -> Option<Led> {
+    if led_num < count() {
+        Some(Led { led_num })
     } else {
         None
     }
@@ -30,7 +28,7 @@ pub fn get(led_num: isize) -> Option<Led> {
 pub fn all() -> LedIter {
     LedIter {
         curr_led: 0,
-        led_count: count() as usize,
+        led_count: count(),
     }
 }
 
@@ -45,19 +43,19 @@ impl Led {
 
     pub fn on(&self) {
         unsafe {
-            command(DRIVER_NUMBER, command_nr::ON, self.led_num, 0);
+            command(DRIVER_NUMBER, command_nr::ON, self.led_num, 0).unwrap();
         }
     }
 
     pub fn off(&self) {
         unsafe {
-            command(DRIVER_NUMBER, command_nr::OFF, self.led_num, 0);
+            command(DRIVER_NUMBER, command_nr::OFF, self.led_num, 0).unwrap();
         }
     }
 
     pub fn toggle(&self) {
         unsafe {
-            command(DRIVER_NUMBER, command_nr::TOGGLE, self.led_num, 0);
+            command(DRIVER_NUMBER, command_nr::TOGGLE, self.led_num, 0).unwrap();
         }
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,27 +1,58 @@
-#[derive(Copy, Clone, Debug)]
-pub enum TockValue<E> {
-    Expected(E),
-    Unexpected(isize),
+use core::fmt::Debug;
+use core::fmt::Error;
+use core::fmt::Formatter;
+
+#[derive(Copy, Clone)]
+pub struct TockError(pub(crate) isize);
+
+pub type TockResult<T> = Result<T, TockError>;
+
+impl TockError {
+    pub fn from_return_code(return_code: isize) -> TockResult<usize> {
+        if return_code >= 0 {
+            Ok(return_code as usize)
+        } else {
+            Err(TockError(return_code))
+        }
+    }
+
+    pub fn get_return_code(&self) -> isize {
+        self.0
+    }
 }
 
-pub type TockResult<T, E> = Result<T, TockValue<E>>;
-
-pub trait TockResultExt<T, E>: Sized {
-    fn as_expected(self) -> Result<T, E>;
-}
-
-impl<T, E> TockResultExt<T, E> for TockResult<T, E> {
-    fn as_expected(self) -> Result<T, E> {
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(TockValue::Expected(err)) => Err(err),
-            Err(TockValue::Unexpected(_)) => panic!("Unexpected error"),
+impl Debug for TockError {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), Error> {
+        match self.0 {
+            FAIL => write!(formatter, "FAIL"),
+            EBUSY => write!(formatter, "EBUSY"),
+            EALREADY => write!(formatter, "EALREADY"),
+            EOFF => write!(formatter, "EOFF"),
+            ERESERVE => write!(formatter, "ERESERVE"),
+            EINVAL => write!(formatter, "EINVAL"),
+            ESIZE => write!(formatter, "ESIZE"),
+            ECANCEL => write!(formatter, "ECANCEL"),
+            ENOMEM => write!(formatter, "ENOMEM"),
+            ENOSUPPORT => write!(formatter, "ENOSUPPORT"),
+            ENODEVICE => write!(formatter, "ENODEVICE"),
+            EUNINSTALLED => write!(formatter, "EUNINSTALLED"),
+            ENOACK => write!(formatter, "ENOACK"),
+            unknown => write!(formatter, "Unknown error code: {}", unknown),
         }
     }
 }
 
 pub const SUCCESS: isize = 0;
+pub const FAIL: isize = -1;
+pub const EBUSY: isize = -2;
 pub const EALREADY: isize = -3;
+pub const EOFF: isize = -4;
+pub const ERESERVE: isize = -5;
 pub const EINVAL: isize = -6;
 pub const ESIZE: isize = -7;
+pub const ECANCEL: isize = -8;
 pub const ENOMEM: isize = -9;
+pub const ENOSUPPORT: isize = -10;
+pub const ENODEVICE: isize = -11;
+pub const EUNINSTALLED: isize = -12;
+pub const ENOACK: isize = -13;

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -29,7 +29,7 @@ pub trait Sensor<Reading: Copy + From<(usize, usize, usize)>> {
                 cb::<Reading> as *const _,
                 mem::transmute(&res),
             );
-            syscalls::command(driver_num, 1, 0, 0);
+            syscalls::command(driver_num, 1, 0, 0).unwrap();
             yieldk_for(|| res.get().is_some());
             res.get().unwrap()
         }

--- a/src/sensors/ninedof.rs
+++ b/src/sensors/ninedof.rs
@@ -67,9 +67,9 @@ pub unsafe fn subscribe(cb: extern "C" fn(usize, usize, usize, usize), ud: usize
 }
 
 pub unsafe fn start_accel_reading() {
-    syscalls::command(DRIVER_NUM, 1, 0, 0);
+    syscalls::command(DRIVER_NUM, 1, 0, 0).unwrap();
 }
 
 pub unsafe fn start_magnetometer_reading() {
-    syscalls::command(DRIVER_NUM, 1, 0, 0);
+    syscalls::command(DRIVER_NUM, 1, 0, 0).unwrap();
 }

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -1,5 +1,6 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use result::TockResult;
 use shared_memory::SharedMemory;
 
 pub fn yieldk_for<F: Fn() -> bool>(_: F) {
@@ -10,7 +11,7 @@ pub fn subscribe<CB: SubscribableCallback>(
     _: usize,
     _: usize,
     _: &mut CB,
-) -> Result<CallbackSubscription, isize> {
+) -> TockResult<CallbackSubscription> {
     unimplemented()
 }
 
@@ -23,11 +24,11 @@ pub unsafe fn subscribe_ptr(
     unimplemented()
 }
 
-pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
+pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> TockResult<usize> {
     unimplemented()
 }
 
-pub fn allow(_: usize, _: usize, _: &mut [u8]) -> Result<SharedMemory, isize> {
+pub fn allow(_: usize, _: usize, _: &mut [u8]) -> TockResult<SharedMemory> {
     unimplemented()
 }
 

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -1,5 +1,6 @@
 use callback::CallbackSubscription;
 use callback::SubscribableCallback;
+use result::TockResult;
 use syscalls;
 
 const DRIVER_NUMBER: usize = 0x60000;
@@ -24,9 +25,9 @@ impl<CB> WithCallback<CB>
 where
     Self: SubscribableCallback,
 {
-    pub fn start_measurement(&mut self) -> Result<CallbackSubscription, isize> {
+    pub fn start_measurement(&mut self) -> TockResult<CallbackSubscription> {
         let subscription = syscalls::subscribe(DRIVER_NUMBER, SUBSCRIBE_CALLBACK, self)?;
-        unsafe { syscalls::command(DRIVER_NUMBER, START_MEASUREMENT, 0, 0) };
+        unsafe { syscalls::command(DRIVER_NUMBER, START_MEASUREMENT, 0, 0) }?;
         Ok(subscription)
     }
 }


### PR DESCRIPTION
This PR proposes to use result types in syscalls for an improved error handling.

Advantages:
- Returning results is the idiomatic way to deal with errors in Rust libraries
- Good early return (`try!` or `?`) and combinators (e.g. `map_err`) support
- In contrast to panics or silent failure, result types communicate clearly why an when an error occurred

Drawbacks:
- It can lead to a lot of `unwrap()` code
- Error handling via return types might require additional machine code instructions (although I think the effect is negligible)

What is your opinion?
Should we use result types for every syscall?
Do error types work in an embedded context or should we prefer to ignore errors in order to save machine code instructions?

PS: The migration to results is not complete. The final goal would be to get rid of all `unwrap()` in the `src` folder.