### PR TITLE
Remove unstable offset_from feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, alloc_error_handler, lang_items, naked_functions, ptr_offset_from)]
+#![feature(asm, alloc_error_handler, lang_items, naked_functions)]
 #![cfg_attr(any(target_arch = "arm", target_arch = "riscv32"), no_std)]
 
 mod callback;

--- a/src/memop.rs
+++ b/src/memop.rs
@@ -75,7 +75,7 @@ pub fn get_flash_region(i: usize) -> Option<&'static [u8]> {
         let start_ptr = start_addr as *const u8;
         let end_addr = unsafe { syscalls::raw::memop(9, i) } as usize;
         // This assumes that the kernel sends consistent results, i.e. start <= end.
-        let len = end_addr - start_addr + 1;
+        let len = end_addr - start_addr;
         Some(unsafe { slice::from_raw_parts(start_ptr, len) })
     } else {
         None

--- a/src/memop.rs
+++ b/src/memop.rs
@@ -71,11 +71,12 @@ pub fn get_flash_region_end(i: usize) -> Option<*const u8> {
 /// flash regions during the application's lifetime.
 pub fn get_flash_region(i: usize) -> Option<&'static [u8]> {
     if i < get_flash_regions_count() {
-        let start = unsafe { syscalls::raw::memop(8, i) as *const u8 };
-        let end = unsafe { syscalls::raw::memop(9, i) as *const u8 };
+        let start_addr = unsafe { syscalls::raw::memop(8, i) } as usize;
+        let start_ptr = start_addr as *const u8;
+        let end_addr = unsafe { syscalls::raw::memop(9, i) } as usize;
         // This assumes that the kernel sends consistent results, i.e. start <= end.
-        let len = unsafe { end.offset_from(start) } as usize;
-        Some(unsafe { slice::from_raw_parts(start, len) })
+        let len = end_addr - start_addr + 1;
+        Some(unsafe { slice::from_raw_parts(start_ptr, len) })
     } else {
         None
     }


### PR DESCRIPTION
# Summary

In this PR I remove the unstable `offset_from` feature which is used to calculate the number of bytes of a slice of bytes in a given range of addresses (the flash region). Clearly, the feature provides a safe and concise way of computing this. However, I find that using a minimal number of unstable/experimental features here has a higher value.