### PR TITLE
Change crate name to libtock.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tock"
+name = "libtock"
 version = "0.1.0"
 authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 license = "MIT/Apache-2.0"

--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -1,11 +1,12 @@
 #![no_std]
 
+use libtock::ble_parser;
+use libtock::led;
+use libtock::simple_ble;
+use libtock::simple_ble::BleCallback;
+use libtock::simple_ble::BleDriver;
+use libtock::syscalls;
 use serde::Deserialize;
-use tock::ble_parser;
-use tock::led;
-use tock::simple_ble::BleCallback;
-use tock::simple_ble::BleDriver;
-use tock::syscalls;
 
 #[derive(Deserialize)]
 struct LedCommand {
@@ -22,7 +23,7 @@ fn main() {
 
     let mut callback = BleCallback::new(|_: usize, _: usize| {
         shared_memory.read_bytes(&mut my_buffer);
-        ble_parser::find(&my_buffer, tock::simple_ble::gap_data::SERVICE_DATA as u8)
+        ble_parser::find(&my_buffer, simple_ble::gap_data::SERVICE_DATA as u8)
             .and_then(|service_data| ble_parser::extract_for_service([91, 79], service_data))
             .and_then(|payload| corepack::from_bytes::<LedCommand>(&payload).ok())
             .and_then(|msg| led::get(msg.nr as isize).map(|led| led.set_state(msg.st)));

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use tock::led;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::led;
+use libtock::timer;
+use libtock::timer::Duration;
 
 fn main() {
     let num_leds = led::count();

--- a/examples/button_leds.rs
+++ b/examples/button_leds.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
-use tock::buttons;
-use tock::buttons::ButtonState;
-use tock::led;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::buttons;
+use libtock::buttons::ButtonState;
+use libtock::led;
+use libtock::timer;
+use libtock::timer::Duration;
 
 fn main() {
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -1,11 +1,11 @@
 #![no_std]
 
 use core::fmt::Write;
-use tock::buttons;
-use tock::buttons::ButtonState;
-use tock::console::Console;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::buttons;
+use libtock::buttons::ButtonState;
+use libtock::console::Console;
+use libtock::timer;
+use libtock::timer::Duration;
 
 fn main() {
     let mut console = Console::new();

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -1,11 +1,11 @@
 #![no_std]
 
 use core::fmt::Write;
-use tock::buttons;
-use tock::buttons::ButtonState;
-use tock::console::Console;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::buttons;
+use libtock::buttons::ButtonState;
+use libtock::console::Console;
+use libtock::timer;
+use libtock::timer::Duration;
 
 // FIXME: Hangs up when buttons are pressed rapidly - problem in console?
 fn main() {

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-use tock::gpio::GpioPinUnitialized;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::gpio::GpioPinUnitialized;
+use libtock::timer;
+use libtock::timer::Duration;
 
 // Example works on P0.03
 fn main() {

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
 use core::fmt::Write;
-use tock::console::Console;
-use tock::gpio::{GpioPinUnitialized, InputMode};
-use tock::timer;
-use tock::timer::Duration;
+use libtock::console::Console;
+use libtock::gpio::{GpioPinUnitialized, InputMode};
+use libtock::timer;
+use libtock::timer::Duration;
 
 // example works on p0.03
 fn main() {

--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -6,11 +6,11 @@ extern crate alloc;
 
 use alloc::string::String;
 use core::fmt::Write;
-use tock::console::Console;
-use tock::gpio::{GpioPinUnitialized, InputMode};
-use tock::syscalls;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::console::Console;
+use libtock::gpio::{GpioPinUnitialized, InputMode};
+use libtock::syscalls;
+use libtock::timer;
+use libtock::timer::Duration;
 
 static mut STATIC: usize = 0;
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
 use core::fmt::Write;
-use tock::console::Console;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::console::Console;
+use libtock::timer;
+use libtock::timer::Duration;
 
 fn main() {
     let mut console = Console::new();

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
 use core::fmt::Write;
-use tock::console::Console;
-use tock::sensors::*;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::console::Console;
+use libtock::sensors::*;
+use libtock::timer;
+use libtock::timer::Duration;
 
 fn main() {
     let mut console = Console::new();

--- a/examples/seven_segment.rs
+++ b/examples/seven_segment.rs
@@ -1,9 +1,9 @@
 #![no_std]
 
-use tock::electronics::ShiftRegister;
-use tock::gpio::GpioPinUnitialized;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::electronics::ShiftRegister;
+use libtock::gpio::GpioPinUnitialized;
+use libtock::timer;
+use libtock::timer::Duration;
 
 fn number_to_bits(n: u8) -> [bool; 8] {
     match n {

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -1,12 +1,12 @@
 #![no_std]
 
+use libtock::ble_composer;
+use libtock::ble_composer::BlePayload;
+use libtock::led;
+use libtock::simple_ble::BleAdvertisingDriver;
+use libtock::timer;
+use libtock::timer::Duration;
 use serde::Serialize;
-use tock::ble_composer;
-use tock::ble_composer::BlePayload;
-use tock::led;
-use tock::simple_ble::BleAdvertisingDriver;
-use tock::timer;
-use tock::timer::Duration;
 
 #[derive(Serialize)]
 struct LedCommand {

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -1,8 +1,9 @@
 #![no_std]
 
 use core::fmt::Write;
-use tock::console::Console;
-use tock::temperature;
+use libtock::console::Console;
+use libtock::syscalls;
+use libtock::temperature;
 
 fn main() {
     let mut console = Console::new();
@@ -14,6 +15,6 @@ fn main() {
     let _temperature = with_callback.start_measurement();
 
     loop {
-        tock::syscalls::yieldk();
+        syscalls::yieldk();
     }
 }

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
 use core::fmt::Write;
-use tock::console::Console;
-use tock::syscalls;
-use tock::timer;
-use tock::timer::Duration;
+use libtock::console::Console;
+use libtock::syscalls;
+use libtock::timer;
+use libtock::timer::Duration;
 
 fn main() {
     let mut console = Console::new();


### PR DESCRIPTION
We change the crate name to 'libtock'. From my perspective this makes sense. We have two libraries now:
 - libtock (a C library for the tock kernel)
 - libtock (a library crate)

This closes: https://github.com/tock/libtock-rs/issues/23.