### PR TITLE
ADC Support and new Error Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ to use:
     you will end up with a TAB file in `target/tab` that you can program onto your
     Tock board (e.g. with `tockloader install target/tab/blink.tab`).
 
+    If you have a hail board you can flash your device as follows:
+     - set the environment variable `hail` to `1`
+     - set  `link-arg=-Tnrf52_layout.ld` in `.cargo/config` to `link-arg=-Thail_layout.ld`
+     - run `run_example.sh` as above.
+
 ## Using libtock-rs
 
 The easiest way to start using libtock-rs is adding an example to the examples folder.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ This script does the following steps for you:
  - create a TAB (tock application bundle)
  - if you have a nRF52-DK board connected: flash this TAB to your board (using tockloader)
 
+## Running the Integration Tests
+Having an nRF52-DK board at hand, integration tests can be run using `./run_hardware_tests.sh`.
+The expected output on the UART console will be as follows.
+```
+[test-results]
+heap_test = "Heap works."
+formatting =  works
+should_be_one = 1
+gpio_works = true
+trait_obj_value_usize = 1
+trait_obj_value_string = string
+callbacks_work = true
+all_tests_run = true
+```
+
 ## License
 
 Licensed under either of

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,4 +1,3 @@
-#![feature(alloc)]
 #![no_std]
 
 use core::fmt::Write;

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,0 +1,22 @@
+#![feature(alloc)]
+#![no_std]
+
+use core::fmt::Write;
+use libtock::adc;
+use libtock::console::Console;
+use libtock::timer;
+use libtock::timer::Duration;
+
+fn main() {
+    let mut console = Console::new();
+    let mut with_callback = adc::with_callback(|channel: usize, value: usize| {
+        writeln!(console, "channel: {}, value: {}", channel, value).unwrap();
+    });
+
+    let adc = with_callback.init().unwrap();
+
+    loop {
+        adc.sample(0).unwrap();
+        timer::sleep(Duration::from_ms(2000));
+    }
+}

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -1,4 +1,3 @@
-#![feature(alloc)]
 #![no_std]
 
 use core::fmt::Write;

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -1,0 +1,29 @@
+#![feature(alloc)]
+#![no_std]
+
+use core::fmt::Write;
+use libtock::adc;
+use libtock::adc::AdcBuffer;
+use libtock::console::Console;
+use libtock::syscalls;
+
+/// Reads a 128 byte sample into a buffer and prints the first value to the console.
+fn main() {
+    let mut console = Console::new();
+    let mut adc_buffer = AdcBuffer::new();
+    let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];
+
+    let adc_buffer = libtock::adc::Adc::init_buffer(&mut adc_buffer).unwrap();
+
+    let mut with_callback = adc::with_callback(|_, _| {
+        adc_buffer.read_bytes(&mut temp_buffer);
+        writeln!(console, "First sample in buffer: {}", temp_buffer[0]).unwrap();
+    });
+
+    let adc = with_callback.init().unwrap();
+
+    loop {
+        adc.sample_continuous_buffered(0, 128).unwrap();
+        syscalls::yieldk();
+    }
+}

--- a/hail_layout.ld
+++ b/hail_layout.ld
@@ -1,0 +1,11 @@
+/* Layout for the Hail board, used by the examples in this repository. */
+
+MEMORY {
+  /* The application region is 64 bytes (0x40) */
+  FLASH (rx) : ORIGIN = 0x00030040, LENGTH = 0x0005FFC0
+  SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
+}
+
+MPU_MIN_ALIGN = 8K;
+
+INCLUDE layout.ld

--- a/run_example.sh
+++ b/run_example.sh
@@ -10,6 +10,15 @@ cargo build --release --target=thumbv7em-none-eabi --example "$1"
 elf_file_name="target/tab/$1/cortex-m4.elf"
 tab_file_name="target/tab/$1.tab"
 
+# Default value for nRF52-DK
+tockloader_flags="--jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000"
+
+hail_defined=${hail:-}
+if [ -n "$hail_defined" ]
+then
+    tockloader_flags=""
+fi
+
 mkdir -p "target/tab/$1"
 cp "target/thumbv7em-none-eabi/release/examples/$1" "$elf_file_name"
 
@@ -21,9 +30,9 @@ then
     then
         echo "do not delete apps from board."
     else
-        tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
+        tockloader uninstall $tockloader_flags || true
     fi
 else
-    tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
+    tockloader uninstall $tockloader_flags || true
 fi
-tockloader install --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 "$tab_file_name"
+tockloader install $tockloader_flags "$tab_file_name"

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,0 +1,171 @@
+use crate::callback::{CallbackSubscription, SubscribableCallback};
+use crate::shared_memory::SharedMemory;
+use crate::syscalls;
+
+pub const DRIVER_NUM: usize = 0x0005;
+pub const BUFFER_SIZE: usize = 128;
+
+mod command {
+    pub const COUNT: usize = 0;
+    pub const START: usize = 1;
+    pub const START_REPEAT: usize = 2;
+    pub const START_REPEAT_BUFFER: usize = 3;
+    pub const START_REPEAT_BUFFER_ALT: usize = 4;
+    pub const STOP: usize = 5;
+}
+
+mod subscribe {
+    pub const SUBSCRIBE_CALLBACK: usize = 0;
+}
+
+mod allow {
+    pub const BUFFER: usize = 0;
+    pub const BUFFER_ALT: usize = 1;
+}
+
+pub struct AdcBuffer {
+    // TODO: make this generic if possible with the driver impl
+    buffer: [u8; BUFFER_SIZE],
+}
+
+impl AdcBuffer {
+    pub fn new() -> AdcBuffer {
+        AdcBuffer {
+            buffer: [0; BUFFER_SIZE],
+        }
+    }
+}
+
+pub struct Adc<'a> {
+    count: usize,
+    #[allow(dead_code)]
+    subscription: CallbackSubscription<'a>,
+}
+
+pub fn with_callback<CB>(callback: CB) -> WithCallback<CB> {
+    WithCallback { callback }
+}
+
+pub struct WithCallback<CB> {
+    callback: CB,
+}
+
+impl<CB: FnMut(usize, usize)> SubscribableCallback for WithCallback<CB> {
+    fn call_rust(&mut self, _: usize, channel: usize, value: usize) {
+        (self.callback)(channel, value);
+    }
+}
+
+impl<'a, CB> WithCallback<CB>
+where
+    Self: SubscribableCallback,
+{
+    pub fn init(&mut self) -> Result<Adc, isize> {
+        let return_value = unsafe { syscalls::command(DRIVER_NUM, command::COUNT, 0, 0) };
+        if return_value < 0 {
+            return Err(return_value);
+        }
+
+        syscalls::subscribe(DRIVER_NUM, subscribe::SUBSCRIBE_CALLBACK, self).map(|subscription| {
+            Adc {
+                count: return_value as usize,
+                subscription,
+            }
+        })
+    }
+}
+
+impl<'a> Adc<'a> {
+    pub fn init_buffer(buffer: &'a mut AdcBuffer) -> Result<SharedMemory, isize> {
+        syscalls::allow(DRIVER_NUM, allow::BUFFER, &mut buffer.buffer)
+    }
+
+    pub fn init_alt_buffer(alt_buffer: &'a mut AdcBuffer) -> Result<SharedMemory, isize> {
+        syscalls::allow(DRIVER_NUM, allow::BUFFER_ALT, &mut alt_buffer.buffer)
+    }
+
+    /// Return the number of available channels
+    pub fn count(&self) -> usize {
+        self.count
+    }
+
+    /// Start a single sample of channel
+    pub fn sample(&self, channel: usize) -> Result<(), isize> {
+        unsafe {
+            let code = syscalls::command(DRIVER_NUM, command::START, channel, 0);
+            if code < 0 {
+                Err(code)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Start continuous sampling of channel
+    pub fn sample_continuous(&self, channel: usize) -> Result<(), isize> {
+        unsafe {
+            let code = syscalls::command(DRIVER_NUM, command::START_REPEAT, channel, 0);
+            if code < 0 {
+                Err(code)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Start continuous sampling to first buffer
+    pub fn sample_continuous_buffered(
+        &self,
+        channel: usize,
+        frequency: usize,
+    ) -> Result<(), isize> {
+        unsafe {
+            let code =
+                syscalls::command(DRIVER_NUM, command::START_REPEAT_BUFFER, channel, frequency);
+            if code < 0 {
+                Err(code)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Start continuous sampling to alternating buffer
+    pub fn sample_continuous_buffered_alt(
+        &self,
+        channel: usize,
+        frequency: usize,
+    ) -> Result<(), isize> {
+        unsafe {
+            let code = syscalls::command(
+                DRIVER_NUM,
+                command::START_REPEAT_BUFFER_ALT,
+                channel,
+                frequency,
+            );
+            if code < 0 {
+                Err(code)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    /// Stop any started sampling operation
+    pub fn stop(&self) -> Result<(), isize> {
+        unsafe {
+            let code = syscalls::command(DRIVER_NUM, command::STOP, 0, 0);
+            if code < 0 {
+                Err(code)
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+impl<'a> Drop for Adc<'a> {
+    fn drop(&mut self) {
+        self.stop().unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate alloc;
 
 mod callback;
 
+pub mod adc;
 pub mod ble_composer;
 pub mod ble_parser;
 pub mod buttons;
@@ -31,10 +32,13 @@ pub mod unwind_symbols;
 
 #[cfg(target_arch = "arm")]
 pub mod entry_point;
+
 #[cfg(target_arch = "arm")]
 mod lang_items;
+
 #[cfg(target_arch = "arm")]
 pub mod syscalls;
+
 #[cfg(not(target_arch = "arm"))]
 #[path = "syscalls_mock.rs"]
 mod syscalls;

--- a/src/result.rs
+++ b/src/result.rs
@@ -21,6 +21,8 @@ impl<T, E> TockResultExt<T, E> for TockResult<T, E> {
 }
 
 pub const SUCCESS: isize = 0;
+pub const FAIL: isize = -1;
+pub const EBUSY: isize = -2;
 pub const EALREADY: isize = -3;
 pub const EINVAL: isize = -6;
 pub const ESIZE: isize = -7;

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -63,9 +63,9 @@ macro_rules! single_value_sensor {
     };
 }
 
-single_value_sensor!(AmbientLightSensor, AmbientLight, 6);
-single_value_sensor!(TemperatureSensor, Temperature, 10);
-single_value_sensor!(HumiditySensor, Humidity, 35);
+single_value_sensor!(AmbientLightSensor, AmbientLight, 0x60002);
+single_value_sensor!(TemperatureSensor, Temperature, 0x60000);
+single_value_sensor!(HumiditySensor, Humidity, 0x60001);
 
 impl fmt::Display for AmbientLight {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {

--- a/src/sensors/ninedof.rs
+++ b/src/sensors/ninedof.rs
@@ -71,5 +71,5 @@ pub unsafe fn start_accel_reading() {
 }
 
 pub unsafe fn start_magnetometer_reading() {
-    syscalls::command(DRIVER_NUM, 1, 0, 0);
+    syscalls::command(DRIVER_NUM, 100, 0, 0);
 }


### PR DESCRIPTION
# Summary
This PR, essentially developed by @flxo, adds ADC support for libtock-rs. Moreover, it proposes new error types for the syscall interface and the particular drivers. Linked by implementing the `From` trait. If accepted we would make this the new standard for all drivers and migrate the remaining drivers in a separate PR.
We could make the examples run on the Hail board and this enables us to fix the sensors drivers, thus beeing able to close https://github.com/tock/libtock-rs/issues/45.

# Open points
## New error types
We would be interested in comments concerning the new error types.

## Hail support
The hail support is rudimentary. Switching boards is not ergonomic at the moment and it would be nice if more boards could be supported more easily in the future.

## Unexpected behavior of the sample-continuously syscall
The sample-continuously syscall only samples once. It is not clear whether this is intentional or a problem in the driver.
