### PR TITLE
Miscellaneous fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 edition = "2018"
 
 [dependencies]
-linked_list_allocator = "0.6.3"
+linked_list_allocator = "0.6.4"
 
 [dev-dependencies]
 corepack = { version = "0.4.0", default-features = false, features = ["alloc"] }

--- a/riscv32_layout.ld
+++ b/riscv32_layout.ld
@@ -1,7 +1,8 @@
 /* Layout for the RISC-V 32 boards, used by the examples in this repository. */
 
 MEMORY {
-  FLASH (rx) : ORIGIN = 0x20430000, LENGTH = 32M
+  /* The TBF header region is 32 bytes (0x20) */
+  FLASH (rx) : ORIGIN = 0x20430020, LENGTH = 32M
   SRAM (rwx) : ORIGIN = 0x80000000, LENGTH = 512K
 }
 

--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -209,6 +209,7 @@ pub unsafe extern "C" fn _start() -> ! {
     // Move arguments we need to keep over to callee-saved locations.
     mv   s0, a0             // s0 = void* app_start
     mv   s1, t0             // s1 = stack_top
+    mv   s2, a3             // s2 = app_heap_break
     //
     // Now we may want to move the stack pointer. If the kernel set the
     // `app_heap_break` larger than we need (and we are going to call `brk()`
@@ -255,7 +256,7 @@ pub unsafe extern "C" fn _start() -> ! {
     mv   a0, s0             // first arg is app_start
     mv   s0, sp             // Set the frame pointer to sp.
     mv   a1, s1             // second arg is stacktop
-    mv   a1, s1             // second arg is stackto
+    mv   a2, s2             // third arg is app_heap_break
     jal  rust_start"
     :                                                              // No output operands
     :

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -113,8 +113,8 @@ pub unsafe fn subscribe_ptr(
     let res;
     asm!("li    a0, 1
           ecall"
-         : "=r" (res)
-         : "r" (major), "r" (minor), "r" (cb), "r" (ud)
+         : "={x10}" (res)
+         : "{x11}" (major), "{x12}" (minor), "{x13}" (cb), "{x14}" (ud)
          : "memory"
          : "volatile" );
     res
@@ -135,8 +135,8 @@ pub unsafe fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> i
     let res;
     asm!("li    a0, 2
           ecall"
-         : "=r" (res)
-         : "r" (major), "r" (minor), "r" (arg1), "r" (arg2)
+         : "={x10}" (res)
+         : "{x11}" (major), "{x12}" (minor), "{x13}" (arg1), "{x14}" (arg2)
          : "memory"
          : "volatile");
     res
@@ -182,8 +182,8 @@ pub unsafe fn allow_ptr(major: usize, minor: usize, slice: *mut u8, len: usize) 
     let res;
     asm!("li    a0, 3
           ecall"
-         : "=r" (res)
-         : "r" (major), "r" (minor), "r" (slice), "r" (len)
+         : "={x10}" (res)
+         : "{x11}" (major), "{x12}" (minor), "{x13}" (slice), "{x14}" (len)
          : "memory"
          : "volatile");
     res
@@ -204,8 +204,8 @@ pub unsafe fn memop(major: u32, arg1: usize) -> isize {
     let res;
     asm!("li    a0, 4
           ecall"
-         : "=r" (res)
-         : "r" (major), "r" (arg1)
+         : "={x10}" (res)
+         : "{x11}" (major), "{x12}" (arg1)
          : "memory"
          : "volatile");
     res


### PR DESCRIPTION
This PR contains four things:
1. Fixes the RV32 linker address
2. Updates the linked_list_allocator version to the latest release
3. Hardcode the syscall registers for RV32 ecalls
4. Fix the arguments for RISC-V 32 when calling rust_start