### PR TITLE
Refactor `layout.ld` and `entry_point.rs`

### DIFF
--- a/hail_layout.ld
+++ b/hail_layout.ld
@@ -6,6 +6,12 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
 }
 
+/*
+ * Any change to STACK_SIZE should be accompanied by a corresponding change to
+ * `elf2tab`'s `--stack` option
+ */
+STACK_SIZE = 2048;
+
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout.ld

--- a/layout.ld
+++ b/layout.ld
@@ -14,11 +14,10 @@
  *         FLASH (rx) : ORIGIN = 0x10030, LENGTH = 0x0FFD0
  *         SRAM (RWX) : ORIGIN = 0x20000, LENGTH = 0x10000
  *     }
+ *     STACK_SIZE = 2048;
  *     MPU_MIN_ALIGN = 8K;
  *     INCLUDE ../libtock-rs/layout.ld
  */
-
-STACK_SIZE = 2048;
 
 ENTRY(_start)
 
@@ -81,21 +80,28 @@ SECTIONS {
         *(.text*)
         *(.rodata*)
         KEEP (*(.syscalls))
-        _etext = .;
         *(.ARM.extab*)
         . = ALIGN(4); /* Make sure we're word-aligned here */
+        _etext = .;
     } > FLASH =0xFF
+
+    /* Application stack */
+    .stack :
+    {
+        . = . + STACK_SIZE;
+
+	_stack_top_unaligned = .;
+        . = ALIGN(8);
+	_stack_top_aligned = .;
+    } > SRAM
 
     /* Data section, static initialized variables
      *  Note: This is placed in Flash after the text section, but needs to be
      *  moved to SRAM at runtime
      */
-    .data :
+    .data : AT (_etext)
     {
-        /* Account for MPU alignment and the stack */
-        . = ALIGN(MPU_MIN_ALIGN);
-        . = . + STACK_SIZE;
-        . = ALIGN(8); /* The stack is aligned to a multiple of 8 bytes. */
+        . = ALIGN(4); /* Make sure we're word-aligned here */
         _data = .;
         KEEP(*(.data*))
         . = ALIGN(4); /* Make sure we're word-aligned at the end of flash */
@@ -147,3 +153,6 @@ SECTIONS {
     } > FLASH
     PROVIDE_HIDDEN (__exidx_end = .);
 }
+
+ASSERT((_stack_top_aligned - _stack_top_unaligned) == 0, "
+STACK_SIZE must be 8 byte multiple")

--- a/nrf52_layout.ld
+++ b/nrf52_layout.ld
@@ -6,6 +6,12 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20002000, LENGTH = 62K
 }
 
+/*
+ * Any change to STACK_SIZE should be accompanied by a corresponding change to
+ * `elf2tab`'s `--stack` option
+ */
+STACK_SIZE = 2048;
+
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout.ld

--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -7,27 +7,54 @@ use core::ptr;
 // application starts. _start is invoked directly by the Tock kernel; it
 // performs stack setup then calls rust_start. rust_start performs data
 // relocation and sets up the heap before calling the rustc-generated main.
-// rust_start and _start are tightly coupled: the order of rust_start's
-// parameters is designed to simplify _start's implementation.
+// rust_start and _start are tightly coupled.
 //
-// The memory layout is controlled by the linker script and these methods. These
-// are written for the following memory layout:
+// The memory layout is controlled by the linker script.
 //
-//     +----------------+ <- app_heap_break
-//     | Heap           |
-//     +----------------| <- heap_bottom
-//     | .data and .bss |
-//     +----------------+ <- stack_top
-//     | Stack          |
-//     | (grows down)   |
-//     +----------------+ <- mem_start
+// When the kernel gives control to us, we get r0-r3 values that is as follows.
+//
+//     +--------------+ <- (r2) mem.len()
+//     | Grant        |
+//     +--------------+
+//     | Unused       |
+//  S  +--------------+ <- (r3) app_heap_break
+//  R  | Heap         |         (hardcoded to mem_start + 3072 in
+//  A  +--------------|          Processs::create which could be lesser than
+//  M  | .bss         |          mem_start + stack + .data + .bss)
+//     +--------------|
+//     | .data        |
+//     +--------------+
+//     | Stack        |
+//     +--------------+ <- (r1) mem_start
+//
+//     +--------------+
+//     | .text        |
+//  F  +--------------+
+//  L  | .crt0_header |
+//  A  +--------------+ <- (r0) app_start
+//  S  | Protected    |
+//  H  | Region       |
+//     +--------------+
+//
+// We want to organize the memory as follows.
+//
+//     +--------------+ <- app_heap_break
+//     | Heap         |
+//     +--------------| <- heap_start
+//     | .bss         |
+//     +--------------|
+//     | .data        |
+//     +--------------+ <- stack_start (stacktop)
+//     | Stack        |
+//     | (grows down) |
+//     +--------------+ <- mem_start
 //
 // app_heap_break and mem_start are given to us by the kernel. The stack size is
-// determined using pointer text_start, and is used with mem_start to compute
-// stack_top. The placement of .data and .bss are given to us by the linker
-// script; the heap is located between the end of .bss and app_heap_break. This
-// requires that .bss is the last (highest-address) section placed by the linker
-// script.
+// determined using pointer app_start, and is used with mem_start to compute
+// stack_start (stacktop). The placement of .data and .bss are given to us by
+// the linker script; the heap is located between the end of .bss and
+// app_heap_break. This requires that .bss is the last (highest-address) section
+// placed by the linker script.
 
 /// Tock programs' entry point. Called by the kernel at program start. Sets up
 /// the stack then calls rust_start() for the remainder of setup.
@@ -36,7 +63,7 @@ use core::ptr;
 #[naked]
 #[link_section = ".start"]
 pub unsafe extern "C" fn _start(
-    text_start: usize,
+    app_start: usize,
     mem_start: usize,
     _memory_len: usize,
     app_heap_break: usize,
@@ -61,29 +88,84 @@ pub unsafe extern "C" fn _start(
         b .Lyield_loop
 
         .Lstack_init:
-        // Initialize the stack pointer. The stack pointer is computed as
+        // Compute the stacktop (stack_start). The stacktop is computed as
         // stack_size + mem_start plus padding to align the stack to a multiple
         // of 8 bytes. The 8 byte alignment is to follow ARM AAPCS:
         // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka4127.html
-        ldr ip, [r0, #36]  // ip = text_start->stack_size
-        add ip, ip, r1     // ip = text_start->stack_size + mem_start
-        add ip, #7         // ip = text_start->stack_size + mem_start + 7
-        bic r1, ip, #7     // r1 = (text_start->stack_size + mem_start + 7) & ~0x7
-        mov sp, r1         // sp = r1
+        ldr r4, [r0, #36]  // r4 = app_start->stack_size
+        add r4, r4, r1     // r4 = app_start->stack_size + mem_start
+        add r4, #7         // r4 = app_start->stack_size + mem_start + 7
+        bic r4, r4, #7     // r4 = (app_start->stack_size + mem_start + 7) & ~0x7
+        mov sp, r4         // sp = r4
 
-        // Call rust_start. text_start, stack_top, and app_heap_break are
-        // already in the correct registers.
+        // We need to pass app_start, stacktop and app_heap_break to rust_start.
+        // Temporarily store them in r6, r7 and r8
+        mov r6, r0
+        mov r7, sp
+
+        // Debug support, tell the kernel the stack location
+        //
+        // memop(10, stacktop)
+        // r7 contains stacktop
+        mov r0, #10
+        mov r1, r7
+        svc 4
+
+        // Debug support, tell the kernel the heap_start location
+        mov r0, r6
+        ldr r4, [r0, #24] // r4 = app_start->bss_start
+        ldr r5, [r0, #28] // r5 = app_start->bss_size
+        add r4, r4, r5    // r4 = bss_start + bss_size
+        //
+        // memop(11, r4)
+        mov r0, #11
+        mov r1, r4
+        svc 4
+
+        // Store heap_start (and soon to be app_heap_break) in r8
+        mov r8, r4
+
+        // There is a possibility that stack + .data + .bss is greater than
+        // 3072. Therefore setup the initial app_heap_break to heap_start (that
+        // is zero initial heap) and let rust_start determine where the actual
+        // app_heap_break should go.
+        //
+        // Also, because app_heap_break is where the unprivileged MPU region
+        // ends, in case mem_start + stack + .data + .bss is greater than
+        // initial app_heap_break (mem_start + 3072), we will get a memory fault
+        // in rust_start when initializing .data and .bss. Setting
+        // app_heap_break to heap_start avoids that.
+
+        // memop(0, r8)
+        mov r0, #0
+        mov r1, r8
+        svc 4
+
+        // NOTE: If there is a hard-fault before this point, then
+        //       process_detail_fmt in kernel/src/process.rs panics which
+        //       will result in us losing the PC of the instruction
+        //       generating the hard-fault. Therefore any code before
+        //       this point is critical code
+
+        // Setup parameters needed by rust_start
+        // r6 (app_start), r7 (stacktop), r8 (app_heap_break)
+        mov r0, r6
+        mov r1, r7
+        mov r2, r8
+
+        // Call rust_start
         bl rust_start"
         :                                                              // No output operands
-        : "{r0}"(text_start) "{r1}"(mem_start) "{r3}"(app_heap_break)  // Input operands
-        : "cc" "ip" "lr" "memory" "r0" "r1" "r2" "r3"                  // Clobbers
-        :                                                              // Options
+        : "{r0}"(app_start), "{r1}"(mem_start), "{r3}"(app_heap_break) // Input operands
+        : "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r12",
+          "cc", "memory"                                               // Clobbers
+        : "volatile"                                                   // Options
     );
     intrinsics::unreachable();
 }
 
 /// The header encoded at the beginning of .text by the linker script. It is
-/// accessed by rust_start() using its text_start parameter.
+/// accessed by rust_start() using its app_start parameter.
 #[repr(C)]
 struct LayoutHeader {
     got_sym_start: usize,
@@ -104,23 +186,22 @@ struct LayoutHeader {
 /// into the rustc-generated main(). This cannot use mutable global variables or
 /// global references to globals until it is done setting up the data segment.
 #[no_mangle]
-pub unsafe extern "C" fn rust_start(
-    text_start: usize,
-    stack_top: usize,
-    _skipped: usize,
-    app_heap_break: usize,
-) -> ! {
+pub unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, app_heap_break: usize) -> ! {
     extern "C" {
-        // This function is created internally by`rustc`. See `src/lang_items.rs` for more details.
+        // This function is created internally by `rustc`. See
+        // `src/lang_items.rs` for more details.
         fn main(argc: isize, argv: *const *const u8) -> isize;
     }
 
     // Copy .data into its final location in RAM (determined by the linker
     // script -- should be immediately above the stack).
-    let layout_header: &LayoutHeader = core::mem::transmute(text_start);
+    let layout_header: &LayoutHeader = core::mem::transmute(app_start);
+
+    let data_flash_start_addr = app_start + layout_header.data_sym_start;
+
     intrinsics::copy_nonoverlapping(
-        (text_start + layout_header.data_sym_start) as *const u8,
-        stack_top as *mut u8,
+        data_flash_start_addr as *const u8,
+        stacktop as *mut u8,
         layout_header.data_size,
     );
 
@@ -136,11 +217,23 @@ pub unsafe extern "C" fn rust_start(
     // look like at the LLVM level. Once we know what the relocation strategy
     // looks like we can write the dynamic linker.
 
-    // Initialize the heap and tell the kernel where everything is. The heap is
-    // placed between .bss and the end of application memory.
-    ALLOCATOR.lock().init(bss_end, app_heap_break);
-    syscalls::memop(10, stack_top);
-    syscalls::memop(11, bss_end);
+    // Initialize the heap. Unlike libtock-c's newlib allocator, which can use
+    // `sbrk` system call to dynamically request heap memory from the kernel, we
+    // need to tell `linked_list_allocator` where the heap starts and ends.
+    //
+    // Heap size is set using `elf2tab` with `--heap-size` option, which is
+    // currently at 1024. If you change the `elf2tab` heap size, make sure to
+    // make the corresponding change here.
+    const HEAP_SIZE: usize = 1024;
+
+    // we could have also bss_end for app_heap_start
+    let app_heap_start = app_heap_break;
+    let app_heap_end = app_heap_break + HEAP_SIZE;
+
+    // tell the kernel the new app heap break
+    syscalls::memop(0, app_heap_end);
+
+    ALLOCATOR.lock().init(app_heap_start, HEAP_SIZE);
 
     main(0, ptr::null());
 


### PR DESCRIPTION
#### `layout.ld` changes

- Remove `STACK_SIZE` from `.data` section (as its generating improper relocations) and introduce a seperate `.stack` section.

- Tell the linker that in `FLASH` region, `.data` section is starting at `_etext`.

- In `.crt0_header` section, indicate the correct address for data symbols in flash.

- Document dependency of `STACK_SIZE` with `elf2tab`'s `--stack` option

#### `entry_point.rs` changes

- Added documentation and renamed variables to be consistent with `libtock-c` and kernel code.

- Moved debug support and initial `app_heap_break` setup to `_start`.

- Fixed `.data` relocation and corrected the parameters to `ALLOCATOR.lock().init(...)`

- Fixed issue #82 
