### PR TITLE
Add a script to build for RISC-V

### DIFF
--- a/flash.sh
+++ b/flash.sh
@@ -4,8 +4,36 @@ set -eux
 
 artifact="$(basename $1)"
 rust_target_folder="$(readlink -f $(dirname $1)/../..)"
+
+case "${PLATFORM}" in
+    "nrf52"|"nrf52840")
+        tockloader_flags="--jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52"
+        binary_name=cortex-m4.elf
+        tockload=y
+        ;;
+    "hail")
+        tockloader_flags=""
+        binary_name=cortex-m4.elf
+        tockload=y
+        ;;
+    "riscv32")
+        tockloader_flags=""
+        binary_name=rv32imac.elf
+        tockload=n
+        ;;
+    "opentitan")
+        tockloader_flags=""
+        binary_name=rv32imc.elf
+        tockload=n
+        ;;
+    *)
+        echo "Unknown platform \"${PLATFORM}\""
+        exit 1
+        ;;
+esac
+
 libtock_target_path="${rust_target_folder}/tab/${PLATFORM}/${artifact}"
-elf_file_name="${libtock_target_path}/cortex-m4.elf"
+elf_file_name="${libtock_target_path}/${binary_name}"
 tab_file_name="${libtock_target_path}.tab"
 
 mkdir -p "${libtock_target_path}"
@@ -13,18 +41,10 @@ cp "$1" "${elf_file_name}"
 
 elf2tab -n "${artifact}" -o "${tab_file_name}" "${elf_file_name}" --stack 2048 --app-heap 1024 --kernel-heap 1024 --protected-region-size=64
 
-case "${PLATFORM}" in
-    "nrf52"|"nrf52840")
-        tockloader_flags="--jlink --arch cortex-m4 --board nrf52dk --jtag-device nrf52"
-        ;;
-    "hail")
-        tockloader_flags=""
-        ;;
-    *)
-        echo "Tockloader flags unknown for platform \"${PLATFORM}\""
-        exit 1
-        ;;
-esac
+if [ $tockload == "n" ]; then
+	echo "Skipping flashing for platform \"${PLATFORM}\""
+	exit 0
+fi
 
 tockloader uninstall ${tockloader_flags} || true
 tockloader install ${tockloader_flags} "${tab_file_name}"

--- a/layout_opentitan.ld
+++ b/layout_opentitan.ld
@@ -1,9 +1,16 @@
 /* Layout for the RISC-V 32 boards, used by the examples in this repository. */
 
 MEMORY {
-  /* The TBF header region is 32 bytes (0x20) */
-  FLASH (rx) : ORIGIN = 0x20030020, LENGTH = 32M
-  SRAM (rwx) : ORIGIN = 0x10000000, LENGTH = 512K
+  /*
+   * The TBF header can change in size so use 0x40 combined with
+   * --protected-region-size with elf2tab to cover a header upto that
+   * size.
+   *
+   * Note that the SRAM address may need to be changed depending on
+   * the kernel binary, check for the actual address of APP_MEMORY!
+   */
+  FLASH (rx) : ORIGIN = 0x20030040, LENGTH = 32M
+  SRAM (rwx) : ORIGIN = 0x10002800, LENGTH = 512K
 }
 
 /*

--- a/layout_riscv32.ld
+++ b/layout_riscv32.ld
@@ -1,9 +1,16 @@
 /* Layout for the RISC-V 32 boards, used by the examples in this repository. */
 
 MEMORY {
-  /* The TBF header region is 32 bytes (0x20) */
-  FLASH (rx) : ORIGIN = 0x20430020, LENGTH = 32M
-  SRAM (rwx) : ORIGIN = 0x80000000, LENGTH = 512K
+  /*
+   * The TBF header can change in size so use 0x40 combined with
+   * --protected-region-size with elf2tab to cover a header upto that
+   * size.
+   *
+   * Note that the SRAM address may need to be changed depending on
+   * the kernel binary, check for the actual address of APP_MEMORY!
+   */
+  FLASH (rx) : ORIGIN = 0x20430040, LENGTH = 32M
+  SRAM (rwx) : ORIGIN = 0x80002400, LENGTH = 512K
 }
 
 /*


### PR DESCRIPTION
Currently, all of the scripts that run elf2tab are for the ARM boards and
also call tockloader. None of the RISC-V boards use tockloader at the moment
but still need the final tbf binary. Add a simple script to build and then
run elf2tab.

This can certainly be expanded in the future but right now I'm looking for something simple that we can keep in tree to let RISC-V be built easily against master