### PR TITLE
Pin serde to a specific version, to keep compatibility with libtock-rs' toolchain.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ linked_list_allocator = "0.6.3"
 
 [dev-dependencies]
 corepack = { version = "0.4.0", default-features = false, features = ["alloc"] }
-serde = { version = "1.0.84", default-features = false, features = ["derive"] }
+# We pin the serde version because newer serde versions may not be compatible
+# with the nightly toolchain used by libtock-rs.
+serde = { version = "=1.0.84", default-features = false, features = ["derive"] }
 
 [profile.dev]
 panic = "abort"


### PR DESCRIPTION
The latest version of serde requires a newer toolchain. This change allows the examples to keep building, un-breaking the Travis build.