### PR TITLE
Entry point cleanup

### DIFF
--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -5,6 +5,7 @@ use crate::syscalls;
 use core::alloc::Alloc;
 use core::alloc::GlobalAlloc;
 use core::alloc::Layout;
+use core::intrinsics;
 use core::mem;
 use core::ptr;
 use core::ptr::NonNull;
@@ -47,7 +48,34 @@ unsafe impl GlobalAlloc for TockAllocator {
     }
 }
 
-/// Tock programs' entry point
+// Note: At the moment, rust_start is incomplete. The rest of this comment
+// describes how rust_start *should* work. It does not currently perform data
+// relocation (note the TODO in rust_start's source).
+//
+// _start and rust_start are the first two procedures executed when a Tock
+// application starts. _start is invoked directly by the Tock kernel; it
+// performs stack setup then calls rust_start. rust_start performs data
+// relocation and sets up the heap before calling the rustc-generated main.
+// rust_start and _start are tightly coupled: the order of rust_start's
+// parameters is designed to simplify _start's implementation.
+//
+// The memory layout set up by these methods is as follows:
+//
+//     +----------------+ <- app_heap_break
+//     | Heap           |
+//     +----------------| <- heap_bottom
+//     | Data (globals) |
+//     +----------------+ <- stack_top
+//     | Stack          |
+//     | (grows down)   |
+//     +----------------+ <- mem_start
+//
+// app_heap_break and mem_start are given to us by the kernel. The stack size is
+// determined using pointer text_start, and is used with mem_start to compute
+// stack_top.
+
+/// Tock programs' entry point. Called by the kernel at program start. Sets up
+/// the stack then calls rust_start() for the remainder of setup.
 #[doc(hidden)]
 #[no_mangle]
 #[naked]
@@ -56,6 +84,40 @@ pub unsafe extern "C" fn _start(
     text_start: usize,
     mem_start: usize,
     _memory_len: usize,
+    app_heap_break: usize,
+) -> ! {
+    asm!("
+        // Initialize the stack pointer. The stack pointer is computed as
+        // stack_size + mem_start plus padding to align the stack to a multiple
+        // of 8 bytes. The 8 byte alignment is to follow ARM AAPCS:
+        // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka4127.html
+        ldr ip, [r0, #36]  // ip = text_start->stack_size
+        add ip, ip, r1     // ip = text_start->stack_size + mem_start
+        add ip, #7         // ip = text_start->stack_size + mem_start + 7
+        bic r1, ip, #7     // r1 = (text_start->stack_size + mem_start + 7) & ~0x7
+        mov sp, r1         // sp = r1
+
+        // Call rust_start. text_start, stack_top, and app_heap_break are
+        // already in the correct registers.
+        bl rust_start"
+        :                                                              // No output operands
+        : "{r0}"(text_start) "{r1}"(mem_start) "{r3}"(app_heap_break)  // Input operands
+        : "cc" "ip" "lr" "memory" "r0" "r1" "r2" "r3"                  // Clobbers
+        :                                                              // Options
+    );
+    intrinsics::unreachable();
+}
+
+/// Rust setup, called by _start. Uses the extern "C" calling convention so that
+/// the assembly in _start knows how to call it (the Rust ABI is not defined).
+/// Sets up the data segment (including relocations) and the heap, then calls
+/// into the rustc-generated main(). This cannot use mutable global variables or
+/// global references to globals until it is done setting up the data segment.
+#[no_mangle]
+pub unsafe extern "C" fn rust_start(
+    _text_start: usize,
+    stack_top: usize,
+    _skipped: usize,
     _app_heap_break: usize,
 ) -> ! {
     extern "C" {
@@ -63,17 +125,11 @@ pub unsafe extern "C" fn _start(
         fn main(argc: isize, argv: *const *const u8) -> isize;
     }
 
-    let stack_size = *(text_start as *const usize).offset(9);
-    let real_stack_top = mem_start + stack_size;
-    // Set the effective stack top below the real stack stop and use the space in between for the heap
-    let effective_stack_top = real_stack_top - HEAP_SIZE;
-    TockAllocator.init(effective_stack_top, real_stack_top);
+    // TODO: Copy over .data and perform relocations, *then* initialize the heap.
+    TockAllocator.init(stack_top, stack_top + HEAP_SIZE);
 
-    asm!("mov sp, $0" : : "r"(effective_stack_top) : "memory" :  "volatile" );
-
-    syscalls::memop(0, effective_stack_top + HEAP_SIZE);
-    syscalls::memop(11, effective_stack_top + HEAP_SIZE);
-    syscalls::memop(10, effective_stack_top);
+    syscalls::memop(10, stack_top);
+    syscalls::memop(11, stack_top + HEAP_SIZE);
 
     main(0, ptr::null());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
     alloc,
     allocator_api,
     alloc_error_handler,
+    core_intrinsics,
     lang_items,
     naked_functions
 )]


### PR DESCRIPTION
This refactors libtock's entry point to avoid a couple of sources of undefined behavior:

1. The [naked functions RFC](https://github.com/rust-lang/rfcs/blob/master/text/1201-naked-fns.md) mentions that naked functions cannot soundly have anything in them except inline assembly, because the stack is not setup. Further, the existing start point relied a local variable (effective_stack_top) surviving across a stack pointer change, which is not guaranteed (it may have been stored on the stack).
1. The ARM C ABI requires the stack pointer to be aligned it a multiple of 8 bytes; the existing stack pointer calculation does not ensure that.

The new entry point is split into two procedures. _start is now almost purely inline assembly and is kept simple, and the Rust code (which will do more complex setup in the future) has been moved to rust_start. In the future, rust_start will copy .data from flash to RAM and perform relocations (similar to _c_start in libtock-c).

This contribution is dual-licensed under the MIT & Apache 2.0 licenses.

Note: this is a re-do of [pull request 57](https://github.com/tock/libtock-rs/pull/57)