### PR TITLE
Tell the kernel where the app put its stack

### DIFF
--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -71,6 +71,10 @@ pub unsafe extern "C" fn _start(
 
     asm!("mov sp, $0" : : "r"(effective_stack_top) : "memory" :  "volatile" );
 
+    syscalls::memop(0, effective_stack_top + HEAP_SIZE);
+    syscalls::memop(11, effective_stack_top + HEAP_SIZE);
+    syscalls::memop(10, effective_stack_top);
+
     main(0, ptr::null());
 
     loop {


### PR DESCRIPTION
This doesn't have any correctness implications, but it does help with debugging when the app memory map is printed during debugging.

I copied this from the libtock-c version.