### PR TITLE
Remove intrinsics

### DIFF
--- a/src/entry_point/mod.rs
+++ b/src/entry_point/mod.rs
@@ -1,6 +1,5 @@
 use crate::memop;
 use crate::syscalls;
-use core::intrinsics;
 use core::ptr;
 
 // _start and rust_start are the first two procedures executed when a Tock
@@ -99,7 +98,7 @@ pub unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, app_heap_
 
     let data_flash_start_addr = app_start + layout_header.data_sym_start;
 
-    intrinsics::copy_nonoverlapping(
+    ptr::copy_nonoverlapping(
         data_flash_start_addr as *const u8,
         stacktop as *mut u8,
         layout_header.data_size,

--- a/src/entry_point/start_item_arm.rs
+++ b/src/entry_point/start_item_arm.rs
@@ -1,4 +1,4 @@
-use core::intrinsics;
+use core::hint;
 
 /// Tock programs' entry point. Called by the kernel at program start. Sets up
 /// the stack then calls rust_start() for the remainder of setup.
@@ -109,5 +109,5 @@ pub unsafe extern "C" fn _start(
           "cc", "memory"                                               // Clobbers
         : "volatile"                                                   // Options
     );
-    intrinsics::unreachable();
+    hint::unreachable_unchecked()
 }

--- a/src/entry_point/start_item_riscv32.rs
+++ b/src/entry_point/start_item_riscv32.rs
@@ -1,4 +1,4 @@
-use core::intrinsics;
+use core::hint;
 
 /// Tock programs' entry point. Called by the kernel at program start. Sets up
 /// the stack then calls rust_start() for the remainder of setup.
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn _start() -> ! {
       "t0", "t1", "t2", "t3", "t4", "t5", "t6", "ra"               // Clobbers
     : "volatile"                                                   // Options
     );
-    intrinsics::unreachable();
+    hint::unreachable_unchecked();
 }
 
 /// Ensure an abort symbol exists.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,4 @@
-#![feature(
-    asm,
-    alloc_error_handler,
-    core_intrinsics,
-    lang_items,
-    naked_functions,
-    ptr_offset_from
-)]
+#![feature(asm, alloc_error_handler, lang_items, naked_functions, ptr_offset_from)]
 #![cfg_attr(any(target_arch = "arm", target_arch = "riscv32"), no_std)]
 
 mod callback;


### PR DESCRIPTION
# Summary

The error message when not enabling the `#![feature(core_intrinsics)]` feature reads

> use of unstable library feature 'core_intrinsics': intrinsics are unlikely to ever be stabilized, instead they should be used through stabilized interfaces in the rest of the standard library

I think we should - unlike other nightly features which will hopefully be stabilized - not use this unless absolutely necessary. I removed the feature in a straightforward way, however. @jrvanwhy is the expert in that matter.