### PR TITLE
Enable clippy and fix lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,10 @@ install:
   - rustup target add thumbv7em-none-eabi
   - rustup target add riscv32imc-unknown-none-elf
   - rustup component add rustfmt-preview
+  - rustup component add clippy
 
 script:
   - cargo fmt --all -- --check
   - cargo test --workspace
+  - cargo clippy --workspace --all-targets
   - ./build_examples.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-    "editor.formatOnSave": true,
-    "rust.all_targets": true,
+  "editor.formatOnSave": true,
+  "rust.all_targets": true,
+  "rust.clippy_preference": "on"
 }

--- a/README.md
+++ b/README.md
@@ -48,21 +48,22 @@ This project is nascent and still under heavy development, but first steps:
 1.  Use the `run_example` script to compile and run the example app you want
     to use:
 
-        ```bash
-        ./run_example.sh blink
-        ```
+    ```bash
+    ./run_example.sh blink
+    ```
 
-        Due to bug #28 this will currently only work if you are using the nRF52-DK platform.
+    Due to bug #28 this will currently only work if you are using the nRF52-DK platform.
 
-        If you have a nRF52840-DK you must change `link-arg=-Tnrf52_layout.ld` in
-        `.cargo/config` to `link-arg=-Tnrf52840_layout.ld`
+    If you have a nRF52840-DK you must change `link-arg=-Tnrf52_layout.ld` in
+    `.cargo/config` to `link-arg=-Tnrf52840_layout.ld`
 
-        If you have a hail board you can flash your device as follows:
-         - set the environment variable `hail` to `1`
-         - change `link-arg=-Tnrf52_layout.ld` in `.cargo/config` to `link-arg=-Thail_layout.ld`
-         - run `run_example.sh` as above.
+    If you have a hail board you can flash your device as follows:
 
-        For other platforms, you may have to create your own memory layout definition.
+    - set the environment variable `hail` to `1`
+    - change `link-arg=-Tnrf52_layout.ld` in `.cargo/config` to `link-arg=-Thail_layout.ld`
+    - run `run_example.sh` as above.
+
+    For other platforms, you may have to create your own memory layout definition.
 
 ## Using libtock-rs
 

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -9,6 +9,7 @@ use syn;
 use syn::Error;
 use syn::ItemFn;
 
+#[allow(clippy::needless_doctest_main)]
 /// Procedural attribute macro. This is meant to be applied to a binary's async
 /// `main()`, transforming into a function that returns a type acceptable for
 /// `main()`. In other words, this will not compile with libtock-rs:
@@ -30,7 +31,7 @@ pub fn main(_: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 fn generate_main_wrapped(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    try_generate_main_wrapped(input).unwrap_or_else(|err| err.to_compile_error().into())
+    try_generate_main_wrapped(input).unwrap_or_else(|err| err.to_compile_error())
 }
 
 fn try_generate_main_wrapped(
@@ -63,11 +64,8 @@ mod tests {
             async fn main() -> ::libtock::result::TockResult<()>{
                 method_call().await;
             }
-        }
-        .into();
-        let actual: ItemFn = syn::parse2::<ItemFn>(generate_main_wrapped(method_def.into()))
-            .unwrap()
-            .into();
+        };
+        let actual: ItemFn = syn::parse2::<ItemFn>(generate_main_wrapped(method_def)).unwrap();
         let expected: ItemFn = syn::parse2::<ItemFn>(quote!(
             fn main() -> ::libtock::result::TockResult<()> {
                 static mut MAIN_INVOKED: bool = false;
@@ -83,8 +81,7 @@ mod tests {
                 unsafe { ::core::executor::block_on(_block) }
             }
         ))
-        .unwrap()
-        .into();
+        .unwrap();
         assert_eq!(actual, expected);
     }
 }

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -13,7 +13,7 @@ async fn main() -> TockResult<()> {
     let mut driver = context.create_timer_driver()?;
     let timer_driver = driver.activate()?;
 
-    let mut console = Console::new();
+    let mut console = Console::default();
     let mut with_callback = adc::with_callback(|channel: usize, value: usize| {
         writeln!(console, "channel: {}, value: {}", channel, value).unwrap();
     });

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -10,8 +10,8 @@ use libtock::syscalls;
 #[libtock::main]
 /// Reads a 128 byte sample into a buffer and prints the first value to the console.
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
-    let mut adc_buffer = AdcBuffer::new();
+    let mut console = Console::default();
+    let mut adc_buffer = AdcBuffer::default();
     let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];
 
     let adc_buffer = libtock::adc::Adc::init_buffer(&mut adc_buffer)?;

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -10,7 +10,7 @@ use libtock::timer::Duration;
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
+    let mut console = Console::default();
     let mut with_callback = buttons::with_callback(|_, _| {});
     let mut buttons = with_callback.init()?;
     let mut button = buttons.iter_mut().next().unwrap();

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -10,7 +10,7 @@ use libtock::result::TockResult;
 // FIXME: Hangs up when buttons are pressed rapidly. Yielding in callback leads to stack overflow.
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
+    let mut console = Console::default();
 
     let mut with_callback = buttons::with_callback(|button_num: usize, state| {
         writeln!(

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -11,7 +11,7 @@ use libtock::timer::Duration;
 // example works on p0.03
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
+    let mut console = Console::default();
     let pin = GpioPinUnitialized::new(0);
     let pin = pin.open_for_read(None, InputMode::PullDown)?;
     let context = timer::DriverContext::create()?;

--- a/examples/hardware_test.rs
+++ b/examples/hardware_test.rs
@@ -21,20 +21,20 @@ trait MyTrait {
 
 impl MyTrait for usize {
     fn do_something_with_a_console(&self, console: &mut Console) {
-        write!(console, "trait_obj_value_usize = {}\n", &self).unwrap();
+        writeln!(console, "trait_obj_value_usize = {}", &self).unwrap();
     }
 }
 
 impl MyTrait for String {
     fn do_something_with_a_console(&self, console: &mut Console) {
-        write!(console, "trait_obj_value_string = {}\n", &self).unwrap();
+        writeln!(console, "trait_obj_value_string = {}", &self).unwrap();
     }
 }
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
-    write!(console, "[test-results]\n")?;
+    let mut console = Console::default();
+    writeln!(console, "[test-results]")?;
 
     test_heap(&mut console);
     test_formatting(&mut console);
@@ -49,12 +49,12 @@ async fn main() -> TockResult<()> {
 
 fn test_heap(console: &mut Console) {
     let mut string = String::from("heap_test = \"Heap ");
-    string.push_str("works.\"\n");
-    write!(console, "{}", string).unwrap();
+    string.push_str("works.\"");
+    writeln!(console, "{}", string).unwrap();
 }
 
 fn test_formatting(console: &mut Console) {
-    write!(console, "formatting =  {}\n", String::from("works")).unwrap();
+    writeln!(console, "formatting =  {}", String::from("works")).unwrap();
 }
 
 /// needs P0.03 and P0.04 to be connected
@@ -91,7 +91,7 @@ fn test_trait_objects(console: &mut Console) -> TockResult<()> {
 fn test_static_mut(console: &mut Console) {
     increment_static_mut();
 
-    write!(console, "should_be_one = {}\n", unsafe { STATIC }).unwrap();
+    writeln!(console, "should_be_one = {}", unsafe { STATIC }).unwrap();
 }
 
 /// needs P0.03 and P0.04 to be connected
@@ -106,13 +106,13 @@ fn test_gpio(console: &mut Console) {
     let pin_out = pin_out.open_for_write().ok().unwrap();
     pin_out.set_high().ok().unwrap();
 
-    write!(console, "gpio_works = {}\n", pin_in.read()).unwrap();
+    writeln!(console, "gpio_works = {}", pin_in.read()).unwrap();
 }
 
 async fn test_callbacks_and_wait_forever(console: &mut Console) -> TockResult<()> {
     let mut with_callback = timer::with_callback(|_, _| {
-        write!(console, "callbacks_work = true\n").unwrap();
-        write!(console, "all_tests_run = true").unwrap();
+        writeln!(console, "callbacks_work = true").unwrap();
+        writeln!(console, "all_tests_run = true").unwrap();
     });
 
     let mut timer = with_callback.init()?;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -8,7 +8,7 @@ use libtock::timer::Duration;
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
+    let mut console = Console::default();
     let context = timer::DriverContext::create()?;
     let mut driver = context.create_timer_driver()?;
     let timer_driver = driver.activate()?;

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -3,17 +3,18 @@
 use core::fmt::Write;
 use libtock::console::Console;
 use libtock::result::TockResult;
+use libtock::sensors::Ninedof;
 use libtock::sensors::*;
 use libtock::timer;
 use libtock::timer::Duration;
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
+    let mut console = Console::default();
     let mut humidity = HumiditySensor;
     let mut temperature = TemperatureSensor;
     let mut light = AmbientLightSensor;
-    let mut ninedof = unsafe { Ninedof::new() };
+    let mut ninedof = Ninedof::default();
     let context = timer::DriverContext::create()?;
     let mut driver = context.create_timer_driver()?;
     let timer_driver = driver.activate()?;

--- a/examples/simple_ble.rs
+++ b/examples/simple_ble.rs
@@ -24,7 +24,7 @@ async fn main() -> TockResult<()> {
     let payload = corepack::to_bytes(LedCommand { nr: 2, st: true }).unwrap();
 
     let mut buffer = BleAdvertisingDriver::create_advertising_buffer();
-    let mut gap_payload = BlePayload::new();
+    let mut gap_payload = BlePayload::default();
     gap_payload
         .add_flag(ble_composer::flags::LE_GENERAL_DISCOVERABLE)
         .unwrap();
@@ -34,10 +34,7 @@ async fn main() -> TockResult<()> {
         .unwrap();
 
     gap_payload
-        .add(
-            ble_composer::gap_types::COMPLETE_LOCAL_NAME,
-            "Tock!".as_bytes(),
-        )
+        .add(ble_composer::gap_types::COMPLETE_LOCAL_NAME, b"Tock!")
         .unwrap();
     gap_payload.add_service_payload([91, 79], &payload).unwrap();
 

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -7,7 +7,7 @@ use libtock::temperature;
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
+    let mut console = Console::default();
     let temperature = temperature::measure_temperature().await?;
     writeln!(console, "Temperature: {}", temperature).map_err(Into::into)
 }

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -9,7 +9,7 @@ use libtock::timer::Duration;
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
-    let mut console = Console::new();
+    let mut console = Console::default();
 
     let mut with_callback = timer::with_callback(|_, _| {
         writeln!(

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -29,8 +29,8 @@ pub struct AdcBuffer {
     buffer: [u8; BUFFER_SIZE],
 }
 
-impl AdcBuffer {
-    pub fn new() -> AdcBuffer {
+impl Default for AdcBuffer {
+    fn default() -> Self {
         AdcBuffer {
             buffer: [0; BUFFER_SIZE],
         }

--- a/src/ble_composer.rs
+++ b/src/ble_composer.rs
@@ -36,13 +36,6 @@ impl BlePayload {
         Ok(())
     }
 
-    pub fn new() -> Self {
-        BlePayload {
-            bytes: [0; 39],
-            occupied: 0,
-        }
-    }
-
     pub fn add_service_payload(&mut self, uuid: [u8; 2], content: &[u8]) -> Result<(), ()> {
         self.check_can_write_num_bytes(4 + content.len())?;
         self.bytes[self.occupied] = (content.len() + 3) as u8;
@@ -65,6 +58,14 @@ impl BlePayload {
     }
 }
 
+impl Default for BlePayload {
+    fn default() -> Self {
+        BlePayload {
+            bytes: [0; 39],
+            occupied: 0,
+        }
+    }
+}
 impl AsRef<[u8]> for BlePayload {
     fn as_ref(&self) -> &[u8] {
         &self.bytes[0..self.occupied]
@@ -77,7 +78,7 @@ mod test {
 
     #[test]
     fn test_add() {
-        let mut pld = BlePayload::new();
+        let mut pld = BlePayload::default();
         pld.add(1, &[2]).unwrap();
         assert_eq!(pld.as_ref().len(), 3);
         assert_eq!(pld.as_ref(), &mut [2, 1, 2])
@@ -85,14 +86,14 @@ mod test {
 
     #[test]
     fn test_add_service_payload() {
-        let mut pld = BlePayload::new();
+        let mut pld = BlePayload::default();
         pld.add_service_payload([1, 2], &[2]).unwrap();
         assert_eq!(pld.as_ref(), &[4, 0x16, 1, 2, 2])
     }
 
     #[test]
     fn test_add_service_payload_two_times() {
-        let mut pld = BlePayload::new();
+        let mut pld = BlePayload::default();
         pld.add_service_payload([1, 2], &[2]).unwrap();
         pld.add_service_payload([1, 2], &[2, 3]).unwrap();
 
@@ -101,13 +102,13 @@ mod test {
 
     #[test]
     fn big_data_causes_error() {
-        let mut pld = BlePayload::new();
+        let mut pld = BlePayload::default();
         assert!(pld.add_service_payload([1, 2], &[0; 36]).is_err());
     }
 
     #[test]
     fn initial_size_is_zero() {
-        let pld = BlePayload::new();
+        let pld = BlePayload::default();
         assert_eq!(pld.as_ref().len(), 0);
     }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -25,12 +25,6 @@ pub struct Console {
 }
 
 impl Console {
-    pub fn new() -> Console {
-        Console {
-            allow_buffer: [0; 64],
-        }
-    }
-
     pub fn write<S: AsRef<[u8]>>(&mut self, text: S) -> TockResult<()> {
         let mut not_written_yet = text.as_ref();
         while !not_written_yet.is_empty() {
@@ -66,6 +60,14 @@ impl Console {
         mem::drop(shared_memory);
 
         Ok(())
+    }
+}
+
+impl Default for Console {
+    fn default() -> Self {
+        Console {
+            allow_buffer: [0; 64],
+        }
     }
 }
 

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -7,13 +7,15 @@ use crate::console::Console;
 
 pub fn println() {
     let buffer = [b'\n'];
-    let _ = Console::new().write(&buffer);
+    let mut console = Console::default();
+    let _ = console.write(&buffer);
 }
 
 pub fn print_as_hex(value: usize) {
     let mut buffer = [b'\n'; 11];
     write_as_hex(&mut buffer, value);
-    let _ = Console::new().write(buffer);
+    let mut console = Console::default();
+    let _ = console.write(buffer);
 }
 
 #[cfg(target_arch = "arm")]
@@ -24,34 +26,42 @@ pub fn print_stack_pointer() {
     let mut buffer = [b'\n'; 15];
     buffer[0..4].clone_from_slice(b"SP: ");
     write_as_hex(&mut buffer[4..15], stack_pointer);
-    let _ = Console::new().write(buffer);
+    let mut console = Console::default();
+    let _ = console.write(buffer);
 }
 
 #[cfg(target_arch = "riscv32")]
 pub fn print_stack_pointer() {}
 
-#[inline(always)] // Initial stack size is too small (128 bytes currently)
-pub fn dump_address(address: *const usize) {
+#[inline(always)]
+/// Dumps address
+/// # Safety
+/// dereferences pointer without check - may lead to access violation.
+pub unsafe fn dump_address(address: *const usize) {
     let mut buffer = [b' '; 28];
     write_as_hex(&mut buffer[0..10], address as usize);
     buffer[10] = b':';
-    write_as_hex(&mut buffer[12..22], unsafe { *address });
+    write_as_hex(&mut buffer[12..22], *address);
     for index in 0..4 {
-        let byte = unsafe { *(address as *const u8).offset(index) };
+        let byte = *(address as *const u8).offset(index);
         let byte_is_printable_char = byte >= 0x20 && byte < 0x80;
         if byte_is_printable_char {
             buffer[23 + index as usize] = byte;
         }
     }
     buffer[27] = b'\n';
-    let _ = Console::new().write(&buffer);
+    let mut console = Console::default();
+    let _ = console.write(&buffer);
 }
 
-pub fn dump_memory(start_address: *const usize, count: isize) {
+/// Dumps arbitrary memory regions.
+/// # Safety
+/// dereferences pointer without check - may lead to access violation.
+pub unsafe fn dump_memory(start_address: *const usize, count: isize) {
     let range = if count < 0 { count..0 } else { 0..count };
 
     for offset in range {
-        dump_address(unsafe { start_address.offset(offset) });
+        dump_address(start_address.offset(offset));
     }
 }
 

--- a/src/memop.rs
+++ b/src/memop.rs
@@ -3,16 +3,19 @@
 use crate::syscalls;
 use core::slice;
 
-// Setting the break is marked as unsafe as it should only be called by the entry point to setup
-// the allocator. Updating the break afterwards can lead to allocated memory becoming unaccessible.
-//
-// Alternate allocator implementations may still find this useful in the future.
+/// Set the memory break
+/// # Safety
+/// Setting the break is marked as unsafe as it should only be called by the entry point to setup
+/// the allocator. Updating the break afterwards can lead to allocated memory becoming unaccessible.
+///
+/// Alternate allocator implementations may still find this useful in the future.
 pub unsafe fn set_brk(ptr: *const u8) -> bool {
     syscalls::raw::memop(0, ptr as usize) == 0
 }
 
-pub unsafe fn increment_brk(increment: usize) -> Option<*const u8> {
-    let result = syscalls::raw::memop(1, increment);
+/// Increment the memory break
+pub fn increment_brk(increment: usize) -> Option<*const u8> {
+    let result = unsafe { syscalls::raw::memop(1, increment) };
     if result >= 0 {
         Some(result as *const u8)
     } else {
@@ -64,8 +67,8 @@ pub fn get_flash_region_end(i: usize) -> Option<*const u8> {
     }
 }
 
-// It is safe to return a 'static immutable slice, as the Tock kernel doesn't change the layout of
-// flash regions during the application's lifetime.
+/// It is safe to return a 'static immutable slice, as the Tock kernel doesn't change the layout of
+/// flash regions during the application's lifetime.
 pub fn get_flash_region(i: usize) -> Option<&'static [u8]> {
     if i < get_flash_regions_count() {
         let start = unsafe { syscalls::raw::memop(8, i) as *const u8 };
@@ -78,15 +81,22 @@ pub fn get_flash_region(i: usize) -> Option<&'static [u8]> {
     }
 }
 
-// Setting the stack_top and heap_start addresses are marked as unsafe as they should only be called
-// by the entry point to setup the allocator. Updating these values afterwards can lead to incorrect
-// debug output from the kernel.
-//
-// Alternate allocator implementations may still find this useful in the future.
+/// Set the top of the stack
+/// # Safety
+/// Setting the stack_top and heap_start addresses are marked as unsafe as they should only be called
+/// by the entry point to setup the allocator. Updating these values afterwards can lead to incorrect
+/// debug output from the kernel.
+///
+/// Alternate allocator implementations may still find this useful in the future.
 pub unsafe fn set_stack_top(ptr: *const u8) {
     let _ = syscalls::raw::memop(10, ptr as usize);
 }
 
+/// Set the top of the heap
+/// # Safety
+/// Setting the stack_top and heap_start addresses are marked as unsafe as they should only be called
+/// by the entry point to setup the allocator. Updating these values afterwards can lead to incorrect
+/// debug output from the kernel.
 pub unsafe fn set_heap_start(ptr: *const u8) {
     let _ = syscalls::raw::memop(11, ptr as usize);
 }

--- a/src/sensors/ninedof.rs
+++ b/src/sensors/ninedof.rs
@@ -30,10 +30,6 @@ struct CbData {
 }
 
 impl Ninedof {
-    pub unsafe fn new() -> Ninedof {
-        Ninedof
-    }
-
     pub fn read_acceleration(&mut self) -> TockResult<NinedofReading> {
         let res: CbData = Default::default();
         subscribe(Self::cb, unsafe { mem::transmute(&res) })?;
@@ -58,6 +54,12 @@ impl Ninedof {
             z: z as i32,
         });
         res.ready.set(true);
+    }
+}
+
+impl Default for Ninedof {
+    fn default() -> Self {
+        Ninedof
     }
 }
 

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -89,7 +89,7 @@ pub fn command(
     arg1: usize,
     arg2: usize,
 ) -> Result<usize, CommandError> {
-    let return_code = unsafe { raw::command(driver_number, command_number, arg1, arg2) };
+    let return_code = raw::command(driver_number, command_number, arg1, arg2);
     if return_code >= 0 {
         Ok(return_code as usize)
     } else {

--- a/src/syscalls/mod.rs
+++ b/src/syscalls/mod.rs
@@ -89,7 +89,7 @@ pub fn command(
     arg1: usize,
     arg2: usize,
 ) -> Result<usize, CommandError> {
-    let return_code = raw::command(driver_number, command_number, arg1, arg2);
+    let return_code = unsafe { raw::command(driver_number, command_number, arg1, arg2) };
     if return_code >= 0 {
         Ok(return_code as usize)
     } else {

--- a/src/syscalls/platform_arm.rs
+++ b/src/syscalls/platform_arm.rs
@@ -48,15 +48,15 @@ pub unsafe fn subscribe(
 }
 
 #[inline(always)]
-pub fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
-    unsafe {
-        let res;
-        asm!("svc 2" : "={r0}"(res)
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
+    let res;
+    asm!("svc 2" : "={r0}"(res)
                      : "{r0}"(major) "{r1}"(minor) "{r2}"(arg1) "{r3}"(arg2)
                      : "memory"
                      : "volatile");
-        res
-    }
+    res
 }
 
 #[inline(always)]

--- a/src/syscalls/platform_arm.rs
+++ b/src/syscalls/platform_arm.rs
@@ -31,6 +31,8 @@ pub unsafe fn yieldk() {
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn subscribe(
     major: usize,
     minor: usize,
@@ -46,16 +48,20 @@ pub unsafe fn subscribe(
 }
 
 #[inline(always)]
-pub unsafe fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
-    let res;
-    asm!("svc 2" : "={r0}"(res)
-                 : "{r0}"(major) "{r1}"(minor) "{r2}"(arg1) "{r3}"(arg2)
-                 : "memory"
-                 : "volatile");
-    res
+pub fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
+    unsafe {
+        let res;
+        asm!("svc 2" : "={r0}"(res)
+                     : "{r0}"(major) "{r1}"(minor) "{r2}"(arg1) "{r3}"(arg2)
+                     : "memory"
+                     : "volatile");
+        res
+    }
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn command1(major: usize, minor: usize, arg: usize) -> isize {
     let res;
     asm!("svc 2" : "={r0}"(res)
@@ -66,6 +72,8 @@ pub unsafe fn command1(major: usize, minor: usize, arg: usize) -> isize {
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn allow(major: usize, minor: usize, slice: *mut u8, len: usize) -> isize {
     let res;
     asm!("svc 3" : "={r0}"(res)
@@ -76,6 +84,8 @@ pub unsafe fn allow(major: usize, minor: usize, slice: *mut u8, len: usize) -> i
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn memop(major: u32, arg1: usize) -> isize {
     let res;
     asm!("svc 4" : "={r0}"(res)

--- a/src/syscalls/platform_mock.rs
+++ b/src/syscalls/platform_mock.rs
@@ -16,7 +16,10 @@ pub unsafe fn subscribe(
     unimplemented()
 }
 
-pub fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
+/// Send a command to the tock kernel
+/// # Safety
+/// This function usually involves assembly calls which are unsafe.
+pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
     unimplemented()
 }
 

--- a/src/syscalls/platform_mock.rs
+++ b/src/syscalls/platform_mock.rs
@@ -1,5 +1,12 @@
+/// yield for a callback fired by the kernel
+/// # Safety
+/// Yielding inside a callback conflicts with Rust's safety guarantees. For example,
+/// a FnMut closure could be triggered multiple times making a &mut a shared reference.
 pub unsafe fn yieldk() {}
 
+/// Subscribe a callback to the kernel
+/// # Safety
+/// Unsafe as passed callback is dereferenced and called.
 pub unsafe fn subscribe(
     _: usize,
     _: usize,
@@ -9,18 +16,27 @@ pub unsafe fn subscribe(
     unimplemented()
 }
 
-pub unsafe fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
+pub fn command(_: usize, _: usize, _: usize, _: usize) -> isize {
     unimplemented()
 }
 
+/// Call a command only taking into accoun the first argument
+/// # Safety
+/// Unsafe as ignored arguments cause leaking of registers to the kernel
 pub unsafe fn command1(_: usize, _: usize, _: usize) -> isize {
     unimplemented()
 }
 
+/// Share a memory region with the kernel
+/// # Safety
+/// Unsafe as the pointer to the shared buffer is potentially dereferenced by the kernel.
 pub unsafe fn allow(_: usize, _: usize, _: *mut u8, _: usize) -> isize {
     unimplemented()
 }
 
+/// Generic operations on the app's memory as requesting more memory
+/// # Safety
+/// Allows the kernel to do generic operations on the app's memory which can cause memory corruption.
 pub unsafe fn memop(_: u32, _: usize) -> isize {
     unimplemented()
 }

--- a/src/syscalls/platform_riscv32.rs
+++ b/src/syscalls/platform_riscv32.rs
@@ -1,4 +1,6 @@
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn yieldk() {
     /* TODO: Stop yielding */
     asm! (
@@ -12,6 +14,8 @@ pub unsafe fn yieldk() {
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn subscribe(
     major: usize,
     minor: usize,
@@ -29,18 +33,22 @@ pub unsafe fn subscribe(
 }
 
 #[inline(always)]
-pub unsafe fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
-    let res;
-    asm!("li    a0, 2
+pub fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
+    unsafe {
+        let res;
+        asm!("li    a0, 2
           ecall"
          : "={x10}" (res)
          : "{x11}" (major), "{x12}" (minor), "{x13}" (arg1), "{x14}" (arg2)
          : "memory"
          : "volatile");
-    res
+        res
+    }
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn command1(major: usize, minor: usize, arg: usize) -> isize {
     let res;
     asm!("li    a0, 2
@@ -53,6 +61,8 @@ pub unsafe fn command1(major: usize, minor: usize, arg: usize) -> isize {
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn allow(major: usize, minor: usize, slice: *mut u8, len: usize) -> isize {
     let res;
     asm!("li    a0, 3
@@ -65,6 +75,8 @@ pub unsafe fn allow(major: usize, minor: usize, slice: *mut u8, len: usize) -> i
 }
 
 #[inline(always)]
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
 pub unsafe fn memop(major: u32, arg1: usize) -> isize {
     let res;
     asm!("li    a0, 4

--- a/src/syscalls/platform_riscv32.rs
+++ b/src/syscalls/platform_riscv32.rs
@@ -33,17 +33,17 @@ pub unsafe fn subscribe(
 }
 
 #[inline(always)]
-pub fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
-    unsafe {
-        let res;
-        asm!("li    a0, 2
+// Justification: documentation is generated from mocks
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn command(major: usize, minor: usize, arg1: usize, arg2: usize) -> isize {
+    let res;
+    asm!("li    a0, 2
           ecall"
          : "={x10}" (res)
          : "{x11}" (major), "{x12}" (minor), "{x13}" (arg1), "{x14}" (arg2)
          : "memory"
          : "volatile");
-        res
-    }
+    res
 }
 
 #[inline(always)]


### PR DESCRIPTION
# Summary

In this PR I enable clippy in CI and fix some lints. Some soiutions may be a matter of taste. Most significantly I removed some `unsafe` constraints, where I think there is no unsafety.