### PR TITLE
Do not allocate a new String when printing to the console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2018-04-12
+  - nightly-2018-11-30
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
   - rustup component add rustfmt-preview
 
 script:
-  - rustfmt --check src/lib.rs
-  - rustfmt --check examples/*.rs
+  - cargo fmt --all -- --check
   - cargo test --lib
   - ./build_examples.sh

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
-reorder_imports = true
-reorder_modules = true
 use_field_init_shorthand = true
 use_try_shorthand = true
+edition = "2018"

--- a/src/ble_composer.rs
+++ b/src/ble_composer.rs
@@ -49,6 +49,8 @@ impl BlePayload {
 mod test {
     use super::*;
 
+    use alloc::vec;
+
     #[test]
     pub fn test_add() {
         let mut pld = BlePayload::new();

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -2,6 +2,11 @@
 
 use crate::console::Console;
 
+pub fn println() {
+    let buffer = [b'\n'];
+    Console::new().write(&buffer);
+}
+
 pub fn print_as_hex(value: usize) {
     let mut buffer = [b'\n'; 11];
     write_as_hex(&mut buffer, value);
@@ -18,13 +23,29 @@ pub fn print_stack_pointer() {
     Console::new().write(buffer);
 }
 
-#[inline(always)] // Initial stack size is too small (64 bytes currently)
+#[inline(always)] // Initial stack size is too small (128 bytes currently)
 pub fn dump_address(address: *const usize) {
-    let mut buffer = [b'\n'; 23];
+    let mut buffer = [b' '; 28];
     write_as_hex(&mut buffer[0..10], address as usize);
-    buffer[10..12].clone_from_slice(b": ");
+    buffer[10] = b':';
     write_as_hex(&mut buffer[12..22], unsafe { *address });
+    for index in 0..4 {
+        let byte = unsafe { *(address as *const u8).offset(index) };
+        let byte_is_printable_char = byte >= 0x20 && byte < 0x80;
+        if byte_is_printable_char {
+            buffer[23 + index as usize] = byte;
+        }
+    }
+    buffer[27] = b'\n';
     Console::new().write(&buffer);
+}
+
+pub fn dump_memory(start_address: *const usize, count: isize) {
+    let range = if count < 0 { count..0 } else { 0..count };
+
+    for offset in range {
+        dump_address(unsafe { start_address.offset(offset) });
+    }
 }
 
 fn write_as_hex(buffer: &mut [u8], value: usize) {

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,7 +5,7 @@ use crate::console::Console;
 pub fn print_as_hex(value: usize) {
     let mut buffer = [b'\n'; 11];
     write_as_hex(&mut buffer, value);
-    Console::new().write_bytes(&buffer);
+    Console::new().write(buffer);
 }
 
 pub fn print_stack_pointer() {
@@ -15,7 +15,7 @@ pub fn print_stack_pointer() {
     let mut buffer = [b'\n'; 15];
     buffer[0..4].clone_from_slice(b"SP: ");
     write_as_hex(&mut buffer[4..15], stack_pointer);
-    Console::new().write_bytes(&buffer);
+    Console::new().write(buffer);
 }
 
 #[inline(always)] // Initial stack size is too small (64 bytes currently)
@@ -24,7 +24,7 @@ pub fn dump_address(address: *const usize) {
     write_as_hex(&mut buffer[0..10], address as usize);
     buffer[10..12].clone_from_slice(b": ");
     write_as_hex(&mut buffer[12..22], unsafe { *address });
-    Console::new().write_bytes(&buffer);
+    Console::new().write(&buffer);
 }
 
 fn write_as_hex(buffer: &mut [u8], value: usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,10 +9,6 @@
 )]
 #![no_std]
 
-#[cfg(test)]
-#[macro_use]
-extern crate alloc;
-#[cfg(not(test))]
 extern crate alloc;
 
 mod callback;


### PR DESCRIPTION
This PR removes the need for heap allocations when printing text to the console. Instead, a stack-based byte buffer is used.

Advantages:
- Stack allocations are cheap and do not lead to memory fragmentation.
- An optionally heapless version of `libtock` could be built in the future.

The PR also contains some minor improvement commits from my stash.