### PR TITLE
Revert "Initialize .data and .bss in libtock-rs."

### DIFF
--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -10,6 +10,8 @@ use core::mem;
 use core::ptr;
 use core::ptr::NonNull;
 
+const HEAP_SIZE: usize = 0x400;
+
 // None-threaded heap wrapper based on `r9` register instead of global variable
 pub(crate) struct TockAllocator;
 
@@ -57,13 +59,12 @@ unsafe impl GlobalAlloc for TockAllocator {
 // rust_start and _start are tightly coupled: the order of rust_start's
 // parameters is designed to simplify _start's implementation.
 //
-// The memory layout is controlled by the linker script and these methods. These
-// are written for the following memory layout:
+// The memory layout set up by these methods is as follows:
 //
 //     +----------------+ <- app_heap_break
 //     | Heap           |
 //     +----------------| <- heap_bottom
-//     | .data and .bss |
+//     | Data (globals) |
 //     +----------------+ <- stack_top
 //     | Stack          |
 //     | (grows down)   |
@@ -71,10 +72,7 @@ unsafe impl GlobalAlloc for TockAllocator {
 //
 // app_heap_break and mem_start are given to us by the kernel. The stack size is
 // determined using pointer text_start, and is used with mem_start to compute
-// stack_top. The placement of .data and .bss are given to us by the linker
-// script; the heap is located between the end of .bss and app_heap_break. This
-// requires that .bss is the last (highest-address) section placed by the linker
-// script.
+// stack_top.
 
 /// Tock programs' entry point. Called by the kernel at program start. Sets up
 /// the stack then calls rust_start() for the remainder of setup.
@@ -110,22 +108,6 @@ pub unsafe extern "C" fn _start(
     intrinsics::unreachable();
 }
 
-/// The header encoded at the beginning of .text by the linker script. It is
-/// accessed by rust_start() using its text_start parameter.
-#[repr(C)]
-struct LayoutHeader {
-    got_sym_start: usize,
-    got_start: usize,
-    got_size: usize,
-    data_sym_start: usize,
-    data_start: usize,
-    data_size: usize,
-    bss_start: usize,
-    bss_size: usize,
-    reldata_start: usize,
-    stack_size: usize,
-}
-
 /// Rust setup, called by _start. Uses the extern "C" calling convention so that
 /// the assembly in _start knows how to call it (the Rust ABI is not defined).
 /// Sets up the data segment (including relocations) and the heap, then calls
@@ -133,42 +115,21 @@ struct LayoutHeader {
 /// global references to globals until it is done setting up the data segment.
 #[no_mangle]
 pub unsafe extern "C" fn rust_start(
-    text_start: usize,
+    _text_start: usize,
     stack_top: usize,
     _skipped: usize,
-    app_heap_break: usize,
+    _app_heap_break: usize,
 ) -> ! {
     extern "C" {
         // This function is created internally by`rustc`. See `src/lang_items.rs` for more details.
         fn main(argc: isize, argv: *const *const u8) -> isize;
     }
 
-    // Copy .data into its final location in RAM (determined by the linker
-    // script -- should be immediately above the stack).
-    let layout_header: &LayoutHeader = core::mem::transmute(text_start);
-    intrinsics::copy_nonoverlapping(
-        (text_start + layout_header.data_sym_start) as *const u8,
-        stack_top as *mut u8,
-        layout_header.data_size,
-    );
+    // TODO: Copy over .data and perform relocations, *then* initialize the heap.
+    TockAllocator.init(stack_top, stack_top + HEAP_SIZE);
 
-    // Zero .bss (specified by the linker script).
-    let bss_end = layout_header.bss_start + layout_header.bss_size; // 1 past the end of .bss
-    for i in layout_header.bss_start..bss_end {
-        core::ptr::write(i as *mut u8, 0);
-    }
-
-    // TODO: Wait for rustc to have working ROPI-RWPI relocation support, then
-    // implement dynamic relocations here. At the moment, rustc does not have
-    // working ROPI-RWPI support, and it is not clear what that support would
-    // look like at the LLVM level. Once we know what the relocation strategy
-    // looks like we can write the dynamic linker.
-
-    // Initialize the heap and tell the kernel where everything is. The heap is
-    // placed between .bss and the end of application memory.
-    TockAllocator.init(bss_end, app_heap_break);
     syscalls::memop(10, stack_top);
-    syscalls::memop(11, bss_end);
+    syscalls::memop(11, stack_top + HEAP_SIZE);
 
     main(0, ptr::null());
 


### PR DESCRIPTION
This commit creates access faults in most of the examples. Thus we have to revert it until we have found the root cause.