### PR TITLE
Implement creation of ble payload in userland

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ linked_list_allocator = "0.6.2"
 
 [dev-dependencies]
 corepack = { version = "0.3.1", default-features = false, features = ["alloc"] }
-serde_derive = { version = "1.0.66", default-features = false }
-serde = { version = "1.0.66", default-features = false }
+serde_derive = { version = "=1.0.69", default-features = false }
+serde = { version = "=1.0.69", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 # libtock-rs
 Rust userland library for Tock (WIP)
 
+Tested with tock a3b36d5872315ff05ef5ad34ed9453b0789218ce.
+
 ## Getting Started
 
 This project is nascent and still under heavy development, but first steps:

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -9,6 +9,8 @@ extern crate serde_derive;
 extern crate tock;
 
 use alloc::String;
+use tock::ble_composer;
+use tock::ble_composer::BlePayload;
 use tock::led;
 use tock::simple_ble::BleAdvertisingDriver;
 use tock::timer;
@@ -25,14 +27,23 @@ fn main() {
     let led = led::get(0).unwrap();
 
     let name = String::from("Tock!");
-    let mut uuid: [u8; 2] = [0x18, 0x00];
+    let uuid: [u8; 2] = [0x00, 0x18];
 
-    let mut payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
+    let payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
 
     let mut buffer = BleAdvertisingDriver::create_advertising_buffer();
-    let handle =
-        BleAdvertisingDriver::initialize(100, name, &mut uuid, true, &mut payload, &mut buffer)
-            .unwrap();
+    let mut gap_payload = BlePayload::new();
+    gap_payload.add_flag(ble_composer::flags::LE_GENERAL_DISCOVERABLE);
+
+    gap_payload.add(ble_composer::gap_types::UUID, &uuid);
+
+    gap_payload.add(
+        ble_composer::gap_types::COMPLETE_LOCAL_NAME,
+        name.as_bytes(),
+    );
+    gap_payload.add_service_payload([91, 79], &payload);
+
+    let handle = BleAdvertisingDriver::initialize(100, &gap_payload, &mut buffer).unwrap();
 
     loop {
         led.on();

--- a/run_example.sh
+++ b/run_example.sh
@@ -21,9 +21,9 @@ then
     then
         echo "do not delete apps from board."
     else
-        tockloader uninstall --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 || true
+        tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
     fi
 else
-    tockloader uninstall --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 || true
+    tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
 fi
-tockloader install --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 "$tab_file_name"
+tockloader install --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 "$tab_file_name"

--- a/run_hardware_test.sh
+++ b/run_hardware_test.sh
@@ -4,7 +4,7 @@
 
 set -eux
 
-yes 0|tockloader uninstall --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 || true
+yes 0|tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
 
 ./run_example.sh hardware_test_server --dont-clear-apps
 ./run_example.sh hardware_test --dont-clear-apps

--- a/run_ipc_example.sh
+++ b/run_ipc_example.sh
@@ -4,7 +4,7 @@
 
 set -eux
 
-yes 0|tockloader uninstall --jtag --arch cortex-m4 --board nrf52-dk --jtag-device nrf52 --app-address 0x20000 || true
+yes 0|tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
 
 ./run_example.sh ipcclient --dont-clear-apps
 ./run_example.sh ipcserver --dont-clear-apps

--- a/src/ble_composer.rs
+++ b/src/ble_composer.rs
@@ -1,0 +1,64 @@
+use alloc::*;
+
+pub mod gap_types {
+    pub static COMPLETE_LOCAL_NAME: u8 = 0x09;
+    pub static SERVICE_DATA: u8 = 0x16;
+    pub static UUID: u8 = 0x02;
+    pub static FLAGS: u8 = 0x01;
+}
+
+pub mod flags {
+    pub static LE_GENERAL_DISCOVERABLE: u8 = 0x01;
+}
+
+pub struct BlePayload {
+    pub bytes: Vec<u8>,
+}
+
+impl BlePayload {
+    pub fn add(&mut self, kind: u8, content: &[u8]) {
+        self.bytes.push((content.len() + 1) as u8);
+        self.bytes.push(kind);
+        for e in content {
+            self.bytes.push(*e);
+        }
+    }
+
+    pub fn add_flag(&mut self, flag: u8) {
+        self.bytes.push(2);
+        self.bytes.push(gap_types::FLAGS);
+        self.bytes.push(flag);
+    }
+
+    pub fn new() -> Self {
+        BlePayload { bytes: Vec::new() }
+    }
+
+    pub fn add_service_payload(&mut self, uuid: [u8; 2], content: &[u8]) {
+        self.bytes.push((content.len() + 3) as u8);
+        self.bytes.push(gap_types::SERVICE_DATA);
+        self.bytes.push(uuid[0]);
+        self.bytes.push(uuid[1]);
+        for e in content {
+            self.bytes.push(*e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ble_composer::*;
+    #[test]
+    pub fn test_add() {
+        let mut pld = BlePayload::new();
+        pld.add(1, &[2]);
+        assert_eq!(pld.bytes, vec![2, 1, 2])
+    }
+
+    #[test]
+    pub fn test_add_service_payload() {
+        let mut pld = BlePayload::new();
+        pld.add_service_payload([1, 2], &[2]);
+        assert_eq!(pld.bytes, &[4, 0x16, 1, 2, 2])
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 
 mod callback;
 
+pub mod ble_composer;
 pub mod ble_parser;
 pub mod buttons;
 pub mod console;


### PR DESCRIPTION
# Content of the pull request
This pull request implements the generation of ble payload in user land as implemented in tock/tock#855 on kernel side. This closes #50.

# Testing
Unit tests have been written for the payload composer. The two ble apps have been run successfully.

# Known issues
Using serde-derive and corepack in combination with defect messagepack packages leads to memory corruption (reproducable without a ble context) and eventually kernel panics. However, I find it is desireable to have examples of these standard techniques in libtock-rs.