### PR TITLE
Fix src/led.rs so panic!() doesn't infinitely recurse if the LED driver is unavailable.

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -14,7 +14,7 @@ use syn::ItemFn;
 /// `main()`. In other words, this will not compile with libtock-rs:
 ///     async fn main() {}
 /// and this will:
-///     #[async_main]
+///     #[libtock::main]
 ///     async fn main() {}
 #[proc_macro_attribute]
 pub fn main(_: TokenStream, input: TokenStream) -> TokenStream {

--- a/src/led.rs
+++ b/src/led.rs
@@ -26,10 +26,12 @@ pub fn get(led_num: usize) -> Option<Led> {
     }
 }
 
+/// Returns an iterator over all available LEDs. If the LED driver is not
+/// present, the iterator will be empty.
 pub fn all() -> LedIter {
     LedIter {
         curr_led: 0,
-        led_count: count().ok().unwrap(),
+        led_count: count().unwrap_or(0),
     }
 }
 


### PR DESCRIPTION
Currently, the LED interface calls `panic!` (via `unwrap`) if the LED driver crate is not available on the board. This panic-in-panic recurses until the program faults (stack overflow).

This tweak makes the LED interface more robust, treating a board with no LED syscall driver as if it has 0 LEDs.

This also fixes a stale comment from #115.