### PR TITLE
Use elf2tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ to use:
     ```
 
     This should work if you are using the nRF52-DK platform. For other platforms,
-    you will end up with a TAB file in `target/` that you can program onto your
-    Tock board (e.g. with `tockloader install target/blink.tab`).
+    you will end up with a TAB file in `target/tab` that you can program onto your
+    Tock board (e.g. with `tockloader install target/tab/blink.tab`).
 
 ## Using libtock-rs
 

--- a/layout.ld
+++ b/layout.ld
@@ -5,8 +5,6 @@
  */
 
 STACK_SIZE = 2048;
-APP_HEAP_SIZE = 1024;
-KERNEL_HEAP_SIZE = 1024;
 
 ENTRY(_start)
 
@@ -20,13 +18,14 @@ MEMORY {
 }
 
 SECTIONS {
-    /* Text section, Code! */
-    .text :
+    /* Section for just the app crt0 header.
+     * This must be first so that the app can find it.
+     */
+    .crt0_header :
     {
-        _text = .;
+        _beginning = .; /* Start of the app in flash. */
         /**
          * Populate the header expected by `crt0`:
-         *
          *
          *  struct hdr {
          *    uint32_t got_sym_start;
@@ -42,13 +41,13 @@ SECTIONS {
          *  };
          */
         /* Offset of GOT symbols in flash */
-        LONG(LOADADDR(.got) - _text);
+        LONG(LOADADDR(.got) - _beginning);
         /* Offset of GOT section in memory */
         LONG(_got);
         /* Size of GOT section */
         LONG(SIZEOF(.got));
         /* Offset of data symbols in flash */
-        LONG(LOADADDR(.data) - _text);
+        LONG(LOADADDR(.data) - _beginning);
         /* Offset of data section in memory */
         LONG(_data);
         /* Size of data section */
@@ -57,12 +56,28 @@ SECTIONS {
         LONG(_bss);
         /* Size of BSS section */
         LONG(SIZEOF(.bss));
-        /* First address offset after program flash, where elf2tbf places
+        /* First address offset after program flash, where elf2tab places
          * .rel.data section */
-        LONG(LOADADDR(.endsec) - _text);
+        LONG(LOADADDR(.endflash) - _beginning);
         /* The size of the stack requested by this application */
         LONG(STACK_SIZE);
+    } > FLASH =0xFF
 
+    /* App state section. Used for persistent app data.
+     * We put this first so that if the app code changes but the persistent
+     * data doesn't, the app_state can be preserved.
+     */
+    .wfr.app_state :
+    {
+        KEEP (*(.app_state))
+        . = ALIGN(4); /* Make sure we're word-aligned here */
+    } > FLASH =0xFF
+
+    /* Text section, Code! */
+    .text :
+    {
+        . = ALIGN(4);
+        _text = .;
         KEEP (*(.start))
         *(.text*)
         *(.rodata*)
@@ -72,19 +87,14 @@ SECTIONS {
         . = ALIGN(4); /* Make sure we're word-aligned here */
     } > FLASH =0xFF
 
-
-    /* App state section. Used for persistent app data. */
-    .app_state :
-    {
-        KEEP (*(.app_state))
-    } > FLASH =0xFF
-
     /* Global Offset Table */
     .got :
     {
+        . = ALIGN(4); /* Make sure we're word-aligned here */
         _got = .;
         *(.got*)
         *(.got.plt*)
+        . = ALIGN(4);
     } > SRAM AT > FLASH
 
     /* Data section, static initialized variables
@@ -93,39 +103,24 @@ SECTIONS {
      */
     .data :
     {
+        . = ALIGN(4); /* Make sure we're word-aligned here */
         _data = .;
         KEEP(*(.data*))
+        . = ALIGN(4); /* Make sure we're word-aligned at the end of flash */
     } > SRAM AT > FLASH
 
     /* BSS section, static uninitialized variables */
     .bss :
     {
+        . = ALIGN(4); /* Make sure we're word-aligned here */
         _bss = .;
         KEEP(*(.bss*))
         *(COMMON)
+        . = ALIGN(4);
     } > SRAM
 
-    /*
-     * __NOTE__: The following symbols are used only to hint to elf2tbf how much
-     * total memory to request from the OS.
-     */
-    .stack :
-    {
-        . += STACK_SIZE;
-    } > SRAM
-
-    .app_heap :
-    {
-        . += APP_HEAP_SIZE;
-    } > SRAM
-
-    .kernel_heap :
-    {
-        . += KERNEL_HEAP_SIZE;
-    } > SRAM
-
-    _sram_end = .;
-    .endsec :
+    /* End of flash. */
+    .endflash :
     {
     } > FLASH
 
@@ -149,5 +144,4 @@ SECTIONS {
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)
     } > FLASH
     PROVIDE_HIDDEN (__exidx_end = .);
-
 }

--- a/run_example.sh
+++ b/run_example.sh
@@ -4,21 +4,16 @@
 
 set -eux
 
-tab_file_name=metadata.toml
-elf_file_name=cortex-m4.elf
-bin_file_name=cortex-m4.bin
-
 cargo build --release --target=thumbv7em-none-eabi --example "$1"
-cp target/thumbv7em-none-eabi/release/examples/"$1" "target/$elf_file_name"
-cargo run --manifest-path tock/userland/tools/elf2tbf/Cargo.toml -- -n "$1" -o "target/$bin_file_name" "target/$elf_file_name"
 
-echo "tab-version = 1" > "target/$tab_file_name"
-echo "name = \"$1\"" >> "target/$tab_file_name"
-echo "only-for-boards = \"\"" >> "target/$tab_file_name"
-echo "build-date = $(date "+%Y-%m-%dT%H:%M:%SZ")" >> "target/$tab_file_name"
 
-out_file_name="$1".tab
-tar -C target -cf "target/$out_file_name" "$bin_file_name" "$tab_file_name"
+elf_file_name="target/tab/$1/cortex-m4.elf"
+tab_file_name="target/tab/$1.tab"
+
+mkdir -p "target/tab/$1"
+cp "target/thumbv7em-none-eabi/release/examples/$1" "$elf_file_name"
+
+cargo run --manifest-path tock/userland/tools/elf2tab/Cargo.toml -- -n "$1" -o "$tab_file_name" "$elf_file_name" --stack 2048 --app-heap 1024 --kernel-heap 1024
 
 if [ "$#" -ge "2" ]
 then
@@ -31,4 +26,4 @@ then
 else
     tockloader uninstall --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 || true
 fi
-tockloader install --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 "target/$out_file_name"
+tockloader install --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 "$tab_file_name"


### PR DESCRIPTION
Content of this PR
- Update Tock
- Use elf2tab instead of elf2tbf
- Improve folder structure for converted elf files
- Sync linker scripts