### PR TITLE
Re-enable support for synchronous main functions and fix `panic!()` in boards with no LED capsule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 0.2.0 (WIP)
 
-- Many functions, including `main()`, are asynchronous
+- Many functions are asynchronous
   - To retrieve the value of an asynchronous `value`, use `value.await`
   - This is only possible within an `async fn`, so either
     - Make the caller `fn` of `.await` an `async fn`
     - Not recommended: Use `core::executor::block_on(value)` to retrieve the `value`
+  - `async_main!` is provided for applications that want to have an `async`
+    `main()`
 - `syscalls::yieldk_for` is no longer available
   - Yielding manually is discouraged as it conflicts with Rust's safety guarantees. If you need to wait for a condition, use `futures::wait_until` and `.await`.
 - `syscalls::yieldk` has become `unsafe` for the same reason

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The boiler plate code you would write is
 
 use libtock::result::TockResult;
 
-async fn main() -> TockResult<()> {
+fn main() {
   // Your code
 }
 ```
@@ -89,6 +89,16 @@ This script does the following steps for you:
  - cross-compile your program
  - create a TAB (tock application bundle)
  - if you have a nRF52-DK board connected: flash this TAB to your board (using tockloader)
+
+If you would like your `main()` to be `async`, you can wrap it using
+`libtock::async_main!`:
+```rust
+#![no_std]
+
+libtock::async_main!(async_main);
+async fn async_main() {
+}
+```
 
 ## Running the Integration Tests
 Having an nRF52-DK board at hand, integration tests can be run using `./run_hardware_tests.sh`.

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -8,7 +8,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let mut with_callback = adc::with_callback(|channel: usize, value: usize| {
         writeln!(console, "channel: {}, value: {}", channel, value).unwrap();

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -7,7 +7,8 @@ use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let mut with_callback = adc::with_callback(|channel: usize, value: usize| {
         writeln!(console, "channel: {}, value: {}", channel, value).unwrap();

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -7,8 +7,12 @@ use libtock::console::Console;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
+fn main() {
+    let _ = main_impl();
+}
+
 /// Reads a 128 byte sample into a buffer and prints the first value to the console.
-fn main() -> TockResult<()> {
+fn main_impl() -> TockResult<()> {
     let mut console = Console::new();
     let mut adc_buffer = AdcBuffer::new();
     let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -8,7 +8,8 @@ use libtock::result::TockResult;
 use libtock::syscalls;
 
 /// Reads a 128 byte sample into a buffer and prints the first value to the console.
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let mut adc_buffer = AdcBuffer::new();
     let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -7,12 +7,8 @@ use libtock::console::Console;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
-fn main() {
-    let _ = main_impl();
-}
-
 /// Reads a 128 byte sample into a buffer and prints the first value to the console.
-fn main_impl() -> TockResult<()> {
+fn main() -> TockResult<()> {
     let mut console = Console::new();
     let mut adc_buffer = AdcBuffer::new();
     let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -8,8 +8,7 @@ use libtock::result::TockResult;
 use libtock::syscalls;
 
 /// Reads a 128 byte sample into a buffer and prints the first value to the console.
-libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+fn main() -> TockResult<()> {
     let mut console = Console::new();
     let mut adc_buffer = AdcBuffer::new();
     let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -10,7 +10,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     future::try_join(blink_periodically(), blink_on_button_press()).await?;
     Ok(())
 }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -9,7 +9,8 @@ use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     future::try_join(blink_periodically(), blink_on_button_press()).await?;
     Ok(())
 }

--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -15,7 +15,8 @@ struct LedCommand {
     pub st: bool,
 }
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut shared_buffer = BleDriver::create_scan_buffer();
     let mut my_buffer = BleDriver::create_scan_buffer();
     let shared_memory = BleDriver::share_memory(&mut shared_buffer)?;

--- a/examples/ble_scanning.rs
+++ b/examples/ble_scanning.rs
@@ -16,7 +16,7 @@ struct LedCommand {
 }
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut shared_buffer = BleDriver::create_scan_buffer();
     let mut my_buffer = BleDriver::create_scan_buffer();
     let shared_memory = BleDriver::share_memory(&mut shared_buffer)?;

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -5,7 +5,8 @@ use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let num_leds = led::count()?;
 
     // Blink the LEDs in a binary count pattern and scale

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -6,7 +6,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let num_leds = led::count()?;
 
     // Blink the LEDs in a binary count pattern and scale

--- a/examples/blink_random.rs
+++ b/examples/blink_random.rs
@@ -7,7 +7,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let num_leds = led::count().ok().unwrap();
     // blink_nibble assumes 4 leds.
     assert_eq!(num_leds, 4);

--- a/examples/blink_random.rs
+++ b/examples/blink_random.rs
@@ -6,7 +6,8 @@ use libtock::rng;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let num_leds = led::count().ok().unwrap();
     // blink_nibble assumes 4 leds.
     assert_eq!(num_leds, 4);

--- a/examples/button_leds.rs
+++ b/examples/button_leds.rs
@@ -7,7 +7,7 @@ use libtock::led;
 use libtock::result::TockResult;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {
         match state {
             ButtonState::Pressed => led::get(button_num).unwrap().toggle().ok().unwrap(),

--- a/examples/button_leds.rs
+++ b/examples/button_leds.rs
@@ -6,7 +6,8 @@ use libtock::buttons::ButtonState;
 use libtock::led;
 use libtock::result::TockResult;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {
         match state {
             ButtonState::Pressed => led::get(button_num).unwrap().toggle().ok().unwrap(),

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -8,7 +8,8 @@ use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let mut with_callback = buttons::with_callback(|_, _| {});
     let mut buttons = with_callback.init()?;

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -9,7 +9,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let mut with_callback = buttons::with_callback(|_, _| {});
     let mut buttons = with_callback.init()?;

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -8,7 +8,8 @@ use libtock::console::Console;
 use libtock::result::TockResult;
 
 // FIXME: Hangs up when buttons are pressed rapidly. Yielding in callback leads to stack overflow.
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
 
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -9,7 +9,7 @@ use libtock::result::TockResult;
 
 // FIXME: Hangs up when buttons are pressed rapidly. Yielding in callback leads to stack overflow.
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
 
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -6,7 +6,8 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 // Example works on P0.03
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let pin = GpioPinUnitialized::new(0);
     let pin = pin.open_for_write()?;
 

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -7,7 +7,7 @@ use libtock::timer::Duration;
 
 // Example works on P0.03
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let pin = GpioPinUnitialized::new(0);
     let pin = pin.open_for_write()?;
 

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -10,7 +10,7 @@ use libtock::timer::Duration;
 
 // example works on p0.03
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let pin = GpioPinUnitialized::new(0);
     let pin = pin.open_for_read(None, InputMode::PullDown)?;

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -9,7 +9,8 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 // example works on p0.03
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let pin = GpioPinUnitialized::new(0);
     let pin = pin.open_for_read(None, InputMode::PullDown)?;

--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -32,7 +32,7 @@ impl MyTrait for String {
 }
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     write!(console, "[test-results]\n").unwrap();
 

--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -31,7 +31,8 @@ impl MyTrait for String {
     }
 }
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     write!(console, "[test-results]\n").unwrap();
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -7,7 +7,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
 
     for i in 0.. {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -6,7 +6,8 @@ use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
 
     for i in 0.. {

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -2,7 +2,8 @@
 
 use libtock::result::TockResult;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let _ = libtock::LibTock {};
     panic!("Bye world!");
 }

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -2,7 +2,7 @@
 
 use libtock::result::TockResult;
 
-fn main() -> TockResult<()> {
+fn main() {
     let _ = libtock::LibTock {};
     panic!("Bye world!");
 }

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-use libtock::result::TockResult;
-
 fn main() {
     let _ = libtock::LibTock {};
     panic!("Bye world!");

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -2,8 +2,7 @@
 
 use libtock::result::TockResult;
 
-libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+fn main() -> TockResult<()> {
     let _ = libtock::LibTock {};
     panic!("Bye world!");
 }

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -8,7 +8,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let mut humidity = HumiditySensor;
     let mut temperature = TemperatureSensor;

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -7,7 +7,8 @@ use libtock::sensors::*;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let mut humidity = HumiditySensor;
     let mut temperature = TemperatureSensor;

--- a/examples/seven_segment.rs
+++ b/examples/seven_segment.rs
@@ -23,7 +23,8 @@ fn number_to_bits(n: u8) -> [bool; 8] {
 }
 
 // Example works on a shift register on P0.03, P0.04, P0.28
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let shift_register = ShiftRegister::new(
         GpioPinUnitialized::new(0).open_for_write()?,
         GpioPinUnitialized::new(1).open_for_write()?,

--- a/examples/seven_segment.rs
+++ b/examples/seven_segment.rs
@@ -24,7 +24,7 @@ fn number_to_bits(n: u8) -> [bool; 8] {
 
 // Example works on a shift register on P0.03, P0.04, P0.28
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let shift_register = ShiftRegister::new(
         GpioPinUnitialized::new(0).open_for_write()?,
         GpioPinUnitialized::new(1).open_for_write()?,

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -15,7 +15,8 @@ struct LedCommand {
     pub st: bool,
 }
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let led = led::get(0).unwrap();
 
     let uuid: [u8; 2] = [0x00, 0x18];

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -16,7 +16,7 @@ struct LedCommand {
 }
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let led = led::get(0).unwrap();
 
     let uuid: [u8; 2] = [0x00, 0x18];

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -6,7 +6,7 @@ use libtock::result::TockResult;
 use libtock::temperature;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let temperature = temperature::measure_temperature().await?;
     writeln!(console, "Temperature: {}", temperature).map_err(Into::into)

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -5,7 +5,8 @@ use libtock::console::Console;
 use libtock::result::TockResult;
 use libtock::temperature;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
     let temperature = temperature::measure_temperature().await?;
     writeln!(console, "Temperature: {}", temperature).map_err(Into::into)

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -8,7 +8,7 @@ use libtock::timer;
 use libtock::timer::Duration;
 
 libtock::async_main!(async_main);
-fn async_main() -> TockResult<()> {
+async fn async_main() -> TockResult<()> {
     let mut console = Console::new();
 
     let mut with_callback = timer::with_callback(|_, _| {

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -7,7 +7,8 @@ use libtock::result::TockResult;
 use libtock::timer;
 use libtock::timer::Duration;
 
-async fn main() -> TockResult<()> {
+libtock::async_main!(async_main);
+fn async_main() -> TockResult<()> {
     let mut console = Console::new();
 
     let mut with_callback = timer::with_callback(|_, _| {

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -27,3 +27,23 @@ impl<T, F: Fn() -> Option<T>> Future for WaitForValue<F> {
         }
     }
 }
+
+/// Generates a synchronous `main()` function that calls the provided
+/// asynchronous function. To avoid name conflicts, the asynchronous function
+/// must not be called `main()`; `async_main()` is fine.
+///
+/// Example:
+///     libtock::async_main!(async_main);
+///     async fn async_main() {
+///         // Snipped
+///     }
+#[macro_export]
+macro_rules! async_main {
+    ($main_name:ident) => {
+        fn main() {
+            unsafe {
+                ::core::executor::block_on($main_name());
+            }
+        }
+    };
+}

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -41,6 +41,7 @@ impl<T, F: Fn() -> Option<T>> Future for WaitForValue<F> {
 macro_rules! async_main {
     ($main_name:ident) => {
         fn main() {
+            use ::libtock::lang_items::Termination;
             static mut MAIN_INVOKED: bool = false;
             unsafe {
                 // core::executor::block_on is unsafe and documented as being
@@ -53,11 +54,7 @@ macro_rules! async_main {
                 }
                 MAIN_INVOKED = true;
 
-                // TODO: We would like to be able to handle errors, but doing so
-                // is nontrivial. In particular, it is not obvious how errors
-                // should be displayed. In the meantime, we silence the "unused
-                // Result" warning.
-                let _ = ::core::executor::block_on($main_name());
+                ::core::executor::block_on($main_name()).report();
             }
         }
     };

--- a/src/led.rs
+++ b/src/led.rs
@@ -26,10 +26,12 @@ pub fn get(led_num: usize) -> Option<Led> {
     }
 }
 
+/// Returns an iterator over all available LEDs. If the LED driver is not
+/// present, the iterator will be empty.
 pub fn all() -> LedIter {
     LedIter {
         curr_led: 0,
-        led_count: count().ok().unwrap(),
+        led_count: count().unwrap_or(0),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod unwind_symbols;
 pub mod entry_point;
 
 #[cfg(any(target_arch = "arm", target_arch = "riscv32"))]
-mod lang_items;
+pub mod lang_items;
 
 pub mod syscalls;
 


### PR DESCRIPTION
This breaks the existing support for `async` `main()` functions. Instead, an `async_main!()` macro is provided to generate a synchronous `main()` that wraps the provided `async` `main()` function (which, unfortunately, must not be called `main()`).

I would prefer to be more consistent with Tokio and use a procedural macro attribute (as was originally done in #104), but I found that has some significant drawbacks:
  1. If main() does not parse, the error message does not point to the correct code.
  2. It adds a requirement to update `syn` every time the toolchain is updated.

These drawbacks are elaborated upon in #111.

This solves #111 and #113.