### PR TITLE
Change RISC-V register names in clobbers.

### DIFF
--- a/src/entry_point/start_item_riscv32.rs
+++ b/src/entry_point/start_item_riscv32.rs
@@ -93,8 +93,8 @@ pub unsafe extern "C" fn _start() -> ! {
     jal  rust_start"
     :                                                              // No output operands
     :
-    : "memory", "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7",
-      "t0", "t1", "t2", "t3", "t4", "t5", "t6", "ra"               // Clobbers
+    : "memory", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
+      "x5", "x6", "x7", "x28", "x29", "x30", "x31", "x1"           // Clobbers
     : "volatile"                                                   // Options
     );
     hint::unreachable_unchecked();

--- a/src/syscalls/platform_riscv32.rs
+++ b/src/syscalls/platform_riscv32.rs
@@ -8,8 +8,8 @@ pub unsafe fn yieldk() {
             ecall"
             :
             :
-            : "memory", "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7",
-            "t0", "t1", "t2", "t3", "t4", "t5", "t6", "ra"
+            : "memory", "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17",
+            "x5", "x6", "x7", "x28", "x29", "x30", "x31", "x1"
             : "volatile");
 }
 


### PR DESCRIPTION
As of right now, asm clobbers of specific registers in Rust only work
with the registers' x-style names, not the a/t/ra names.

Fixes #139.

See rust-lang/rust#60392.