### PR TITLE
171 enable debug symbols in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,12 @@ required-features = ["alloc"]
 [profile.dev]
 panic = "abort"
 lto = true
+debug = true
 
 [profile.release]
 panic = "abort"
 lto = true
+debug = true
 
 [workspace]
 members = [


### PR DESCRIPTION
This fixes https://github.com/tock/libtock-rs/issues/171