### PR TITLE
layout_riscv32.ld: Update the SRAM size to be correct 

### DIFF
--- a/layout_riscv32.ld
+++ b/layout_riscv32.ld
@@ -10,7 +10,7 @@ MEMORY {
    * the kernel binary, check for the actual address of APP_MEMORY!
    */
   FLASH (rx) : ORIGIN = 0x20430040, LENGTH = 32M
-  SRAM (rwx) : ORIGIN = 0x80002400, LENGTH = 512K
+  SRAM (rwx) : ORIGIN = 0x80002400, LENGTH = 0x1C00
 }
 
 /*


### PR DESCRIPTION
Reduce the size so we don't go over the memory avaliable in the hardware
or QEMU.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>