### PR TITLE
Add a ReturnCode enum instead of manipulating isize codes.

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -15,7 +15,7 @@ pub enum TockError {
 pub struct SubscribeError {
     pub driver_number: usize,
     pub subscribe_number: usize,
-    pub return_code: isize,
+    pub return_code: ReturnCode,
 }
 
 impl From<SubscribeError> for TockError {
@@ -30,7 +30,7 @@ pub struct CommandError {
     pub command_number: usize,
     pub arg1: usize,
     pub arg2: usize,
-    pub return_code: isize,
+    pub return_code: ReturnCode,
 }
 
 impl From<CommandError> for TockError {
@@ -43,7 +43,7 @@ impl From<CommandError> for TockError {
 pub struct AllowError {
     pub driver_number: usize,
     pub allow_number: usize,
-    pub return_code: isize,
+    pub return_code: ReturnCode,
 }
 
 impl From<AllowError> for TockError {
@@ -70,10 +70,29 @@ impl From<OtherError> for TockError {
     }
 }
 
-pub const SUCCESS: isize = 0;
-pub const FAIL: isize = -1;
-pub const EBUSY: isize = -2;
-pub const EALREADY: isize = -3;
-pub const EINVAL: isize = -6;
-pub const ESIZE: isize = -7;
-pub const ENOMEM: isize = -9;
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum ReturnCode {
+    SUCCESS,
+    FAIL,
+    EBUSY,
+    EALREADY,
+    EINVAL,
+    ESIZE,
+    ENOMEM,
+    UNKNOWN(isize),
+}
+
+impl From<isize> for ReturnCode {
+    fn from(return_code: isize) -> Self {
+        match return_code {
+            0 => ReturnCode::SUCCESS,
+            -1 => ReturnCode::FAIL,
+            -2 => ReturnCode::EBUSY,
+            -3 => ReturnCode::EALREADY,
+            -6 => ReturnCode::EINVAL,
+            -7 => ReturnCode::ESIZE,
+            -9 => ReturnCode::ENOMEM,
+            _ => ReturnCode::UNKNOWN(return_code),
+        }
+    }
+}

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -10,6 +10,7 @@ use crate::callback::CallbackSubscription;
 use crate::callback::SubscribableCallback;
 use crate::result::AllowError;
 use crate::result::CommandError;
+use crate::result::ReturnCode;
 use crate::result::SubscribeError;
 use crate::shared_memory::SharedMemory;
 
@@ -71,8 +72,9 @@ pub fn subscribe_fn(
             userdata,
         )
     };
+    let return_code = ReturnCode::from(return_code);
 
-    if return_code == 0 {
+    if return_code == ReturnCode::SUCCESS {
         Ok(())
     } else {
         Err(SubscribeError {
@@ -98,7 +100,7 @@ pub fn command(
             command_number,
             arg1,
             arg2,
-            return_code,
+            return_code: ReturnCode::from(return_code),
         })
     }
 }
@@ -127,7 +129,7 @@ pub fn command1_insecure(
             command_number,
             arg1: arg,
             arg2: 0,
-            return_code,
+            return_code: ReturnCode::from(return_code),
         })
     }
 }
@@ -146,7 +148,9 @@ pub fn allow(
             len,
         )
     };
-    if return_code == 0 {
+    let return_code = ReturnCode::from(return_code);
+
+    if return_code == ReturnCode::SUCCESS {
         Ok(SharedMemory::new(
             driver_number,
             allow_number,


### PR DESCRIPTION
This gives more typing to the syscall errors, and should make the code cleaner and less error-prone by forcing users to use the enumerated code instead of manually re-defining their own constants or using raw isize values.