### PR TITLE
Add a memop module defining safe abstractions over syscall::memop.

### DIFF
--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -1,3 +1,4 @@
+use crate::memop;
 use crate::syscalls;
 use crate::ALLOCATOR;
 use core::intrinsics;
@@ -348,8 +349,8 @@ pub unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, app_heap_
     let app_heap_start = app_heap_break;
     let app_heap_end = app_heap_break + HEAP_SIZE;
 
-    // tell the kernel the new app heap break
-    syscalls::memop(0, app_heap_end);
+    // Tell the kernel the new app heap break.
+    memop::set_brk(app_heap_end as *const u8);
 
     ALLOCATOR.lock().init(app_heap_start, HEAP_SIZE);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,11 @@
-#![feature(asm, alloc_error_handler, core_intrinsics, lang_items, naked_functions)]
+#![feature(
+    asm,
+    alloc_error_handler,
+    core_intrinsics,
+    lang_items,
+    naked_functions,
+    ptr_offset_from
+)]
 #![no_std]
 
 extern crate alloc;
@@ -14,6 +21,7 @@ pub mod debug;
 pub mod electronics;
 pub mod gpio;
 pub mod led;
+pub mod memop;
 pub mod result;
 pub mod sensors;
 pub mod shared_memory;

--- a/src/memop.rs
+++ b/src/memop.rs
@@ -1,0 +1,90 @@
+use crate::syscalls;
+use core::slice;
+
+// Setting the break is marked as unsafe as it should only be called by the entry point to setup
+// the allocator. Updating the break afterwards can lead to allocated memory becoming unaccessible.
+//
+// Alternate allocator implementations may still find this useful in the future.
+pub unsafe fn set_brk(ptr: *const u8) -> bool {
+    syscalls::memop(0, ptr as usize) == 0
+}
+
+pub unsafe fn increment_brk(increment: usize) -> Option<*const u8> {
+    let result = syscalls::memop(1, increment);
+    if result >= 0 {
+        Some(result as *const u8)
+    } else {
+        None
+    }
+}
+
+pub fn get_brk() -> *const u8 {
+    unsafe { syscalls::memop(1, 0) as *const u8 }
+}
+
+pub fn get_mem_start() -> *const u8 {
+    unsafe { syscalls::memop(2, 0) as *const u8 }
+}
+
+pub fn get_mem_end() -> *const u8 {
+    unsafe { syscalls::memop(3, 0) as *const u8 }
+}
+
+pub fn get_flash_start() -> *const u8 {
+    unsafe { syscalls::memop(4, 0) as *const u8 }
+}
+
+pub fn get_flash_end() -> *const u8 {
+    unsafe { syscalls::memop(5, 0) as *const u8 }
+}
+
+pub fn get_grant_start() -> *const u8 {
+    unsafe { syscalls::memop(6, 0) as *const u8 }
+}
+
+pub fn get_flash_regions_count() -> usize {
+    unsafe { syscalls::memop(7, 0) as usize }
+}
+
+pub fn get_flash_region_start(i: usize) -> Option<*const u8> {
+    if i < get_flash_regions_count() {
+        Some(unsafe { syscalls::memop(8, i) as *const u8 })
+    } else {
+        None
+    }
+}
+
+pub fn get_flash_region_end(i: usize) -> Option<*const u8> {
+    if i < get_flash_regions_count() {
+        Some(unsafe { syscalls::memop(9, i) as *const u8 })
+    } else {
+        None
+    }
+}
+
+// It is safe to return a 'static immutable slice, as the Tock kernel doesn't change the layout of
+// flash regions during the application's lifetime.
+pub fn get_flash_region(i: usize) -> Option<&'static [u8]> {
+    if i < get_flash_regions_count() {
+        let start = unsafe { syscalls::memop(8, i) as *const u8 };
+        let end = unsafe { syscalls::memop(9, i) as *const u8 };
+        // This assumes that the kernel sends consistent results, i.e. start <= end.
+        let len = unsafe { end.offset_from(start) } as usize;
+        Some(unsafe { slice::from_raw_parts(start, len) })
+    } else {
+        None
+    }
+}
+
+// Setting the stack_top and heap_start addresses are marked as unsafe as they should only be called
+// by the entry point to setup the allocator. Updating these values afterwards can lead to incorrect
+// debug output from the kernel.
+//
+// Alternate allocator implementations may still find this useful in the future.
+pub unsafe fn set_stack_top(ptr: *const u8) {
+    let _ = syscalls::memop(10, ptr as usize);
+}
+
+pub unsafe fn set_heap_start(ptr: *const u8) {
+    let _ = syscalls::memop(11, ptr as usize);
+}

--- a/src/memop.rs
+++ b/src/memop.rs
@@ -1,3 +1,5 @@
+// Last updated for Tock 1.4.
+// See https://github.com/tock/tock/blob/master/doc/syscalls/memop.md
 use crate::syscalls;
 use core::slice;
 

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -35,6 +35,10 @@ pub unsafe fn allow_ptr(_: usize, _: usize, _: *mut u8, _: usize) -> isize {
     unimplemented()
 }
 
+pub unsafe fn memop(_: u32, _: usize) -> isize {
+    unimplemented()
+}
+
 fn unimplemented() -> ! {
     unimplemented!("Unimplemented for tests");
 }


### PR DESCRIPTION
This change adds a `memop` module with functions abstracting sub-syscall numbers of `syscall::memop`. The other syscalls already have safe abstractions for each driver, and `memop` functions can be useful for the entry_point and for debugging from userspace.