### PR TITLE
Fix some old toolchain problems

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -12,3 +12,15 @@ rustflags = [
   "-C", "relocation-model=static",
   "-D", "warnings",
 ]
+
+# Target configuration for the travis CI Linux build
+[target.x86_64-unknown-linux-gnu]
+rustflags = [
+  "-D", "warnings",
+]
+
+# Target configuration for the travis CI OS-X build
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-D", "warnings",
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ install:
 
 script:
   - cargo fmt --all -- --check
-  - cargo test --lib --all
+  - cargo test --workspace
   - ./build_examples.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
     "editor.formatOnSave": true,
-    "rust.target": "thumbv7em-none-eabi",
-    "rust.all_targets": false,
+    "rust.all_targets": true,
 }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -12,10 +12,18 @@ use syn::ItemFn;
 /// Procedural attribute macro. This is meant to be applied to a binary's async
 /// `main()`, transforming into a function that returns a type acceptable for
 /// `main()`. In other words, this will not compile with libtock-rs:
-///     async fn main() {}
+/// ```ignore
+/// async fn main() {
+///     // async code
+/// }
+/// ```
 /// and this will:
-///     #[libtock::main]
-///     async fn main() {}
+/// ```ignore
+/// #[libtock::main]
+/// async fn main() {
+///     // async code
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn main(_: TokenStream, input: TokenStream) -> TokenStream {
     generate_main_wrapped(input.into()).into()

--- a/src/ble_composer.rs
+++ b/src/ble_composer.rs
@@ -78,7 +78,7 @@ mod test {
     #[test]
     fn test_add() {
         let mut pld = BlePayload::new();
-        pld.add(1, &[2]);
+        pld.add(1, &[2]).unwrap();
         assert_eq!(pld.as_ref().len(), 3);
         assert_eq!(pld.as_ref(), &mut [2, 1, 2])
     }
@@ -86,15 +86,15 @@ mod test {
     #[test]
     fn test_add_service_payload() {
         let mut pld = BlePayload::new();
-        pld.add_service_payload([1, 2], &[2]);
+        pld.add_service_payload([1, 2], &[2]).unwrap();
         assert_eq!(pld.as_ref(), &[4, 0x16, 1, 2, 2])
     }
 
     #[test]
     fn test_add_service_payload_two_times() {
         let mut pld = BlePayload::new();
-        pld.add_service_payload([1, 2], &[2]);
-        pld.add_service_payload([1, 2], &[2, 3]);
+        pld.add_service_payload([1, 2], &[2]).unwrap();
+        pld.add_service_payload([1, 2], &[2, 3]).unwrap();
 
         assert_eq!(pld.as_ref(), &[4, 0x16, 1, 2, 2, 5, 0x16, 1, 2, 2, 3])
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,7 @@
     naked_functions,
     ptr_offset_from
 )]
-#![no_std]
-
-extern crate alloc;
+#![cfg_attr(any(target_arch = "arm", target_arch = "riscv32"), no_std)]
 
 mod callback;
 
@@ -31,7 +29,6 @@ pub mod simple_ble;
 pub mod temperature;
 pub mod timer;
 pub mod unwind_symbols;
-pub use libtock_codegen::main;
 
 #[cfg(any(target_arch = "arm", target_arch = "riscv32"))]
 pub mod entry_point;
@@ -40,6 +37,8 @@ pub mod entry_point;
 mod lang_items;
 
 pub mod syscalls;
+
+pub use libtock_codegen::main;
 
 // Dummy structure to force importing the panic_handler and other no_std elements when nothing else
 // is imported.

--- a/src/result.rs
+++ b/src/result.rs
@@ -11,6 +11,13 @@ pub enum TockError {
     Other(OtherError),
 }
 
+#[cfg(not(any(target_arch = "arm", target_arch = "riscv32")))]
+impl core::fmt::Debug for TockError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "impl Debug only for test builds")
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct SubscribeError {
     pub driver_number: usize,

--- a/src/temperature.rs
+++ b/src/temperature.rs
@@ -51,8 +51,6 @@ impl Display for Temperature {
 #[cfg(test)]
 mod test {
     use super::*;
-    use alloc::string::String;
-    use alloc::string::ToString;
 
     #[test]
     fn render_temperature() {


### PR DESCRIPTION
This PR
- Fixes `cargo test`
- Enables the `--all-targets` flag for VSCode. This means, examples and tests will be checked on-the-fly.
- Makes travis complain if there are unfixed warnings
