### PR TITLE
Support for RISC-V without atomic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache: rust
 
 install:
   - rustup target add thumbv7em-none-eabi
+  - rustup target add riscv32imc-unknown-none-elf
   - rustup component add rustfmt-preview
 
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2018"
 
 [dependencies]
 core = { package = "async-support", path = "async-support" }
-linked_list_allocator = "0.6.4"
+linked_list_allocator = { version = "0.6.4", default-features = false }
 
 [dev-dependencies]
 corepack = { version = "0.4.0", default-features = false, features = ["alloc"] }
 # We pin the serde version because newer serde versions may not be compatible
 # with the nightly toolchain used by libtock-rs.
 serde = { version = "=1.0.84", default-features = false, features = ["derive"] }
-futures = { version = "0.3.1", default-features = false }
+futures = { version = "0.3.1", default-features = false, features = ["unstable", "cfg-target-has-atomic"] }
 
 [profile.dev]
 panic = "abort"

--- a/build_examples.sh
+++ b/build_examples.sh
@@ -3,3 +3,4 @@
 set -eux
 
 cargo build --release --target=thumbv7em-none-eabi --examples
+cargo build --release --target=riscv32imc-unknown-none-elf --examples # Important for tests: This target does not support atomics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,10 +45,6 @@ pub mod syscalls;
 #[path = "syscalls_mock.rs"]
 mod syscalls;
 
-#[cfg(any(target_arch = "arm", target_arch = "riscv32"))]
-#[global_allocator]
-static ALLOCATOR: linked_list_allocator::LockedHeap = linked_list_allocator::LockedHeap::empty();
-
 // Dummy structure to force importing the panic_handler and other no_std elements when nothing else
 // is imported.
 pub struct LibTock;


### PR DESCRIPTION
Fixes #106 

- The `spin` feature of the `linked_list_allocator` has been disabled, s.t. the allocator does not rely on atomics anymore.