### PR TITLE
Give libtock-rs support for the LowLevelDebug capsule.

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -52,6 +52,39 @@ pub fn dump_memory(start_address: *const usize, count: isize) {
     }
 }
 
+/// Use the LowLevelDebug capsule (if present) to print a single number. If the
+/// capsule is not present, this is a no-op.
+#[inline(always)] // Improve reliability for relocation issues
+pub fn low_level_print1(value: usize) {
+    unsafe {
+        asm!("svc 2"
+            :                // No output operands
+            : "{r0}"(0x8)    // Driver number
+              "{r1}"(2)      // Command number
+              "{r2}"(value)  // Value to print
+            : "r0"           // Clobbers (syscall return value)
+            : "volatile"
+        );
+    }
+}
+
+/// Use the LowLevelDebug capsule (if present) to print two numbers. If the
+/// capsule is not present, this is a no-op.
+#[inline(always)] // Improve reliability for relocation issues
+pub fn low_level_print2(value1: usize, value2: usize) {
+    unsafe {
+        asm!("svc 2"
+            :                 // No output operands
+            : "{r0}"(0x8)     // Driver number
+              "{r1}"(3)       // Command number
+              "{r2}"(value1)  // First value to print
+              "{r3}"(value2)  // Second value to print
+            : "r0"            // Clobbers (syscall return value)
+            : "volatile"
+        );
+    }
+}
+
 fn write_as_hex(buffer: &mut [u8], value: usize) {
     write_formatted(buffer, value, 0x10_00_00_00, 0x10);
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -52,64 +52,32 @@ pub fn dump_memory(start_address: *const usize, count: isize) {
     }
 }
 
+/// Use the LowLevelDebug capsule (if present) to indicate the given status
+/// code. If the capsule is not present, this is a no-op.
+#[inline(always)] // Improve reliability for relocation issues
+pub fn low_level_status_code(code: usize) {
+    unsafe {
+        crate::syscalls::command1_insecure(0x8, 1, code);
+    }
+}
+
 /// Use the LowLevelDebug capsule (if present) to print a single number. If the
 /// capsule is not present, this is a no-op.
-#[cfg(target_arch = "arm")]
 #[inline(always)] // Improve reliability for relocation issues
 pub fn low_level_print1(value: usize) {
     unsafe {
-        asm!("svc 2"
-            :                // No output operands
-            : "{r0}"(0x8)    // Driver number
-              "{r1}"(2)      // Command number
-              "{r2}"(value)  // Value to print
-            : "r0"           // Clobbers (syscall return value)
-            : "volatile"
-        );
+        crate::syscalls::command1_insecure(0x8, 2, value);
     }
 }
 
 /// Use the LowLevelDebug capsule (if present) to print two numbers. If the
 /// capsule is not present, this is a no-op.
-#[cfg(target_arch = "arm")]
 #[inline(always)] // Improve reliability for relocation issues
 pub fn low_level_print2(value1: usize, value2: usize) {
     unsafe {
-        asm!("svc 2"
-            :                 // No output operands
-            : "{r0}"(0x8)     // Driver number
-              "{r1}"(3)       // Command number
-              "{r2}"(value1)  // First value to print
-              "{r3}"(value2)  // Second value to print
-            : "r0"            // Clobbers (syscall return value)
-            : "volatile"
-        );
+        crate::syscalls::command(0x8, 3, value1, value2);
     }
 }
-
-/// Use the LowLevelDebug capsule (if present) to indicate the given status
-/// code. If the capsule is not present, this is a no-op.
-// TODO: Someone with RISC-V hardware should port this to RISC-V.
-#[cfg(target_arch = "arm")]
-#[inline(always)] // Improve reliability for relocation issues
-pub fn low_level_status_code(code: usize) {
-    unsafe {
-        asm!("svc 2"
-            :               // No output operands
-            : "{r0}"(0x8)   // Driver number
-              "{r1}"(1)     // Command number
-              "{r2}"(code)  // Value to print
-            : "r0"          // Clobbers (syscall return value)
-            : "volatile"
-        );
-    }
-}
-
-// Non-functional wrapper so that the panic handler (in lang_items) can build on
-// non-ARM architectures.
-#[cfg(not(target_arch = "arm"))]
-#[inline(always)]
-pub fn low_level_status_code(_code: usize) {}
 
 fn write_as_hex(buffer: &mut [u8], value: usize) {
     write_formatted(buffer, value, 0x10_00_00_00, 0x10);

--- a/src/debug/low_level_debug.rs
+++ b/src/debug/low_level_debug.rs
@@ -2,7 +2,7 @@
 //! useful for toolchain issues. The capsule is documented at:
 //! https://github.com/tock/tock/blob/master/doc/syscalls/00008_low_level_debug.md
 
-use crate::syscalls::{command,command1_insecure};
+use crate::syscalls::{command, command1_insecure};
 
 const DRIVER_NUMBER: usize = 8;
 

--- a/src/debug/low_level_debug.rs
+++ b/src/debug/low_level_debug.rs
@@ -1,0 +1,40 @@
+//! Interface to the Low Level Debug capsule. This provides routines that are
+//! useful for toolchain issues. The capsule is documented at:
+//! https://github.com/tock/tock/blob/master/doc/syscalls/00008_low_level_debug.md
+
+use crate::syscalls::{command,command1_insecure};
+
+const DRIVER_NUMBER: usize = 8;
+
+mod command_nr {
+    pub const ALERT_CODE: usize = 1;
+    pub const PRINT1: usize = 2;
+    pub const PRINT2: usize = 3;
+}
+
+/// Use the LowLevelDebug capsule (if present) to indicate the given status
+/// code. If the capsule is not present, this is a no-op.
+#[inline(always)] // Improve reliability for relocation issues
+pub fn low_level_status_code(code: usize) {
+    unsafe {
+        command1_insecure(DRIVER_NUMBER, command_nr::ALERT_CODE, code);
+    }
+}
+
+/// Use the LowLevelDebug capsule (if present) to print a single number. If the
+/// capsule is not present, this is a no-op.
+#[inline(always)] // Improve reliability for relocation issues
+pub fn low_level_print1(value: usize) {
+    unsafe {
+        command1_insecure(DRIVER_NUMBER, command_nr::PRINT1, value);
+    }
+}
+
+/// Use the LowLevelDebug capsule (if present) to print two numbers. If the
+/// capsule is not present, this is a no-op.
+#[inline(always)] // Improve reliability for relocation issues
+pub fn low_level_print2(value1: usize, value2: usize) {
+    unsafe {
+        command(DRIVER_NUMBER, command_nr::PRINT2, value1, value2);
+    }
+}

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -1,5 +1,8 @@
 //! Heapless debugging functions for Tock troubleshooting
 
+mod low_level_debug;
+pub use low_level_debug::*;
+
 use crate::console::Console;
 
 pub fn println() {
@@ -49,33 +52,6 @@ pub fn dump_memory(start_address: *const usize, count: isize) {
 
     for offset in range {
         dump_address(unsafe { start_address.offset(offset) });
-    }
-}
-
-/// Use the LowLevelDebug capsule (if present) to indicate the given status
-/// code. If the capsule is not present, this is a no-op.
-#[inline(always)] // Improve reliability for relocation issues
-pub fn low_level_status_code(code: usize) {
-    unsafe {
-        crate::syscalls::command1_insecure(0x8, 1, code);
-    }
-}
-
-/// Use the LowLevelDebug capsule (if present) to print a single number. If the
-/// capsule is not present, this is a no-op.
-#[inline(always)] // Improve reliability for relocation issues
-pub fn low_level_print1(value: usize) {
-    unsafe {
-        crate::syscalls::command1_insecure(0x8, 2, value);
-    }
-}
-
-/// Use the LowLevelDebug capsule (if present) to print two numbers. If the
-/// capsule is not present, this is a no-op.
-#[inline(always)] // Improve reliability for relocation issues
-pub fn low_level_print2(value1: usize, value2: usize) {
-    unsafe {
-        crate::syscalls::command(0x8, 3, value1, value2);
     }
 }
 

--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -85,8 +85,12 @@ pub unsafe extern "C" fn _start(
         ldr r5, =.start   // r5 = address of .start
         cmp r4, r5
         beq .Lstack_init  // Jump to stack initialization if pc was correct
+        movw r0, #8       // LowLevelDebug driver number
+        movw r1, #1       // LowLevelDebug 'print status code' command
+        movw r2, #2       // LowLevelDebug relocation failed status code
+        svc 2             // command() syscall
         .Lyield_loop:
-        svc 0             // yield() syscall
+        svc 0             // yield() syscall (in infinite loop)
         b .Lyield_loop
 
         .Lstack_init:

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -43,7 +43,20 @@ impl Termination for () {
 }
 
 #[panic_handler]
-fn flash_all_leds(_info: &PanicInfo) -> ! {
+fn panic_handler(_info: &PanicInfo) -> ! {
+    // Signal a panic using the LowLevelDebug capsule (if available).
+    unsafe {
+        asm!("svc 2"
+            :              // No output operands
+            : "{r0}"(0x8)  // Driver number
+              "{r1}"(1)    // Command number
+              "{r2}"(1)    // Panic status code
+            : "r0"         // Clobbers (syscall return value)
+            : "volatile"
+        );
+    }
+
+    // Flash all LEDs (if available).
     loop {
         for led in led::all() {
             led.on();

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -45,16 +45,7 @@ impl Termination for () {
 #[panic_handler]
 fn panic_handler(_info: &PanicInfo) -> ! {
     // Signal a panic using the LowLevelDebug capsule (if available).
-    unsafe {
-        asm!("svc 2"
-            :              // No output operands
-            : "{r0}"(0x8)  // Driver number
-              "{r1}"(1)    // Command number
-              "{r2}"(1)    // Panic status code
-            : "r0"         // Clobbers (syscall return value)
-            : "volatile"
-        );
-    }
+    super::debug::low_level_status_code(1);
 
     // Flash all LEDs (if available).
     loop {

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -27,6 +27,10 @@ pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
     unimplemented()
 }
 
+pub unsafe fn command1_insecure(_: usize, _: usize, _: usize) -> isize {
+    unimplemented()
+}
+
 pub fn allow(_: usize, _: usize, _: &mut [u8]) -> Result<SharedMemory, isize> {
     unimplemented()
 }


### PR DESCRIPTION
  1. Add methods to access LowLevelDebug's integer-printing functionality.
  2. Report the "mismatched location" status code when the location check fails.
  3. Report the "application panic" status code in the panic handler.

This change depends on https://github.com/tock/tock/pull/1430. By design, if the LowLevelDebug capsule is not present in the kernel this change is a no-op.