### PR TITLE
Remove unnecessary usage of heap in BLE implememtation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ This script does the following steps for you:
 
 ## Running the Integration Tests
 Having an nRF52-DK board at hand, integration tests can be run using `./run_hardware_tests.sh`.
+The pins P0.03 and P0.04 need to be connected (on a nRF52-DK).
 The expected output on the UART console will be as follows.
 ```
 [test-results]

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -15,7 +15,7 @@ fn main() {
     let adc_buffer = libtock::adc::Adc::init_buffer(&mut adc_buffer).unwrap();
 
     let mut with_callback = adc::with_callback(|_, _| {
-        adc_buffer.read_bytes(&mut temp_buffer);
+        adc_buffer.read_bytes(&mut temp_buffer[..]);
         writeln!(console, "First sample in buffer: {}", temp_buffer[0]).unwrap();
     });
 

--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -22,7 +22,7 @@ fn main() {
     let shared_memory = BleDriver::share_memory(&mut shared_buffer).unwrap();
 
     let mut callback = BleCallback::new(|_: usize, _: usize| {
-        shared_memory.read_bytes(&mut my_buffer);
+        shared_memory.read_bytes(&mut my_buffer[..]);
         ble_parser::find(&my_buffer, simple_ble::gap_data::SERVICE_DATA as u8)
             .and_then(|service_data| ble_parser::extract_for_service([91, 79], service_data))
             .and_then(|payload| corepack::from_bytes::<LedCommand>(&payload).ok())

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -24,15 +24,21 @@ fn main() {
 
     let mut buffer = BleAdvertisingDriver::create_advertising_buffer();
     let mut gap_payload = BlePayload::new();
-    gap_payload.add_flag(ble_composer::flags::LE_GENERAL_DISCOVERABLE);
+    gap_payload
+        .add_flag(ble_composer::flags::LE_GENERAL_DISCOVERABLE)
+        .unwrap();
 
-    gap_payload.add(ble_composer::gap_types::UUID, &uuid);
+    gap_payload
+        .add(ble_composer::gap_types::UUID, &uuid)
+        .unwrap();
 
-    gap_payload.add(
-        ble_composer::gap_types::COMPLETE_LOCAL_NAME,
-        "Tock!".as_bytes(),
-    );
-    gap_payload.add_service_payload([91, 79], &payload);
+    gap_payload
+        .add(
+            ble_composer::gap_types::COMPLETE_LOCAL_NAME,
+            "Tock!".as_bytes(),
+        )
+        .unwrap();
+    gap_payload.add_service_payload([91, 79], &payload).unwrap();
 
     let handle = BleAdvertisingDriver::initialize(100, &gap_payload, &mut buffer).unwrap();
 

--- a/src/ble_parser.rs
+++ b/src/ble_parser.rs
@@ -45,7 +45,7 @@ mod test {
     use crate::simple_ble::BUFFER_SIZE_SCAN;
 
     #[test]
-    pub fn extracts_data_for_ids_correctly() {
+    fn extracts_data_for_ids_correctly() {
         let mut buf = [0; BUFFER_SIZE_SCAN];
         {
             let slice = &mut buf[8..23];
@@ -62,7 +62,7 @@ mod test {
     }
 
     #[test]
-    pub fn doesnt_panic_for_defect_packets() {
+    fn doesnt_panic_for_defect_packets() {
         let mut buf = [0; BUFFER_SIZE_SCAN];
         {
             let slice = &mut buf[8..18];
@@ -72,7 +72,7 @@ mod test {
     }
 
     #[test]
-    pub fn ignores_illegal_lengths_in_packets() {
+    fn ignores_illegal_lengths_in_packets() {
         let mut buf = [0; 11];
         {
             let slice = &mut buf[8..10];

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -20,12 +20,12 @@ impl<'a> SharedMemory<'a> {
         }
     }
 
-    pub fn read_bytes(&self, destination: &mut [u8]) {
-        safe_copy(self.buffer_to_share, destination);
+    pub fn read_bytes<T: AsMut<[u8]>>(&self, mut destination: T) {
+        safe_copy(self.buffer_to_share, destination.as_mut());
     }
 
-    pub fn write_bytes(&mut self, source: &[u8]) {
-        safe_copy(source, self.buffer_to_share);
+    pub fn write_bytes<T: AsRef<[u8]>>(&mut self, source: T) {
+        safe_copy(source.as_ref(), self.buffer_to_share);
     }
 }
 

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -45,7 +45,7 @@ impl BleAdvertisingDriver {
             ble_commands::ALLOW_ADVERTISMENT_BUFFER,
             advertising_buffer,
         )?;
-        shared_memory.write_bytes(&service_payload.bytes);
+        shared_memory.write_bytes(service_payload);
         Self::start_advertising(gap_flags::BLE_DISCOVERABLE, interval)?;
         Ok(shared_memory)
     }


### PR DESCRIPTION
In this PR we remove unnecessary usage of variable length vectors. As the BLE payload has a fixed length (39 bytes) we can construct our BLE payload without using the heap.