### PR TITLE
layout_riscv32.ld: Update the stack size to work with libtock-rs apps

### DIFF
--- a/layout_riscv32.ld
+++ b/layout_riscv32.ld
@@ -17,7 +17,7 @@ MEMORY {
  * Any change to STACK_SIZE should be accompanied by a corresponding change to
  * `elf2tab`'s `--stack` option
  */
-STACK_SIZE = 2048;
+STACK_SIZE = 2816;
 
 MPU_MIN_ALIGN = 1K;
 


### PR DESCRIPTION
Increase the size of the stack, to avoid growing the stack
out of bounds.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>