### PR TITLE
Create stream to stream events from ble scanning functionality merge after #122

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Cargo.lock
 layout.ld
 platform
 target
+.history

--- a/examples-alloc/ble_scanning.rs
+++ b/examples-alloc/ble_scanning.rs
@@ -1,11 +1,8 @@
 #![no_std]
 
-use futures::future;
 use libtock::ble_parser;
 use libtock::result::TockResult;
 use libtock::simple_ble;
-use libtock::simple_ble::BleCallback;
-use libtock::simple_ble::BleScanningDriver;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -17,27 +14,19 @@ struct LedCommand {
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
+    let led_driver = drivers.leds.init_driver()?;
 
-    let leds_driver = drivers.leds.init_driver()?;
+    let ble_scanning_driver_factory = drivers.ble_scanning;
+    let mut ble_scanning_driver = ble_scanning_driver_factory.create_driver();
+    let mut ble_scanning_driver_sharing = ble_scanning_driver.share_memory()?;
+    let ble_scanning_driver_scanning = ble_scanning_driver_sharing.start()?;
 
-    let mut shared_buffer = BleScanningDriver::create_scan_buffer();
-    let mut my_buffer = BleScanningDriver::create_scan_buffer();
-    let shared_memory = drivers.ble_scanning.share_memory(&mut shared_buffer)?;
-
-    let mut callback = BleCallback::new(|_: usize, _: usize| {
-        shared_memory.read_bytes(&mut my_buffer[..]);
-        ble_parser::find(&my_buffer, simple_ble::gap_data::SERVICE_DATA as u8)
+    loop {
+        let value = ble_scanning_driver_scanning.stream_values().await;
+        ble_parser::find(&value, simple_ble::gap_data::SERVICE_DATA as u8)
             .and_then(|service_data| ble_parser::extract_for_service([91, 79], service_data))
             .and_then(|payload| corepack::from_bytes::<LedCommand>(&payload).ok())
-            .and_then(|msg| {
-                leds_driver
-                    .get(msg.nr as usize)
-                    .map(|led| led.set(msg.st))
-                    .into()
-            });
-    });
-
-    let _subscription = drivers.ble_scanning.start(&mut callback)?;
-
-    future::pending().await
+            .and_then(|msg| led_driver.get(msg.nr as usize).ok())
+            .and_then(|led| led.on().ok());
+    }
 }

--- a/examples-alloc/ble_scanning.rs
+++ b/examples-alloc/ble_scanning.rs
@@ -14,7 +14,7 @@ struct LedCommand {
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
-    let led_driver = drivers.leds.init_driver()?;
+    let leds_driver = drivers.leds.init_driver()?;
 
     let ble_scanning_driver_factory = drivers.ble_scanning;
     let mut ble_scanning_driver = ble_scanning_driver_factory.create_driver();
@@ -26,7 +26,7 @@ async fn main() -> TockResult<()> {
         ble_parser::find(&value, simple_ble::gap_data::SERVICE_DATA as u8)
             .and_then(|service_data| ble_parser::extract_for_service([91, 79], service_data))
             .and_then(|payload| corepack::from_bytes::<LedCommand>(&payload).ok())
-            .and_then(|msg| led_driver.get(msg.nr as usize).ok())
+            .and_then(|msg| leds_driver.get(msg.nr as usize).ok())
             .and_then(|led| led.on().ok());
     }
 }

--- a/examples-alloc/ble_scanning.rs
+++ b/examples-alloc/ble_scanning.rs
@@ -16,7 +16,7 @@ async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
     let leds_driver = drivers.leds.init_driver()?;
 
-    let ble_scanning_driver_factory = drivers.ble_scanning;
+    let mut ble_scanning_driver_factory = drivers.ble_scanning;
     let mut ble_scanning_driver = ble_scanning_driver_factory.create_driver();
     let mut ble_scanning_driver_sharing = ble_scanning_driver.share_memory()?;
     let ble_scanning_driver_scanning = ble_scanning_driver_sharing.start()?;

--- a/examples-alloc/simple_ble.rs
+++ b/examples-alloc/simple_ble.rs
@@ -16,12 +16,12 @@ struct LedCommand {
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
-
-    let leds_driver = drivers.leds.init_driver()?;
+    let led_driver = drivers.leds.init_driver()?;
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
+    let mut ble_advertising_driver = drivers.ble_advertising.create_driver();
 
-    let led = leds_driver.leds().next().unwrap();
+    let led = led_driver.leds().next().unwrap();
 
     let uuid: [u8; 2] = [0x00, 0x18];
 
@@ -44,9 +44,7 @@ async fn main() -> TockResult<()> {
 
     gap_payload.add_service_payload([91, 79], &payload).unwrap();
 
-    let _handle = drivers
-        .ble_advertising
-        .initialize(100, &gap_payload, &mut buffer);
+    let _handle = ble_advertising_driver.initialize(100, &gap_payload, &mut buffer);
 
     loop {
         led.on()?;

--- a/examples-alloc/simple_ble.rs
+++ b/examples-alloc/simple_ble.rs
@@ -16,12 +16,12 @@ struct LedCommand {
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
-    let led_driver = drivers.leds.init_driver()?;
+    let leds_driver = drivers.leds.init_driver()?;
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
     let mut ble_advertising_driver = drivers.ble_advertising.create_driver();
 
-    let led = led_driver.leds().next().unwrap();
+    let led = leds_driver.leds().next().unwrap();
 
     let uuid: [u8; 2] = [0x00, 0x18];
 

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -11,8 +11,8 @@ use crate::sensors::ninedof::NinedofDriver;
 use crate::sensors::AmbientLightSensor;
 use crate::sensors::HumiditySensor;
 use crate::sensors::TemperatureSensor;
-use crate::simple_ble::BleAdvertisingDriver;
-use crate::simple_ble::BleScanningDriver;
+use crate::simple_ble::BleAdvertisingDriverFactory;
+use crate::simple_ble::BleScanningDriverFactory;
 use crate::temperature::TemperatureDriverFactory;
 use crate::timer::DriverContext;
 use core::cell::Cell;
@@ -28,8 +28,8 @@ pub struct Drivers {
     pub buttons: ButtonsDriverFactory,
     pub adc: AdcDriverFactory,
     pub rng: RngDriver,
-    pub ble_advertising: BleAdvertisingDriver,
-    pub ble_scanning: BleScanningDriver,
+    pub ble_advertising: BleAdvertisingDriverFactory,
+    pub ble_scanning: BleScanningDriverFactory,
     pub ambient_light_sensor: AmbientLightSensor,
     pub temperature_sensor: TemperatureSensor,
     pub humidity_sensor: HumiditySensor,
@@ -63,8 +63,8 @@ pub unsafe fn retrieve_drivers_unsafe() -> Drivers {
 #[allow(clippy::declare_interior_mutable_const)]
 const DRIVERS: Drivers = Drivers {
     adc: AdcDriverFactory,
-    ble_advertising: BleAdvertisingDriver,
-    ble_scanning: BleScanningDriver,
+    ble_advertising: BleAdvertisingDriverFactory,
+    ble_scanning: BleScanningDriverFactory,
     buttons: ButtonsDriverFactory,
     console: ConsoleDriver,
     leds: LedsDriverFactory,

--- a/src/simple_ble.rs
+++ b/src/simple_ble.rs
@@ -44,7 +44,7 @@ pub mod gap_data {
 pub struct BleAdvertisingDriverFactory;
 
 impl BleAdvertisingDriverFactory {
-    pub fn create_driver(self) -> BleAdvertisingDriver {
+    pub fn create_driver(&mut self) -> BleAdvertisingDriver {
         // Unfortunately, there is no way to check the availability of the ble advertising driver
         BleAdvertisingDriver
     }
@@ -97,7 +97,7 @@ const EMPTY_SCAN_BUFFER: ScanBuffer = [0; BUFFER_SIZE_SCAN];
 pub struct BleScanningDriverFactory;
 
 impl BleScanningDriverFactory {
-    pub fn create_driver(self) -> BleScanningDriver {
+    pub fn create_driver(&mut self) -> BleScanningDriver {
         BleScanningDriver {
             shared_buffer: EMPTY_SCAN_BUFFER,
             read_value: Cell::new(None),
@@ -116,7 +116,7 @@ impl BleScanningDriverFactory {
 /// # async fn doc() -> TockResult<()> {
 /// let mut drivers = libtock::retrieve_drivers()?;
 /// let led_driver = drivers.leds.init_driver()?;
-/// let ble_scanning_driver_factory = drivers.ble_scanning;
+/// let mut ble_scanning_driver_factory = drivers.ble_scanning;
 /// let mut ble_scanning_driver = ble_scanning_driver_factory.create_driver();
 /// let mut ble_scanning_driver_sharing = ble_scanning_driver.share_memory()?;
 /// let ble_scanning_driver_scanning = ble_scanning_driver_sharing.start()?;


### PR DESCRIPTION
# Summary
In this PR I migrate the ble scanning funtionality from callbacks to `futures::stream::Streams`. 
Only merge after #122 

# Questions/Help needed

 * I decided to make the `BleScanningDriverScanning::stream_values` method to consume `&self` instead of `&mut self`. While I think this is correct it may lead to unexpected behavior when two parallel Tasks consume this stream, i.e. the events are split between the consumers
 * I only implemented infinite streams as the stream of ble events will be either be stopped at runtime (to a point of time predictable at compile time) or continue to produce values forever.
 * I removed the possibilty of registering callbacks to the ble driver directly as for me it seemed to be only feasible for trivial business logic.