### PR TITLE
Create hardware test cases

### DIFF
--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -1,22 +1,128 @@
 #![feature(alloc)]
 #![no_std]
-
+/// Hardware regression tests.
+/// Need P0.03 and P0.04 to be connected (on a nrf52-dk).
 extern crate alloc;
 
 use alloc::string::String;
 use core::fmt::Write;
 use tock::console::Console;
+use tock::gpio::{GpioPinUnitialized, InputMode};
+use tock::syscalls;
 use tock::timer;
 use tock::timer::Duration;
 
+static mut STATIC: usize = 0;
+
+trait MyTrait {
+    fn do_something_with_a_console(&self, console: &mut Console);
+}
+
+impl MyTrait for usize {
+    fn do_something_with_a_console(&self, console: &mut Console) {
+        write!(console, "trait_obj_value_usize = {}\n", &self).unwrap();
+    }
+}
+
+impl MyTrait for String {
+    fn do_something_with_a_console(&self, console: &mut Console) {
+        write!(console, "trait_obj_value_string = {}\n", &self).unwrap();
+    }
+}
+
 fn main() {
     let mut console = Console::new();
-    writeln!(console, "[test-results]").unwrap();
-    let mut string = String::from("heap_test = \"Heap ");
-    string.push_str("works.\"\n");
-    writeln!(console, "{}", string).unwrap();
+    write!(console, "[test-results]\n").unwrap();
+
+    test_heap(&mut console);
+    test_formatting(&mut console);
+    test_static_mut(&mut console);
+
+    test_gpio(&mut console);
+
+    test_trait_objects(&mut console);
+
+    test_callbacks_and_wait_forever(&mut console);
 
     for _ in 0.. {
-        timer::sleep(Duration::from_ms(500))
+        syscalls::yieldk();
     }
+}
+
+fn test_heap(console: &mut Console) {
+    let mut string = String::from("heap_test = \"Heap ");
+    string.push_str("works.\"\n");
+    write!(console, "{}", string).unwrap();
+}
+
+fn test_formatting(console: &mut Console) {
+    write!(console, "formatting =  {}\n", String::from("works")).unwrap();
+}
+
+/// needs P0.03 and P0.04 to be connected
+/// Output order should be:
+/// trait_obj_value_usize = 1
+/// trait_obj_value_string = string
+fn test_trait_objects(console: &mut Console) {
+    let pin_in = GpioPinUnitialized::new(0);
+    let pin_in = pin_in.open_for_read(None, InputMode::PullDown).unwrap();
+
+    let pin_out = GpioPinUnitialized::new(1);
+    let pin_out = pin_out.open_for_write().unwrap();
+    pin_out.set_high();
+
+    let string = String::from("string");
+
+    let x = if pin_in.read() {
+        &1usize as &dyn MyTrait
+    } else {
+        &string as &dyn MyTrait
+    };
+
+    let y = if !pin_in.read() {
+        &1usize as &dyn MyTrait
+    } else {
+        &string as &dyn MyTrait
+    };
+
+    x.do_something_with_a_console(console);
+    y.do_something_with_a_console(console);
+}
+
+fn test_static_mut(console: &mut Console) {
+    increment_static_mut();
+
+    write!(console, "should_be_one = {}\n", unsafe { STATIC }).unwrap();
+}
+
+/// needs P0.03 and P0.04 to be connected
+fn test_gpio(console: &mut Console) {
+    let pin_in = GpioPinUnitialized::new(0);
+    let pin_in = pin_in.open_for_read(None, InputMode::PullDown).unwrap();
+
+    let pin_out = GpioPinUnitialized::new(1);
+    let pin_out = pin_out.open_for_write().unwrap();
+    pin_out.set_high();
+
+    write!(console, "gpio_works = {}\n", pin_in.read()).unwrap();
+}
+
+fn test_callbacks_and_wait_forever(console: &mut Console) {
+    let mut with_callback = timer::with_callback(|_, _| {
+        write!(console, "callbacks_work = true\n").unwrap();
+        write!(console, "all_tests_run = true").unwrap();
+    });
+
+    let mut timer = with_callback.init().unwrap();
+
+    timer.set_alarm(Duration::from_ms(500)).unwrap();
+
+    for _ in 0.. {
+        syscalls::yieldk();
+    }
+}
+
+#[inline(never)]
+fn increment_static_mut() {
+    unsafe { STATIC += 1 };
 }

--- a/run_hardware_test.sh
+++ b/run_hardware_test.sh
@@ -6,5 +6,4 @@ set -eux
 
 yes 0|tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
 
-./run_example.sh hardware_test_server --dont-clear-apps
 ./run_example.sh hardware_test --dont-clear-apps


### PR DESCRIPTION
In this PR I create some more test cases. The tests need a device connected and the pins 0/1 connected. On the NRF52-DK these pins correspond to the pins p0.03 and p0.04 respectively.
The following features of the library are tested:
 - Heap
 - Trait objects
 - GPIO
 - Callbacks
 - shared buffers (indirectly via the console)

This gives a possibility to check whether PR cause regression quickly. More precisely it checks following functions of the library: 
 - command-syscalls
 - allow-syscalls
 - allocation of memory
 - the entry point
 - correct linkage and relocation