### PR TITLE
Add .sbss section to .bss section

### DIFF
--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -122,7 +122,7 @@ SECTIONS {
     {
         . = ALIGN(4); /* Make sure we're word-aligned here */
         _bss = .;
-        KEEP(*(.bss*))
+        KEEP(*(.bss* .sbss*))
         *(COMMON)
         . = ALIGN(4);
     } > SRAM


### PR DESCRIPTION
This is a special section that RISC-V uses (see the comment in the Tock board linker). Without this change, we potentially miss part of the .bss being zeroed properly.