### PR TITLE
Replace TockValue's auto-derived Debug implementation with a hand-written implementation optimized for size.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ linked_list_allocator = "0.6.3"
 
 [dev-dependencies]
 corepack = { version = "0.4.0", default-features = false, features = ["alloc"] }
-serde = { version = "1.0.84", default-features = false, features = ["derive"] }
+# We pin the serde version because newer serde versions may not be compatible
+# with the nightly toolchain used by libtock-rs.
+serde = { version = "=1.0.84", default-features = false, features = ["derive"] }
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
For Google's h1b_tests application, this saves 9440 bytes in .text. The caveat is that invoking Debug on a TockValue will not format the value contained in the TockValue::Expected().

This contains the commit from #86 so that Travis passes, and should be merged no sooner than #86 .