### PR TITLE
Resultify libtock-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.2.0 (WIP)
 
-- Many functions, including `main()` are asynchronous
+- Many functions, including `main()`, are asynchronous
   - To retrieve the value of an asynchronous `value`, use `value.await`
   - This is only possible within an `async fn`, so either
     - Make the caller `fn` of `.await` an `async fn`
@@ -15,6 +15,7 @@
   - `syscalls::subscribe_ptr` becomes `syscalls::raw::subscribe`
   - `syscalls::allow_ptr` becomes `syscalls::raw::allow`
 - Targets without support for atomics can be built
+- Most API functions, including `main()`, return a `Result<T, TockError>`
 
 ## a8bb4fa9be504517d5533511fd8e607ea61f1750 (0.1.0)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ The boiler plate code you would write is
 ```rust
 #![no_std]
 
-async fn main() {
+use libtock::result::TockResult;
+
+async fn main() -> TockResult<()> {
   // Your code
 }
 ```

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -3,19 +3,20 @@
 use core::fmt::Write;
 use libtock::adc;
 use libtock::console::Console;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
     let mut with_callback = adc::with_callback(|channel: usize, value: usize| {
         writeln!(console, "channel: {}, value: {}", channel, value).unwrap();
     });
 
-    let adc = with_callback.init().unwrap();
+    let adc = with_callback.init()?;
 
     loop {
-        adc.sample(0).unwrap();
-        timer::sleep(Duration::from_ms(2000)).await;
+        adc.sample(0)?;
+        timer::sleep(Duration::from_ms(2000)).await?;
     }
 }

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -4,25 +4,26 @@ use core::fmt::Write;
 use libtock::adc;
 use libtock::adc::AdcBuffer;
 use libtock::console::Console;
+use libtock::result::TockResult;
 use libtock::syscalls;
 
 /// Reads a 128 byte sample into a buffer and prints the first value to the console.
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
     let mut adc_buffer = AdcBuffer::new();
     let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];
 
-    let adc_buffer = libtock::adc::Adc::init_buffer(&mut adc_buffer).unwrap();
+    let adc_buffer = libtock::adc::Adc::init_buffer(&mut adc_buffer)?;
 
     let mut with_callback = adc::with_callback(|_, _| {
         adc_buffer.read_bytes(&mut temp_buffer[..]);
         writeln!(console, "First sample in buffer: {}", temp_buffer[0]).unwrap();
     });
 
-    let adc = with_callback.init().unwrap();
+    let adc = with_callback.init()?;
 
     loop {
-        adc.sample_continuous_buffered(0, 128).unwrap();
+        adc.sample_continuous_buffered(0, 128)?;
         unsafe { syscalls::raw::yieldk() };
     }
 }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -5,36 +5,38 @@ use libtock::buttons;
 use libtock::buttons::ButtonState;
 use libtock::futures as libtock_futures;
 use libtock::led;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
-    future::join(blink_periodically(), blink_on_button_press()).await;
+async fn main() -> TockResult<()> {
+    future::try_join(blink_periodically(), blink_on_button_press()).await?;
+    Ok(())
 }
 
-async fn blink_periodically() {
+async fn blink_periodically() -> TockResult<()> {
     let led = led::get(0).unwrap();
     loop {
-        timer::sleep(Duration::from_ms(250)).await;
-        led.on();
-        timer::sleep(Duration::from_ms(250)).await;
-        led.off();
+        timer::sleep(Duration::from_ms(250)).await?;
+        led.on()?;
+        timer::sleep(Duration::from_ms(250)).await?;
+        led.off()?;
     }
 }
 
-async fn blink_on_button_press() {
+async fn blink_on_button_press() -> TockResult<()> {
     let mut with_callback = buttons::with_callback(|_, _| {});
-    let mut buttons = with_callback.init().unwrap();
+    let mut buttons = with_callback.init()?;
     let mut button = buttons.iter_mut().next().unwrap();
-    let button = button.enable().unwrap();
+    let button = button.enable()?;
     let led = led::get(1).unwrap();
 
     loop {
-        libtock_futures::wait_until(|| button.read() == ButtonState::Released).await;
-        libtock_futures::wait_until(|| button.read() == ButtonState::Pressed).await;
-        led.on();
-        libtock_futures::wait_until(|| button.read() == ButtonState::Released).await;
-        libtock_futures::wait_until(|| button.read() == ButtonState::Pressed).await;
-        led.off();
+        libtock_futures::wait_until(|| button.read().ok() == Some(ButtonState::Released)).await;
+        libtock_futures::wait_until(|| button.read().ok() == Some(ButtonState::Pressed)).await;
+        led.on()?;
+        libtock_futures::wait_until(|| button.read().ok() == Some(ButtonState::Released)).await;
+        libtock_futures::wait_until(|| button.read().ok() == Some(ButtonState::Pressed)).await;
+        led.off()?;
     }
 }

--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -3,6 +3,7 @@
 use futures::future;
 use libtock::ble_parser;
 use libtock::led;
+use libtock::result::TockResult;
 use libtock::simple_ble;
 use libtock::simple_ble::BleCallback;
 use libtock::simple_ble::BleDriver;
@@ -14,20 +15,20 @@ struct LedCommand {
     pub st: bool,
 }
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut shared_buffer = BleDriver::create_scan_buffer();
     let mut my_buffer = BleDriver::create_scan_buffer();
-    let shared_memory = BleDriver::share_memory(&mut shared_buffer).unwrap();
+    let shared_memory = BleDriver::share_memory(&mut shared_buffer)?;
 
     let mut callback = BleCallback::new(|_: usize, _: usize| {
         shared_memory.read_bytes(&mut my_buffer[..]);
         ble_parser::find(&my_buffer, simple_ble::gap_data::SERVICE_DATA as u8)
             .and_then(|service_data| ble_parser::extract_for_service([91, 79], service_data))
             .and_then(|payload| corepack::from_bytes::<LedCommand>(&payload).ok())
-            .and_then(|msg| led::get(msg.nr as isize).map(|led| led.set_state(msg.st)));
+            .and_then(|msg| led::get(msg.nr as usize).map(|led| led.set_state(msg.st)));
     });
 
-    let _subscription = BleDriver::start(&mut callback).unwrap();
+    let _subscription = BleDriver::start(&mut callback)?;
 
     future::pending().await
 }

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -1,11 +1,12 @@
 #![no_std]
 
 use libtock::led;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
-    let num_leds = led::count();
+async fn main() -> TockResult<()> {
+    let num_leds = led::count()?;
 
     // Blink the LEDs in a binary count pattern and scale
     // to the number of LEDs on the board.
@@ -13,14 +14,14 @@ async fn main() {
     loop {
         for i in 0..num_leds {
             if count & (1 << i) == (1 << i) {
-                led::get(i).unwrap().on();
+                led::get(i).unwrap().on()?;
             } else {
-                led::get(i).unwrap().off();
+                led::get(i).unwrap().off()?;
             }
         }
         count = count.wrapping_add(1);
 
         // This delay uses an underlying timer in the kernel.
-        timer::sleep(Duration::from_ms(250)).await;
+        timer::sleep(Duration::from_ms(250)).await?;
     }
 }

--- a/examples/blink_random.rs
+++ b/examples/blink_random.rs
@@ -1,36 +1,38 @@
 #![no_std]
 
 use libtock::led;
+use libtock::result::TockResult;
 use libtock::rng;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
-    let num_leds = led::count();
+async fn main() -> TockResult<()> {
+    let num_leds = led::count().ok().unwrap();
     // blink_nibble assumes 4 leds.
     assert_eq!(num_leds, 4);
 
     let mut buf = [0; 64];
     loop {
-        assert!(rng::fill_buffer(&mut buf).await);
+        rng::fill_buffer(&mut buf).await?;
 
         for &x in buf.iter() {
-            blink_nibble(x);
-            timer::sleep(Duration::from_ms(100)).await;
-            blink_nibble(x >> 4);
-            timer::sleep(Duration::from_ms(100)).await;
+            blink_nibble(x)?;
+            timer::sleep(Duration::from_ms(100)).await?;
+            blink_nibble(x >> 4)?;
+            timer::sleep(Duration::from_ms(100)).await?;
         }
     }
 }
 
 // Takes the 4 least-significant bits of x, and turn the 4 leds on/off accordingly.
-fn blink_nibble(x: u8) {
+fn blink_nibble(x: u8) -> TockResult<()> {
     for i in 0..4 {
         let led = led::get(i).unwrap();
         if (x >> i) & 1 != 0 {
-            led.on();
+            led.on()?;
         } else {
-            led.off();
+            led.off()?;
         }
     }
+    Ok(())
 }

--- a/examples/button_leds.rs
+++ b/examples/button_leds.rs
@@ -4,20 +4,20 @@ use futures::future;
 use libtock::buttons;
 use libtock::buttons::ButtonState;
 use libtock::led;
+use libtock::result::TockResult;
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {
-        let i = button_num as isize;
         match state {
-            ButtonState::Pressed => led::get(i).unwrap().toggle(),
+            ButtonState::Pressed => led::get(button_num).unwrap().toggle().ok().unwrap(),
             ButtonState::Released => (),
         };
     });
 
-    let mut buttons = with_callback.init().unwrap();
+    let mut buttons = with_callback.init()?;
 
     for mut button in &mut buttons {
-        button.enable().unwrap();
+        button.enable()?;
     }
 
     future::pending().await

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -4,22 +4,22 @@ use core::fmt::Write;
 use libtock::buttons;
 use libtock::buttons::ButtonState;
 use libtock::console::Console;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
     let mut with_callback = buttons::with_callback(|_, _| {});
-    let mut buttons = with_callback.init().unwrap();
+    let mut buttons = with_callback.init()?;
     let mut button = buttons.iter_mut().next().unwrap();
-    let button = button.enable().unwrap();
+    let button = button.enable()?;
 
     loop {
-        match button.read() {
+        match button.read()? {
             ButtonState::Pressed => writeln!(console, "pressed"),
             ButtonState::Released => writeln!(console, "released"),
-        }
-        .unwrap();
-        timer::sleep(Duration::from_ms(500)).await;
+        }?;
+        timer::sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -5,9 +5,10 @@ use futures::future;
 use libtock::buttons;
 use libtock::buttons::ButtonState;
 use libtock::console::Console;
+use libtock::result::TockResult;
 
-// FIXME: Hangs up when buttons are pressed rapidly - problem in console?
-async fn main() {
+// FIXME: Hangs up when buttons are pressed rapidly. Yielding in callback leads to stack overflow.
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
 
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {
@@ -20,13 +21,14 @@ async fn main() {
                 ButtonState::Released => "released",
             }
         )
+        .ok()
         .unwrap();
     });
 
-    let mut buttons = with_callback.init().unwrap();
+    let mut buttons = with_callback.init()?;
 
     for mut button in &mut buttons {
-        button.enable().unwrap();
+        button.enable()?;
     }
 
     future::pending().await

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -1,18 +1,19 @@
 #![no_std]
 
 use libtock::gpio::GpioPinUnitialized;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
 // Example works on P0.03
-async fn main() {
+async fn main() -> TockResult<()> {
     let pin = GpioPinUnitialized::new(0);
-    let pin = pin.open_for_write().unwrap();
+    let pin = pin.open_for_write()?;
 
     loop {
-        pin.set_high();
-        timer::sleep(Duration::from_ms(500)).await;
-        pin.set_low();
-        timer::sleep(Duration::from_ms(500)).await;
+        pin.set_high()?;
+        timer::sleep(Duration::from_ms(500)).await?;
+        pin.set_low()?;
+        timer::sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -2,22 +2,24 @@
 
 use core::fmt::Write;
 use libtock::console::Console;
-use libtock::gpio::{GpioPinUnitialized, InputMode};
+use libtock::gpio::GpioPinUnitialized;
+use libtock::gpio::InputMode;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
 // example works on p0.03
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
     let pin = GpioPinUnitialized::new(0);
-    let pin = pin.open_for_read(None, InputMode::PullDown).unwrap();
+    let pin = pin.open_for_read(None, InputMode::PullDown)?;
 
     loop {
         if pin.read() {
-            writeln!(console, "true").unwrap();
+            writeln!(console, "true")?;
         } else {
-            writeln!(console, "false").unwrap();
+            writeln!(console, "false")?;
         }
-        timer::sleep(Duration::from_ms(500)).await;
+        timer::sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,14 +2,17 @@
 
 use core::fmt::Write;
 use libtock::console::Console;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
 
     for i in 0.. {
-        writeln!(console, "Hello world! {}", i).unwrap();
-        timer::sleep(Duration::from_ms(500)).await;
+        writeln!(console, "Hello world! {}", i)?;
+        timer::sleep(Duration::from_ms(500)).await?;
     }
+
+    Ok(())
 }

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-async fn main() {
+use libtock::result::TockResult;
+
+async fn main() -> TockResult<()> {
     let _ = libtock::LibTock {};
     panic!("Bye world!");
 }

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -2,21 +2,22 @@
 
 use core::fmt::Write;
 use libtock::console::Console;
+use libtock::result::TockResult;
 use libtock::sensors::*;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
     let mut humidity = HumiditySensor;
     let mut temperature = TemperatureSensor;
     let mut light = AmbientLightSensor;
     let mut ninedof = unsafe { Ninedof::new() };
     loop {
-        writeln!(console, "Humidity:    {}\n", humidity.read()).unwrap();
-        writeln!(console, "Temperature: {}\n", temperature.read()).unwrap();
-        writeln!(console, "Light:       {}\n", light.read()).unwrap();
-        writeln!(console, "Accel:       {}\n", ninedof.read_acceleration()).unwrap();
-        timer::sleep(Duration::from_ms(500)).await;
+        writeln!(console, "Humidity:    {}\n", humidity.read()?)?;
+        writeln!(console, "Temperature: {}\n", temperature.read()?)?;
+        writeln!(console, "Light:       {}\n", light.read()?)?;
+        writeln!(console, "Accel:       {}\n", ninedof.read_acceleration()?)?;
+        timer::sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/seven_segment.rs
+++ b/examples/seven_segment.rs
@@ -2,6 +2,7 @@
 
 use libtock::electronics::ShiftRegister;
 use libtock::gpio::GpioPinUnitialized;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
@@ -22,17 +23,17 @@ fn number_to_bits(n: u8) -> [bool; 8] {
 }
 
 // Example works on a shift register on P0.03, P0.04, P0.28
-async fn main() {
+async fn main() -> TockResult<()> {
     let shift_register = ShiftRegister::new(
-        GpioPinUnitialized::new(0).open_for_write().unwrap(),
-        GpioPinUnitialized::new(1).open_for_write().unwrap(),
-        GpioPinUnitialized::new(2).open_for_write().unwrap(),
+        GpioPinUnitialized::new(0).open_for_write()?,
+        GpioPinUnitialized::new(1).open_for_write()?,
+        GpioPinUnitialized::new(2).open_for_write()?,
     );
 
     let mut i = 0;
     loop {
         i = (i + 1) % 11;
-        shift_register.write_bits(&number_to_bits(i));
-        timer::sleep(Duration::from_ms(200)).await;
+        shift_register.write_bits(&number_to_bits(i))?;
+        timer::sleep(Duration::from_ms(200)).await?;
     }
 }

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -3,6 +3,7 @@
 use libtock::ble_composer;
 use libtock::ble_composer::BlePayload;
 use libtock::led;
+use libtock::result::TockResult;
 use libtock::simple_ble::BleAdvertisingDriver;
 use libtock::timer;
 use libtock::timer::Duration;
@@ -14,7 +15,7 @@ struct LedCommand {
     pub st: bool,
 }
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let led = led::get(0).unwrap();
 
     let uuid: [u8; 2] = [0x00, 0x18];
@@ -39,12 +40,12 @@ async fn main() {
         .unwrap();
     gap_payload.add_service_payload([91, 79], &payload).unwrap();
 
-    let _handle = BleAdvertisingDriver::initialize(100, &gap_payload, &mut buffer).unwrap();
+    let _handle = BleAdvertisingDriver::initialize(100, &gap_payload, &mut buffer);
 
     loop {
-        led.on();
-        timer::sleep(Duration::from_ms(500)).await;
-        led.off();
-        timer::sleep(Duration::from_ms(500)).await;
+        led.on()?;
+        timer::sleep(Duration::from_ms(500)).await?;
+        led.off()?;
+        timer::sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -2,10 +2,11 @@
 
 use core::fmt::Write;
 use libtock::console::Console;
+use libtock::result::TockResult;
 use libtock::temperature;
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
-    let temperature = temperature::measure_temperature().await;
-    writeln!(console, "Temperature: {}", temperature).unwrap();
+    let temperature = temperature::measure_temperature().await?;
+    writeln!(console, "Temperature: {}", temperature).map_err(Into::into)
 }

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -3,10 +3,11 @@
 use core::fmt::Write;
 use futures::future;
 use libtock::console::Console;
+use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() {
+async fn main() -> TockResult<()> {
     let mut console = Console::new();
 
     let mut with_callback = timer::with_callback(|_, _| {
@@ -17,8 +18,8 @@ async fn main() {
         .unwrap();
     });
 
-    let mut timer = with_callback.init().unwrap();
-    timer.set_alarm(Duration::from_ms(2000)).unwrap();
+    let mut timer = with_callback.init()?;
+    timer.set_alarm(Duration::from_ms(2000))?;
 
     future::pending().await
 }

--- a/src/debug/low_level_debug.rs
+++ b/src/debug/low_level_debug.rs
@@ -16,19 +16,19 @@ mod command_nr {
 /// code. If the capsule is not present, this is a no-op.
 #[inline(always)] // Improve reliability for relocation issues
 pub fn low_level_status_code(code: usize) {
-    syscalls::command1_insecure(DRIVER_NUMBER, command_nr::ALERT_CODE, code);
+    let _ = syscalls::command1_insecure(DRIVER_NUMBER, command_nr::ALERT_CODE, code);
 }
 
 /// Use the LowLevelDebug capsule (if present) to print a single number. If the
 /// capsule is not present, this is a no-op.
 #[inline(always)] // Improve reliability for relocation issues
 pub fn low_level_print1(value: usize) {
-    syscalls::command1_insecure(DRIVER_NUMBER, command_nr::PRINT1, value);
+    let _ = syscalls::command1_insecure(DRIVER_NUMBER, command_nr::PRINT1, value);
 }
 
 /// Use the LowLevelDebug capsule (if present) to print two numbers. If the
 /// capsule is not present, this is a no-op.
 #[inline(always)] // Improve reliability for relocation issues
 pub fn low_level_print2(value1: usize, value2: usize) {
-    syscalls::command(DRIVER_NUMBER, command_nr::PRINT2, value1, value2);
+    let _ = syscalls::command(DRIVER_NUMBER, command_nr::PRINT2, value1, value2);
 }

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -7,13 +7,13 @@ use crate::console::Console;
 
 pub fn println() {
     let buffer = [b'\n'];
-    Console::new().write(&buffer);
+    let _ = Console::new().write(&buffer);
 }
 
 pub fn print_as_hex(value: usize) {
     let mut buffer = [b'\n'; 11];
     write_as_hex(&mut buffer, value);
-    Console::new().write(buffer);
+    let _ = Console::new().write(buffer);
 }
 
 #[cfg(target_arch = "arm")]
@@ -24,7 +24,7 @@ pub fn print_stack_pointer() {
     let mut buffer = [b'\n'; 15];
     buffer[0..4].clone_from_slice(b"SP: ");
     write_as_hex(&mut buffer[4..15], stack_pointer);
-    Console::new().write(buffer);
+    let _ = Console::new().write(buffer);
 }
 
 #[cfg(target_arch = "riscv32")]
@@ -44,7 +44,7 @@ pub fn dump_address(address: *const usize) {
         }
     }
     buffer[27] = b'\n';
-    Console::new().write(&buffer);
+    let _ = Console::new().write(&buffer);
 }
 
 pub fn dump_memory(start_address: *const usize, count: isize) {

--- a/src/electronics/shift_register.rs
+++ b/src/electronics/shift_register.rs
@@ -1,4 +1,5 @@
 use crate::gpio::GpioPinWrite;
+use crate::result::TockResult;
 
 pub struct ShiftRegister {
     data_pin: GpioPinWrite,
@@ -19,25 +20,25 @@ impl ShiftRegister {
         }
     }
 
-    pub fn write_bits(&self, values: &[bool]) {
+    pub fn write_bits(&self, values: &[bool]) -> TockResult<()> {
         for i in values {
-            self.push_bit(*i);
+            self.push_bit(*i)?;
         }
-        self.display();
+        self.display()
     }
 
-    fn push_bit(&self, value: bool) {
+    fn push_bit(&self, value: bool) -> TockResult<()> {
         if value {
-            self.data_pin.set_high();
+            self.data_pin.set_high()
         } else {
-            self.data_pin.set_low();
-        }
-        self.clock_pin.set_high();
-        self.clock_pin.set_low();
+            self.data_pin.set_low()
+        }?;
+        self.clock_pin.set_high()?;
+        self.clock_pin.set_low()
     }
 
-    fn display(&self) {
-        self.latch_pin.set_high();
-        self.latch_pin.set_low();
+    fn display(&self) -> TockResult<()> {
+        self.latch_pin.set_high()?;
+        self.latch_pin.set_low()
     }
 }

--- a/src/entry_point.rs
+++ b/src/entry_point.rs
@@ -381,7 +381,7 @@ unsafe impl GlobalAlloc for TockAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         HEAP.allocate_first_fit(layout)
             .ok()
-            .map_or(0 as *mut u8, |allocation| allocation.as_ptr())
+            .map_or(ptr::null_mut(), NonNull::as_ptr)
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -19,6 +19,7 @@
 //! crate.
 
 use crate::led;
+use crate::result::TockError;
 use crate::timer;
 use crate::timer::Duration;
 use core::alloc::Layout;
@@ -41,10 +42,10 @@ pub trait Termination {
 
 impl<T> Termination for T
 where
-    T: Future<Output = ()>,
+    T: Future<Output = Result<(), TockError>>,
 {
     fn report(self) -> i32 {
-        unsafe { executor::block_on(self) };
+        let _ = unsafe { executor::block_on(self) };
         0
     }
 }
@@ -58,13 +59,13 @@ unsafe fn panic_handler(_info: &PanicInfo) -> ! {
     executor::block_on(async {
         loop {
             for led in led::all() {
-                led.on();
+                let _ = led.on();
             }
-            timer::sleep(Duration::from_ms(100)).await;
+            let _ = timer::sleep(Duration::from_ms(100)).await;
             for led in led::all() {
-                led.off();
+                let _ = led.off();
             }
-            timer::sleep(Duration::from_ms(100)).await;
+            let _ = timer::sleep(Duration::from_ms(100)).await;
         }
     });
     // Never type is not supported for T in Future
@@ -76,9 +77,9 @@ unsafe fn cycle_leds(_: Layout) -> ! {
     executor::block_on(async {
         loop {
             for led in led::all() {
-                led.on();
-                timer::sleep(Duration::from_ms(100)).await;
-                led.off();
+                let _ = led.on();
+                let _ = timer::sleep(Duration::from_ms(100)).await;
+                let _ = led.off();
             }
         }
     });

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,3 +1,4 @@
+use crate::result::TockResult;
 use crate::syscalls::command;
 
 const DRIVER_NUMBER: usize = 0x00002;
@@ -13,15 +14,13 @@ pub struct Led {
     led_num: usize,
 }
 
-pub fn count() -> isize {
-    command(DRIVER_NUMBER, command_nr::COUNT, 0, 0)
+pub fn count() -> TockResult<usize> {
+    command(DRIVER_NUMBER, command_nr::COUNT, 0, 0).map_err(Into::into)
 }
 
-pub fn get(led_num: isize) -> Option<Led> {
-    if led_num >= 0 && led_num < count() {
-        Some(Led {
-            led_num: led_num as usize,
-        })
+pub fn get(led_num: usize) -> Option<Led> {
+    if led_num < count().ok().unwrap() {
+        Some(Led { led_num })
     } else {
         None
     }
@@ -30,12 +29,12 @@ pub fn get(led_num: isize) -> Option<Led> {
 pub fn all() -> LedIter {
     LedIter {
         curr_led: 0,
-        led_count: count() as usize,
+        led_count: count().ok().unwrap(),
     }
 }
 
 impl Led {
-    pub fn set_state(&self, state: bool) {
+    pub fn set_state(&self, state: bool) -> TockResult<()> {
         if state {
             self.on()
         } else {
@@ -43,16 +42,19 @@ impl Led {
         }
     }
 
-    pub fn on(&self) {
-        command(DRIVER_NUMBER, command_nr::ON, self.led_num, 0);
+    pub fn on(&self) -> TockResult<()> {
+        command(DRIVER_NUMBER, command_nr::ON, self.led_num, 0)?;
+        Ok(())
     }
 
-    pub fn off(&self) {
-        command(DRIVER_NUMBER, command_nr::OFF, self.led_num, 0);
+    pub fn off(&self) -> TockResult<()> {
+        command(DRIVER_NUMBER, command_nr::OFF, self.led_num, 0)?;
+        Ok(())
     }
 
-    pub fn toggle(&self) {
-        command(DRIVER_NUMBER, command_nr::TOGGLE, self.led_num, 0);
+    pub fn toggle(&self) -> TockResult<()> {
+        command(DRIVER_NUMBER, command_nr::TOGGLE, self.led_num, 0)?;
+        Ok(())
     }
 }
 

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,6 +1,8 @@
 use crate::futures;
+use crate::result::TockResult;
 use crate::syscalls;
 use core::cell::Cell;
+use core::mem;
 
 const DRIVER_NUMBER: usize = 0x40001;
 
@@ -16,13 +18,10 @@ mod allow_nr {
     pub const SHARE_BUFFER: usize = 0;
 }
 
-pub async fn fill_buffer(buf: &mut [u8]) -> bool {
+pub async fn fill_buffer(buf: &mut [u8]) -> TockResult<()> {
     let buf_len = buf.len();
 
-    let result = syscalls::allow(DRIVER_NUMBER, allow_nr::SHARE_BUFFER, buf);
-    if result.is_err() {
-        return false;
-    }
+    let shared_memory = syscalls::allow(DRIVER_NUMBER, allow_nr::SHARE_BUFFER, buf)?;
 
     let is_filled = Cell::new(false);
     let mut is_filled_alarm = |_, _, _| is_filled.set(true);
@@ -30,16 +29,14 @@ pub async fn fill_buffer(buf: &mut [u8]) -> bool {
         DRIVER_NUMBER,
         subscribe_nr::BUFFER_FILLED,
         &mut is_filled_alarm,
-    );
-    if subscription.is_err() {
-        return false;
-    }
+    )?;
 
-    let result_code = syscalls::command(DRIVER_NUMBER, command_nr::REQUEST_RNG, buf_len, 0);
-    if result_code < 0 {
-        return false;
-    }
+    syscalls::command(DRIVER_NUMBER, command_nr::REQUEST_RNG, buf_len, 0)?;
 
     futures::wait_until(|| is_filled.get()).await;
-    true
+
+    mem::drop(subscription);
+    mem::drop(shared_memory);
+
+    Ok(())
 }

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -8,6 +8,9 @@ mod platform;
 
 use crate::callback::CallbackSubscription;
 use crate::callback::SubscribableCallback;
+use crate::result::AllowError;
+use crate::result::CommandError;
+use crate::result::SubscribeError;
 use crate::shared_memory::SharedMemory;
 
 pub mod raw {
@@ -34,7 +37,7 @@ pub fn subscribe<CB: SubscribableCallback>(
     driver_number: usize,
     subscribe_number: usize,
     callback: &mut CB,
-) -> Result<CallbackSubscription, isize> {
+) -> Result<CallbackSubscription, SubscribeError> {
     extern "C" fn c_callback<CB: SubscribableCallback>(
         arg1: usize,
         arg2: usize,
@@ -45,20 +48,13 @@ pub fn subscribe<CB: SubscribableCallback>(
         callback.call_rust(arg1, arg2, arg3);
     }
 
-    let return_code = {
-        subscribe_fn(
-            driver_number,
-            subscribe_number,
-            c_callback::<CB>,
-            callback as *mut CB as usize,
-        )
-    };
-
-    if return_code == 0 {
-        Ok(CallbackSubscription::new(driver_number, subscribe_number))
-    } else {
-        Err(return_code)
-    }
+    subscribe_fn(
+        driver_number,
+        subscribe_number,
+        c_callback::<CB>,
+        callback as *mut CB as usize,
+    )
+    .map(|_| CallbackSubscription::new(driver_number, subscribe_number))
 }
 
 pub fn subscribe_fn(
@@ -66,41 +62,81 @@ pub fn subscribe_fn(
     subscribe_number: usize,
     callback: extern "C" fn(usize, usize, usize, usize),
     userdata: usize,
-) -> isize {
-    unsafe {
+) -> Result<(), SubscribeError> {
+    let return_code = unsafe {
         raw::subscribe(
             driver_number,
             subscribe_number,
             callback as *const _,
             userdata,
         )
+    };
+
+    if return_code == 0 {
+        Ok(())
+    } else {
+        Err(SubscribeError {
+            driver_number,
+            subscribe_number,
+            return_code,
+        })
     }
 }
 
-pub fn command(driver_number: usize, command_number: usize, arg1: usize, arg2: usize) -> isize {
-    unsafe { raw::command(driver_number, command_number, arg1, arg2) }
+pub fn command(
+    driver_number: usize,
+    command_number: usize,
+    arg1: usize,
+    arg2: usize,
+) -> Result<usize, CommandError> {
+    let return_code = unsafe { raw::command(driver_number, command_number, arg1, arg2) };
+    if return_code >= 0 {
+        Ok(return_code as usize)
+    } else {
+        Err(CommandError {
+            driver_number,
+            command_number,
+            arg1,
+            arg2,
+            return_code,
+        })
+    }
 }
 
-// command1_insecure, is a variant of command() that only sets the first
-// argument in the system call interface. It has the benefit of generating
-// simpler assembly than command(), but it leaves the second argument's register
-// as-is which leaks it to the kernel driver being called. Prefer to use
-// command() instead of command1_insecure(), unless the benefit of generating
-// simpler assembly outweighs the drawbacks of potentially leaking arbitrary
-// information to the driver you are calling.
-//
-// At the moment, the only suitable use case for command1_insecure is the low
-// level debug interface.
-
-pub fn command1_insecure(driver_number: usize, command_number: usize, arg: usize) -> isize {
-    unsafe { raw::command1(driver_number, command_number, arg) }
+/// [command1_insecure()] is a variant of [command()] that only sets the first
+/// argument in the system call interface. It has the benefit of generating
+/// simpler assembly than [command()], but it leaves the second argument's register
+/// as-is which leaks it to the kernel driver being called. Prefer to use
+/// [command()] instead of [command1_insecure()], unless the benefit of generating
+/// simpler assembly outweighs the drawbacks of potentially leaking arbitrary
+/// information to the driver you are calling.
+///
+/// At the moment, the only suitable use case for [command1_insecure()] is the low
+/// level debug interface.
+pub fn command1_insecure(
+    driver_number: usize,
+    command_number: usize,
+    arg: usize,
+) -> Result<usize, CommandError> {
+    let return_code = unsafe { raw::command1(driver_number, command_number, arg) };
+    if return_code >= 0 {
+        Ok(return_code as usize)
+    } else {
+        Err(CommandError {
+            driver_number,
+            command_number,
+            arg1: arg,
+            arg2: 0,
+            return_code,
+        })
+    }
 }
 
 pub fn allow(
     driver_number: usize,
     allow_number: usize,
     buffer_to_share: &mut [u8],
-) -> Result<SharedMemory, isize> {
+) -> Result<SharedMemory, AllowError> {
     let len = buffer_to_share.len();
     let return_code = unsafe {
         raw::allow(
@@ -117,6 +153,10 @@ pub fn allow(
             buffer_to_share,
         ))
     } else {
-        Err(return_code)
+        Err(AllowError {
+            driver_number,
+            allow_number,
+            return_code,
+        })
     }
 }


### PR DESCRIPTION
This PR consolidates the error handling of almost the entire code base. Every high-level syscall function now returns a `Result` containing information about whether the call was unsuccessful and, if yes, which parameters were sent to the kernel.

All errors can be mapped to the common error type `TockResult`. This type does not implement `Debug` in order to keep the binary size reasonably small.