### PR TITLE
Makefile: add riscv32imac target in setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ endif
 .PHONY: setup
 setup:
 	rustup target add thumbv7em-none-eabi
+	rustup target add riscv32imac-unknown-none-elf
 	rustup target add riscv32imc-unknown-none-elf
 	rustup component add rustfmt
 	rustup component add clippy


### PR DESCRIPTION
The hifive1 board needs the 'a' atomic operations as well. Install that
target during setup.

Signed-off-by: Dylan Reid <dgreid@chromium.org>