### PR TITLE
Mark stack as NOLOAD

### DIFF
--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -86,7 +86,7 @@ SECTIONS {
     } > FLASH =0xFF
 
     /* Application stack */
-    .stack :
+    .stack (NOLOAD) :
     {
         . = . + STACK_SIZE;
 


### PR DESCRIPTION
We need to reserve space for the stack in the linker script but it doesn't
actually get loaded. Mark this section as NOLOAD to account for this.

While everything seems to usually work okay without NOLOAD I ran into
an issue on a newer toolchain where data was not getting loaded in
the correct place because it was offset by the stack size. Better to
be a little cautious.