### PR TITLE
Split the single command() system call into command0(), command1(), and command2().

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -61,7 +61,7 @@ where
     Self: SubscribableCallback,
 {
     pub fn init(&mut self) -> Result<Adc, isize> {
-        let return_value = unsafe { syscalls::command(DRIVER_NUM, command::COUNT, 0, 0) };
+        let return_value = unsafe { syscalls::command0(DRIVER_NUM, command::COUNT) };
         if return_value < 0 {
             return Err(return_value);
         }
@@ -92,7 +92,7 @@ impl<'a> Adc<'a> {
     /// Start a single sample of channel
     pub fn sample(&self, channel: usize) -> Result<(), isize> {
         unsafe {
-            let code = syscalls::command(DRIVER_NUM, command::START, channel, 0);
+            let code = syscalls::command1(DRIVER_NUM, command::START, channel);
             if code < 0 {
                 Err(code)
             } else {
@@ -104,7 +104,7 @@ impl<'a> Adc<'a> {
     /// Start continuous sampling of channel
     pub fn sample_continuous(&self, channel: usize) -> Result<(), isize> {
         unsafe {
-            let code = syscalls::command(DRIVER_NUM, command::START_REPEAT, channel, 0);
+            let code = syscalls::command2(DRIVER_NUM, command::START_REPEAT, channel, 0);
             if code < 0 {
                 Err(code)
             } else {
@@ -121,7 +121,7 @@ impl<'a> Adc<'a> {
     ) -> Result<(), isize> {
         unsafe {
             let code =
-                syscalls::command(DRIVER_NUM, command::START_REPEAT_BUFFER, channel, frequency);
+                syscalls::command2(DRIVER_NUM, command::START_REPEAT_BUFFER, channel, frequency);
             if code < 0 {
                 Err(code)
             } else {
@@ -137,7 +137,7 @@ impl<'a> Adc<'a> {
         frequency: usize,
     ) -> Result<(), isize> {
         unsafe {
-            let code = syscalls::command(
+            let code = syscalls::command2(
                 DRIVER_NUM,
                 command::START_REPEAT_BUFFER_ALT,
                 channel,
@@ -154,7 +154,7 @@ impl<'a> Adc<'a> {
     /// Stop any started sampling operation
     pub fn stop(&self) -> Result<(), isize> {
         unsafe {
-            let code = syscalls::command(DRIVER_NUM, command::STOP, 0, 0);
+            let code = syscalls::command0(DRIVER_NUM, command::STOP);
             if code < 0 {
                 Err(code)
             } else {

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -37,7 +37,7 @@ where
     Self: SubscribableCallback,
 {
     pub fn init(&mut self) -> TockResult<Buttons, ButtonsError> {
-        let count = unsafe { syscalls::command(DRIVER_NUMBER, command_nr::COUNT, 0, 0) };
+        let count = unsafe { syscalls::command0(DRIVER_NUMBER, command_nr::COUNT) };
         if count < 1 {
             return Err(TockValue::Expected(ButtonsError::NotSupported));
         }
@@ -134,11 +134,10 @@ pub struct ButtonHandle<'a> {
 impl<'a> ButtonHandle<'a> {
     pub fn enable(&mut self) -> TockResult<Button, ButtonError> {
         let return_code = unsafe {
-            syscalls::command(
+            syscalls::command1(
                 DRIVER_NUMBER,
                 command_nr::ENABLE_INTERRUPT,
                 self.button_num,
-                0,
             )
         };
 
@@ -151,11 +150,10 @@ impl<'a> ButtonHandle<'a> {
 
     pub fn disable(&mut self) -> TockResult<(), ButtonError> {
         let return_code = unsafe {
-            syscalls::command(
+            syscalls::command1(
                 DRIVER_NUMBER,
                 command_nr::DISABLE_INTERRUPT,
                 self.button_num,
-                0,
             )
         };
 
@@ -179,11 +177,10 @@ pub enum ButtonError {
 impl<'a> Button<'a> {
     pub fn read(&self) -> ButtonState {
         unsafe {
-            ButtonState::from(syscalls::command(
+            ButtonState::from(syscalls::command1(
                 DRIVER_NUMBER,
                 command_nr::READ,
                 self.handle.button_num,
-                0,
             ) as usize)
         }
     }

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -134,11 +134,7 @@ pub struct ButtonHandle<'a> {
 impl<'a> ButtonHandle<'a> {
     pub fn enable(&mut self) -> TockResult<Button, ButtonError> {
         let return_code = unsafe {
-            syscalls::command1(
-                DRIVER_NUMBER,
-                command_nr::ENABLE_INTERRUPT,
-                self.button_num,
-            )
+            syscalls::command1(DRIVER_NUMBER, command_nr::ENABLE_INTERRUPT, self.button_num)
         };
 
         match return_code {

--- a/src/console.rs
+++ b/src/console.rs
@@ -60,7 +60,7 @@ impl Console {
         }
 
         let result_code =
-            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::WRITE, num_bytes_to_print, 0) };
+            unsafe { syscalls::command1(DRIVER_NUMBER, command_nr::WRITE, num_bytes_to_print) };
         if result_code < 0 {
             return;
         }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -174,11 +174,7 @@ impl Drop for GpioPinWrite {
 impl Drop for GpioPinRead {
     fn drop(&mut self) {
         unsafe {
-            syscalls::command1(
-                DRIVER_NUMBER,
-                gpio_commands::DISABLE_INTERRUPT,
-                self.number,
-            );
+            syscalls::command1(DRIVER_NUMBER, gpio_commands::DISABLE_INTERRUPT, self.number);
             syscalls::command1(DRIVER_NUMBER, gpio_commands::DISABLE, self.number);
         }
     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -65,7 +65,7 @@ impl GpioPinUnitialized {
 
     pub fn open_for_write(self) -> Result<GpioPinWrite, &'static str> {
         match unsafe {
-            syscalls::command(DRIVER_NUMBER, gpio_commands::ENABLE_OUTPUT, self.number, 0)
+            syscalls::command1(DRIVER_NUMBER, gpio_commands::ENABLE_OUTPUT, self.number)
         } {
             0 => Ok(GpioPinWrite {
                 number: self.number,
@@ -106,7 +106,7 @@ impl GpioPinUnitialized {
 
     fn enable_input(self, mode: InputMode) -> Result<GpioPinUnitialized, &'static str> {
         if unsafe {
-            syscalls::command(
+            syscalls::command2(
                 DRIVER_NUMBER,
                 gpio_commands::ENABLE_INPUT,
                 self.number,
@@ -122,7 +122,7 @@ impl GpioPinUnitialized {
 
     fn enable_callback(self, irq_mode: IrqMode) -> Result<GpioPinRead, &'static str> {
         if unsafe {
-            syscalls::command(
+            syscalls::command2(
                 DRIVER_NUMBER,
                 gpio_commands::ENABLE_INTERRUPT,
                 self.number,
@@ -142,31 +142,31 @@ impl GpioPinUnitialized {
 impl GpioPinWrite {
     pub fn set_low(&self) {
         unsafe {
-            syscalls::command(DRIVER_NUMBER, gpio_commands::SET_LOW, self.number, 0);
+            syscalls::command1(DRIVER_NUMBER, gpio_commands::SET_LOW, self.number);
         }
     }
     pub fn set_high(&self) {
         unsafe {
-            syscalls::command(DRIVER_NUMBER, gpio_commands::SET_HIGH, self.number, 0);
+            syscalls::command1(DRIVER_NUMBER, gpio_commands::SET_HIGH, self.number);
         }
     }
     pub fn toggle(&self) {
         unsafe {
-            syscalls::command(DRIVER_NUMBER, gpio_commands::TOGGLE, self.number, 0);
+            syscalls::command1(DRIVER_NUMBER, gpio_commands::TOGGLE, self.number);
         }
     }
 }
 
 impl GpioPinRead {
     pub fn read(&self) -> bool {
-        unsafe { syscalls::command(DRIVER_NUMBER, gpio_commands::READ, self.number, 0) == 1 }
+        unsafe { syscalls::command1(DRIVER_NUMBER, gpio_commands::READ, self.number) == 1 }
     }
 }
 
 impl Drop for GpioPinWrite {
     fn drop(&mut self) {
         unsafe {
-            syscalls::command(DRIVER_NUMBER, gpio_commands::DISABLE, self.number, 0);
+            syscalls::command1(DRIVER_NUMBER, gpio_commands::DISABLE, self.number);
         }
     }
 }
@@ -174,13 +174,12 @@ impl Drop for GpioPinWrite {
 impl Drop for GpioPinRead {
     fn drop(&mut self) {
         unsafe {
-            syscalls::command(
+            syscalls::command1(
                 DRIVER_NUMBER,
                 gpio_commands::DISABLE_INTERRUPT,
                 self.number,
-                0,
             );
-            syscalls::command(DRIVER_NUMBER, gpio_commands::DISABLE, self.number, 0);
+            syscalls::command1(DRIVER_NUMBER, gpio_commands::DISABLE, self.number);
         }
     }
 }

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,4 +1,4 @@
-use crate::syscalls::command;
+use crate::syscalls::{command0,command1};
 
 const DRIVER_NUMBER: usize = 0x00002;
 
@@ -14,7 +14,7 @@ pub struct Led {
 }
 
 pub fn count() -> isize {
-    unsafe { command(DRIVER_NUMBER, command_nr::COUNT, 0, 0) }
+    unsafe { command0(DRIVER_NUMBER, command_nr::COUNT) }
 }
 
 pub fn get(led_num: isize) -> Option<Led> {
@@ -45,19 +45,19 @@ impl Led {
 
     pub fn on(&self) {
         unsafe {
-            command(DRIVER_NUMBER, command_nr::ON, self.led_num, 0);
+            command1(DRIVER_NUMBER, command_nr::ON, self.led_num);
         }
     }
 
     pub fn off(&self) {
         unsafe {
-            command(DRIVER_NUMBER, command_nr::OFF, self.led_num, 0);
+            command1(DRIVER_NUMBER, command_nr::OFF, self.led_num);
         }
     }
 
     pub fn toggle(&self) {
         unsafe {
-            command(DRIVER_NUMBER, command_nr::TOGGLE, self.led_num, 0);
+            command1(DRIVER_NUMBER, command_nr::TOGGLE, self.led_num);
         }
     }
 }

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,4 +1,4 @@
-use crate::syscalls::{command0,command1};
+use crate::syscalls::{command0, command1};
 
 const DRIVER_NUMBER: usize = 0x00002;
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -35,7 +35,7 @@ pub fn fill_buffer(buf: &mut [u8]) -> bool {
     }
 
     let result_code =
-        unsafe { syscalls::command(DRIVER_NUMBER, command_nr::REQUEST_RNG, buf_len, 0) };
+        unsafe { syscalls::command1(DRIVER_NUMBER, command_nr::REQUEST_RNG, buf_len) };
     if result_code < 0 {
         return false;
     }

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -29,7 +29,7 @@ pub trait Sensor<Reading: Copy + From<(usize, usize, usize)>> {
                 cb::<Reading> as *const _,
                 mem::transmute(&res),
             );
-            syscalls::command(driver_num, 1, 0, 0);
+            syscalls::command0(driver_num, 1);
             yieldk_for(|| res.get().is_some());
             res.get().unwrap()
         }

--- a/src/sensors/ninedof.rs
+++ b/src/sensors/ninedof.rs
@@ -67,9 +67,9 @@ pub unsafe fn subscribe(cb: extern "C" fn(usize, usize, usize, usize), ud: usize
 }
 
 pub unsafe fn start_accel_reading() {
-    syscalls::command(DRIVER_NUM, 1, 0, 0);
+    syscalls::command1(DRIVER_NUM, 1, 0);
 }
 
 pub unsafe fn start_magnetometer_reading() {
-    syscalls::command(DRIVER_NUM, 100, 0, 0);
+    syscalls::command1(DRIVER_NUM, 100, 0);
 }

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -52,7 +52,7 @@ impl BleAdvertisingDriver {
 
     fn start_advertising(pdu_type: usize, interval: usize) -> Result<(), isize> {
         let result = unsafe {
-            syscalls::command(
+            syscalls::command2(
                 DRIVER_NUMBER,
                 ble_commands::START_ADVERTISING,
                 pdu_type,
@@ -97,7 +97,7 @@ impl BleDriver {
         let subscription =
             syscalls::subscribe(DRIVER_NUMBER, ble_commands::BLE_PASSIVE_SCAN_SUB, callback)?;
 
-        let result = unsafe { syscalls::command(DRIVER_NUMBER, ble_commands::PASSIVE_SCAN, 1, 0) };
+        let result = unsafe { syscalls::command0(DRIVER_NUMBER, ble_commands::PASSIVE_SCAN) };
         convert_result(result)?;
         Ok(subscription)
     }

--- a/src/syscalls_mock.rs
+++ b/src/syscalls_mock.rs
@@ -23,7 +23,15 @@ pub unsafe fn subscribe_ptr(
     unimplemented()
 }
 
-pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
+pub unsafe fn command0(_: usize, _: usize) -> isize {
+    unimplemented()
+}
+
+pub unsafe fn command1(_: usize, _: usize, _: usize) -> isize {
+    unimplemented()
+}
+
+pub unsafe fn command2(_: usize, _: usize, _: usize, _: usize) -> isize {
     unimplemented()
 }
 

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -26,7 +26,7 @@ where
 {
     pub fn start_measurement(&mut self) -> Result<CallbackSubscription, isize> {
         let subscription = syscalls::subscribe(DRIVER_NUMBER, SUBSCRIBE_CALLBACK, self)?;
-        unsafe { syscalls::command(DRIVER_NUMBER, START_MEASUREMENT, 0, 0) };
+        unsafe { syscalls::command0(DRIVER_NUMBER, START_MEASUREMENT) };
         Ok(subscription)
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -62,14 +62,14 @@ where
 {
     pub fn init(&mut self) -> TockResult<Timer, TimerError> {
         let num_notifications =
-            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::IS_DRIVER_AVAILABLE, 0, 0) };
+            unsafe { syscalls::command0(DRIVER_NUMBER, command_nr::IS_DRIVER_AVAILABLE) };
 
         if num_notifications < 1 {
             return Err(TockValue::Expected(TimerError::NotSupported));
         }
 
         let clock_frequency =
-            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::GET_CLOCK_FREQUENCY, 0, 0) };
+            unsafe { syscalls::command0(DRIVER_NUMBER, command_nr::GET_CLOCK_FREQUENCY) };
 
         if clock_frequency < 1 {
             return Err(TockValue::Expected(TimerError::ErroneousClockFrequency(
@@ -122,7 +122,7 @@ impl<'a> Timer<'a> {
 
     pub fn get_current_clock(&self) -> ClockValue {
         let num_ticks =
-            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::GET_CLOCK_VALUE, 0, 0) };
+            unsafe { syscalls::command0(DRIVER_NUMBER, command_nr::GET_CLOCK_VALUE) };
 
         ClockValue {
             num_ticks,
@@ -132,7 +132,7 @@ impl<'a> Timer<'a> {
 
     pub fn stop_alarm(&mut self, alarm: Alarm) -> TockResult<(), StopAlarmError> {
         let return_code =
-            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::STOP_ALARM, alarm.alarm_id, 0) };
+            unsafe { syscalls::command1(DRIVER_NUMBER, command_nr::STOP_ALARM, alarm.alarm_id) };
 
         match return_code {
             result::SUCCESS => Ok(()),
@@ -166,7 +166,7 @@ impl<'a> Timer<'a> {
         let alarm_instant = now.num_ticks() as usize + ticks;
 
         let alarm_id =
-            unsafe { syscalls::command(DRIVER_NUMBER, command_nr::SET_ALARM, alarm_instant, 0) };
+            unsafe { syscalls::command1(DRIVER_NUMBER, command_nr::SET_ALARM, alarm_instant) };
 
         match alarm_id {
             _ if alarm_id >= 0 => Ok(Alarm {

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -121,8 +121,7 @@ impl<'a> Timer<'a> {
     }
 
     pub fn get_current_clock(&self) -> ClockValue {
-        let num_ticks =
-            unsafe { syscalls::command0(DRIVER_NUMBER, command_nr::GET_CLOCK_VALUE) };
+        let num_ticks = unsafe { syscalls::command0(DRIVER_NUMBER, command_nr::GET_CLOCK_VALUE) };
 
         ClockValue {
             num_ticks,


### PR DESCRIPTION
The existing `command()` definition always sets both argument registers. For many uses of `command()`, this is unnecessary. Setting only the needed argument registers reduces the generated assembly size.

**In its current form, this change is not backwards-compatible:** users of the `command()` function will need to be updated to point to `command0()`, `command1()`, or `command2()` (with `command2()` being a drop-in replacement).

This reduces our test app sizes by 48 and 64 bytes (these apps only use one driver -- Console -- hence the small change), and should simplify the generated assembly which will help with debugging. This PR is motivated by the discussion/investigation at https://github.com/tock/libtock-rs/pull/101#discussion_r339337257.