### PR TITLE
fix nrf52 layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ usually means that they must be compiled especially for your board
 and that there can only be one application written in rust at a time
 and it must be installed as the first application on the board, unless
 you want to play games with linker scripts.
+There are some `*_layout.ld` files provided that allow to run the
+examples on common boards.
+Due to MPU region alignment issues they may not work for applications
+that use a lot of RAM, in that case you may have to change the SRAM
+start address to fit your application.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 # libtock-rs
 Rust userland library for Tock (WIP)
 
-Tested with tock a3b36d5872315ff05ef5ad34ed9453b0789218ce.
+Tested with a tock [master from 2019-10-09](https://github.com/tock/tock/commit/6519a10275fc9b673cd78f612701af282e937d29)
+
+The library works in principle but there is currently the [showstopper
+bug #28](https://github.com/tock/libtock-rs/issues/28) that prevents
+the generation of relocatable code. This means that all applications
+must be installed at the flash address they are compiled with, which
+usually means that there can only be on application written in rust
+and it must be installed as the first application on the board, unless
+you want to play games with linker scripts.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 # libtock-rs
 Rust userland library for Tock (WIP)
 
-Tested with a tock [master from 2019-10-09](https://github.com/tock/tock/commit/6519a10275fc9b673cd78f612701af282e937d29)
+Tested with tock [Release 1.4](https://github.com/tock/tock/commit/2cef02405e699c06cefd0aae6a89f0e8cc4395ab).
 
-The library works in principle but there is currently the [showstopper
+The library works in principle on most boards, but there is currently the [showstopper
 bug #28](https://github.com/tock/libtock-rs/issues/28) that prevents
 the generation of relocatable code. This means that all applications
 must be installed at the flash address they are compiled with, which
-usually means that there can only be on application written in rust
+usually means that they must be compiled especially for your board
+and that there can only be one application written in rust at a time
 and it must be installed as the first application on the board, unless
 you want to play games with linker scripts.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # libtock-rs
 Rust userland library for Tock (WIP)
 
-Tested with tock [Release 1.4](https://github.com/tock/tock/commit/2cef02405e699c06cefd0aae6a89f0e8cc4395ab).
+Tested with tock [Release 1.4.1](https://github.com/tock/tock/commit/7e37bf67761d83fd585cace4fb201e2864d300b1).
 
 The library works in principle on most boards, but there is currently the [showstopper
 bug #28](https://github.com/tock/libtock-rs/issues/28) that prevents

--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ to use:
     ./run_example.sh blink
     ```
 
-    This should work if you are using the nRF52-DK platform. For other platforms,
-    you will end up with a TAB file in `target/tab` that you can program onto your
-    Tock board (e.g. with `tockloader install target/tab/blink.tab`).
+    Due to bug #28 this will currently only work if you are using the nRF52-DK platform.
+
+    If you have a nRF52840-DK you must change `link-arg=-Tnrf52_layout.ld` in
+    `.cargo/config` to `link-arg=-Tnrf52840_layout.ld`
 
     If you have a hail board you can flash your device as follows:
      - set the environment variable `hail` to `1`
-     - set  `link-arg=-Tnrf52_layout.ld` in `.cargo/config` to `link-arg=-Thail_layout.ld`
+     - change `link-arg=-Tnrf52_layout.ld` in `.cargo/config` to `link-arg=-Thail_layout.ld`
      - run `run_example.sh` as above.
+
+    For other platforms, you may have to create your own memory layout definition.
 
 ## Using libtock-rs
 

--- a/nrf52840_layout.ld
+++ b/nrf52840_layout.ld
@@ -1,0 +1,17 @@
+/* Layout for the nRF52840-DK, usable by the examples in this repository. */
+
+MEMORY {
+  /* The application region is 64 bytes (0x40) */
+  FLASH (rx) : ORIGIN = 0x00030040, LENGTH = 0x000CFFC0
+  SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
+}
+
+/*
+ * Any change to STACK_SIZE should be accompanied by a corresponding change to
+ * `elf2tab`'s `--stack` option
+ */
+STACK_SIZE = 2048;
+
+MPU_MIN_ALIGN = 8K;
+
+INCLUDE layout.ld

--- a/nrf52_layout.ld
+++ b/nrf52_layout.ld
@@ -2,7 +2,7 @@
 
 MEMORY {
   /* The application region is 64 bytes (0x40) */
-  FLASH (rx) : ORIGIN = 0x00020040, LENGTH = 0x0005FFC0
+  FLASH (rx) : ORIGIN = 0x00030040, LENGTH = 0x0005FFC0
   SRAM (rwx) : ORIGIN = 0x20002000, LENGTH = 62K
 }
 

--- a/run_example.sh
+++ b/run_example.sh
@@ -11,7 +11,7 @@ elf_file_name="target/tab/$1/cortex-m4.elf"
 tab_file_name="target/tab/$1.tab"
 
 # Default value for nRF52-DK
-tockloader_flags="--jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000"
+tockloader_flags="--jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52"
 
 hail_defined=${hail:-}
 if [ -n "$hail_defined" ]

--- a/run_hardware_test.sh
+++ b/run_hardware_test.sh
@@ -4,6 +4,6 @@
 
 set -eux
 
-yes 0|tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 --app-address 0x20000 || true
+yes 0|tockloader uninstall --jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52 || true
 
 ./run_example.sh hardware_test --dont-clear-apps


### PR DESCRIPTION
It looks like the application start address on nRF52 has moved upwards
by 64kB since the library was tested the last time.