### PR TITLE
Unwind symbols

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod shared_memory;
 pub mod simple_ble;
 pub mod temperature;
 pub mod timer;
+pub mod unwind_symbols;
 
 #[cfg(target_arch = "arm")]
 pub mod entry_point;

--- a/src/unwind_symbols.rs
+++ b/src/unwind_symbols.rs
@@ -1,0 +1,19 @@
+// The stack unwinding ABI in ARM is specified as part of EABI. Although
+// libunwind has not been ported to Tock OS (and likely will not be), LLVM still
+// assumes some of the symbols are present. This causes linking errors
+// (undefined symbol __aeabi_unwind_cpp_pr...). In environments without
+// libunwind, it appears to be common practice to declare the symbols as empty
+// functions; for example, the Linux Kernel does so in arch/arm/kernel/unwind.c.
+// We do so here as well. The addition of these symbols to libtock-rs was
+// discussed at https://groups.google.com/forum/#!topic/tock-dev/eov8fJmskLk.
+#[cfg(target_arch = "arm")]
+#[no_mangle]
+pub extern "C" fn __aeabi_unwind_cpp_pr0() {}
+
+#[cfg(target_arch = "arm")]
+#[no_mangle]
+pub extern "C" fn __aeabi_unwind_cpp_pr1() {}
+
+#[cfg(target_arch = "arm")]
+#[no_mangle]
+pub extern "C" fn __aeabi_unwind_cpp_pr2() {}


### PR DESCRIPTION
These symbols should be part of libunwind, which we do not have in Tock. LLVM relies on their existence and inserts references to them even with `panic = "unwind"`. This leads to linker errors similar to `undefined symbol: __aeabi_unwind_cpp_pr0`. This adds dummy definitions of the symbols to prevent the linker errors.

I did some searching, but could not find any other fix to the problem. This seems to be the accepted fix. This was discussed at https://groups.google.com/forum/#!topic/tock-dev/eov8fJmskLk.