### PR TITLE
core/entry_point: Start the heap at app_heap_break

### DIFF
--- a/core/src/entry_point/mod.rs
+++ b/core/src/entry_point/mod.rs
@@ -84,7 +84,7 @@ libtock_codegen::make_read_env_var!("APP_HEAP_SIZE");
 /// into the rustc-generated main(). This cannot use mutable global variables or
 /// global references to globals until it is done setting up the data segment.
 #[no_mangle]
-unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, _app_heap_break: usize) -> ! {
+unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, app_heap_start: usize) -> ! {
     extern "C" {
         // This function is created internally by `rustc`. See
         // `src/lang_items.rs` for more details.
@@ -122,9 +122,6 @@ unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, _app_heap_bre
     // We get this from the environment to make it easy to set per compile.
     let app_heap_size: usize = read_APP_HEAP_SIZE();
 
-    // Make the heap start exactly at bss_end. The suggested _app_heap_break
-    // is almost always going to be too big and leads to us wasting memory.
-    let app_heap_start = bss_end;
     let app_heap_end = app_heap_start + app_heap_size;
 
     // Tell the kernel the new app heap break.

--- a/core/src/entry_point/start_item_riscv32.rs
+++ b/core/src/entry_point/start_item_riscv32.rs
@@ -78,7 +78,7 @@ pub unsafe extern "C" fn _start() -> ! {
     //
     // memop(11, stacktop + appdata_size);
     li  a0, 4               // a0 = 4   // memop syscall
-    li  a1, 11              // a1 = 10
+    li  a1, 11              // a1 = 11
     mv  a2, t1              // a2 = appdata_size
     ecall                   // memop
     //

--- a/core/src/entry_point/start_item_riscv32.rs
+++ b/core/src/entry_point/start_item_riscv32.rs
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn _start() -> ! {
     mv   a0, s0             // first arg is app_start
     mv   s0, sp             // Set the frame pointer to sp.
     mv   a1, s1             // second arg is stacktop
-    mv   a2, s2             // third arg is app_heap_break
+    mv   a2, t1             // third arg is app_heap_break that we told the kernel
     jal  rust_start"
     :                                                              // No output operands
     :


### PR DESCRIPTION
Start the app's head size at the value of app_head_break passed by the
kernel.

This gives us more space to work with which allows us to create large
buffers (such as for passing to/from the HMAC).

It also means we do what the kernel expects us to do

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>