### PR TITLE
Add OSX target for Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rust:
 
 os:
   - linux
+  - osx
 
 cache: rust
 


### PR DESCRIPTION
This can generally help detect build failures such as https://github.com/tock/tock/pull/1393#issuecomment-539723255.