### PR TITLE
Add bors integration for libtock-rs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+
 language: rust
 rust:
   - nightly-2019-11-06

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# PR Workflow
+
+We use the bors-ng bot to merge PRs. In short, when someone replies `bors r+`,
+your PR has been scheduled for final tests and will be automatically merged. If
+a maintainer replies `bors delegate+`, then you have been granted the authority
+to merge your own PR (usually this will happen if there are some trivial
+changes required). For a full list of bors commands,
+[see the bors documentation](https://bors.tech/documentation/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,45 @@ a maintainer replies `bors delegate+`, then you have been granted the authority
 to merge your own PR (usually this will happen if there are some trivial
 changes required). For a full list of bors commands,
 [see the bors documentation](https://bors.tech/documentation/).
+
+# Tests
+
+Our aim is to provide a number of tests to be safe from regression. Currently,
+the unit tests and the linting is automated, however, the integration tests
+have to be run manually.
+
+## Compilation
+
+`libtock-rs` currently has two compilation targets: `riscv32imac-unknown-none-elf`
+and `thumbv7em-none-eabi`. You can build the library and the examples
+using the script `build_examples.sh`.
+
+## Unit Testing and Linting
+
+There a a number of tests which run in our travis-ci environment. You can run them
+using `cargo test --workspace`.
+
+## Integration tests
+
+If you have a `nRF52-dk` you can run the integration tests as follows.
+The pins P0.03 and P0.04 need to be connected (on a nRF52-DK). Then do the following:
+
+- connect your device to your computer
+- open a console, e.g. `tockloader listen`
+- run the tests `./run_hardware_test.sh
+
+The desired test output is:
+
+The expected output on the UART console will be as follows.
+
+```
+[test-results]
+heap_test = "Heap works."
+formatting =  works
+should_be_one = 1
+gpio_works = true
+trait_obj_value_usize = 1
+trait_obj_value_string = string
+callbacks_work = true
+all_tests_run = true
+```

--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+The contribution guidelines can be found here: [contribution guidelines](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -100,24 +100,6 @@ This script does the following steps for you:
 - create a TAB (tock application bundle)
 - if you have a nRF52-DK board connected: flash this TAB to your board (using tockloader)
 
-## Running the Integration Tests
-
-Having an nRF52-DK board at hand, integration tests can be run using `./run_hardware_tests.sh`.
-The pins P0.03 and P0.04 need to be connected (on a nRF52-DK).
-The expected output on the UART console will be as follows.
-
-```
-[test-results]
-heap_test = "Heap works."
-formatting =  works
-should_be_one = 1
-gpio_works = true
-trait_obj_value_usize = 1
-trait_obj_value_string = string
-callbacks_work = true
-all_tests_run = true
-```
-
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/tock/libtock-rs.svg?branch=master)](https://travis-ci.org/tock/libtock-rs)
+
 # libtock-rs
+
 Rust userland library for Tock (WIP)
 
 Tested with tock [Release 1.4.1](https://github.com/tock/tock/commit/7e37bf67761d83fd585cace4fb201e2864d300b1).
@@ -22,50 +24,51 @@ start address to fit your application.
 
 This project is nascent and still under heavy development, but first steps:
 
-1. Ensure you have [rustup](https://www.rustup.rs/) installed.
+1.  Ensure you have [rustup](https://www.rustup.rs/) installed.
 
-1. Clone the repository.
+1.  Clone the repository.
 
     ```bash
     git clone https://github.com/tock/libtock-rs
     cd libtock-rs
     ```
 
-1. Install `elf2tab`.
+1.  Install `elf2tab`.
 
     ```bash
     cargo install -f elf2tab --version 0.4.0
     ```
 
-1. Add dependencies for cross-compilation.
+1.  Add dependencies for cross-compilation.
 
     ```bash
     rustup target add thumbv7em-none-eabi
     ```
 
-1. Use the `run_example` script to compile and run the example app you want
-to use:
+1.  Use the `run_example` script to compile and run the example app you want
+    to use:
 
-    ```bash
-    ./run_example.sh blink
-    ```
+        ```bash
+        ./run_example.sh blink
+        ```
 
-    Due to bug #28 this will currently only work if you are using the nRF52-DK platform.
+        Due to bug #28 this will currently only work if you are using the nRF52-DK platform.
 
-    If you have a nRF52840-DK you must change `link-arg=-Tnrf52_layout.ld` in
-    `.cargo/config` to `link-arg=-Tnrf52840_layout.ld`
+        If you have a nRF52840-DK you must change `link-arg=-Tnrf52_layout.ld` in
+        `.cargo/config` to `link-arg=-Tnrf52840_layout.ld`
 
-    If you have a hail board you can flash your device as follows:
-     - set the environment variable `hail` to `1`
-     - change `link-arg=-Tnrf52_layout.ld` in `.cargo/config` to `link-arg=-Thail_layout.ld`
-     - run `run_example.sh` as above.
+        If you have a hail board you can flash your device as follows:
+         - set the environment variable `hail` to `1`
+         - change `link-arg=-Tnrf52_layout.ld` in `.cargo/config` to `link-arg=-Thail_layout.ld`
+         - run `run_example.sh` as above.
 
-    For other platforms, you may have to create your own memory layout definition.
+        For other platforms, you may have to create your own memory layout definition.
 
 ## Using libtock-rs
 
 The easiest way to start using libtock-rs is adding an example to the examples folder.
 The boiler plate code you would write is
+
 ```rust
 #![no_std]
 
@@ -76,25 +79,33 @@ async fn main() -> TockResult<()> {
   // Your code
 }
 ```
+
 If you want to use heap based allocation you will have to add
+
 ```rust
 extern crate alloc;
 ```
+
 to the preamble.
 
 To run on the code on your board you can use
+
 ```bash
 ./run_example.sh <your app>
 ```
+
 This script does the following steps for you:
- - cross-compile your program
- - create a TAB (tock application bundle)
- - if you have a nRF52-DK board connected: flash this TAB to your board (using tockloader)
+
+- cross-compile your program
+- create a TAB (tock application bundle)
+- if you have a nRF52-DK board connected: flash this TAB to your board (using tockloader)
 
 ## Running the Integration Tests
+
 Having an nRF52-DK board at hand, integration tests can be run using `./run_hardware_tests.sh`.
 The pins P0.03 and P0.04 need to be connected (on a nRF52-DK).
 The expected output on the UART console will be as follows.
+
 ```
 [test-results]
 heap_test = "Heap works."
@@ -111,10 +122,10 @@ all_tests_run = true
 
 Licensed under either of
 
- * Apache License, Version 2.0
-   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0
+  ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license
+  ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "continuous-integration/travis-ci/push"
+]


### PR DESCRIPTION
# Summary
In this PR I add bors integration for the `libtock-rs` repository as in the `tock` repository.
The idea is to

 * establish a clear work flow (every approved PR gets merged if it is mergeable)
 * manage (potentially conflicting) different PRs

When the PR is approved I will enable the bors app for this repository.