### PR TITLE
lang_items: Yield on a panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ alloc = [ "linked_list_allocator" ]
 core = { package = "async-support", path = "async-support" }
 libtock_codegen = { path = "codegen" }
 linked_list_allocator = { optional = true, version = "=0.6.5", default-features = false }
+futures = { version = "0.3.1", default-features = false, features = ["unstable", "cfg-target-has-atomic"] }
 
 [dev-dependencies]
 corepack = { version = "0.4.0", default-features = false, features = ["alloc"] }
 # We pin the serde version because newer serde versions may not be compatible
 # with the nightly toolchain used by libtock-rs.
 serde = { version = "=1.0.84", default-features = false, features = ["derive"] }
-futures = { version = "0.3.1", default-features = false, features = ["unstable", "cfg-target-has-atomic"] }
 
 [[example]]
 name = "alloc_error"

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -8,6 +8,7 @@ use core::alloc::Layout;
 use core::executor;
 use core::ptr;
 use core::ptr::NonNull;
+use futures::future;
 use linked_list_allocator::Heap;
 
 pub static mut HEAP: Heap = Heap::empty();
@@ -40,6 +41,8 @@ unsafe fn alloc_error_handler(_: Layout) -> ! {
 
         if let (Ok(leds_driver), Ok(timer_driver)) = (leds_driver, timer_driver) {
             let _ = cycle_all_leds(&leds_driver, &timer_driver).await;
+        } else {
+            future::pending::<()>().await
         }
         loop {}
     })

--- a/src/lang_items.rs
+++ b/src/lang_items.rs
@@ -25,6 +25,7 @@ use crate::timer::Duration;
 use crate::timer::ParallelSleepDriver;
 use core::executor;
 use core::panic::PanicInfo;
+use futures::future;
 
 #[lang = "start"]
 extern "C" fn start<T>(main: fn() -> T, _argc: isize, _argv: *const *const u8) -> bool
@@ -71,6 +72,8 @@ unsafe fn report_panic() -> ! {
 
         if let (Ok(leds_driver), Ok(timer_driver)) = (leds_driver, timer_driver) {
             let _ = blink_all_leds(&leds_driver, &timer_driver).await;
+        } else {
+            future::pending::<()>().await
         }
         loop {}
     })


### PR DESCRIPTION
If we panic we need ot yield to ensure any remaining prints are printed
by the kernel. This helps with debugging.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>