### PR TITLE
Correct name of RISC-V target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,6 @@
 [alias]
-rriscv32iamc = "run --release --target=riscv32iamc-unknown-none-elf --example"
-rrv32iamc = "rriscv32iamc"
+rriscv32imac = "run --release --target=riscv32imac-unknown-none-elf --example"
+rrv32imac = "rriscv32imac"
 rriscv32imc = "run --release --target=riscv32imc-unknown-none-elf --example"
 rrv32imc = "rriscv32imc"
 rthumbv7em = "run --release --target=thumbv7em-none-eabi --example"

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 # Available flash commands
 
-- `cargo rriscv32iamc`/`cargo rrv32iamc`: Use the `riscv32iamc-unknown-none-elf` target
+- `cargo rriscv32imac`/`cargo rrv32imac`: Use the `riscv32imac-unknown-none-elf` target
 - `cargo rriscv32imc`/`cargo rrv32imc`: Use the `riscv32imc-unknown-none-elf` target
 - `cargo rthumbv7em`/`cargo rtv7em`: Use the `thumbv7em-none-eabi` target
 


### PR DESCRIPTION
$ rustup target install riscv32iamc-unknown-none-elf
error: toolchain 'nightly-2019-11-06-x86_64-unknown-linux-gnu' does not contain component 'rust-std' for target 'riscv32iamc-unknown-none-elf'; did you mean 'riscv32imac-unknown-none-elf'?