### PR TITLE
Remove extern crate statement

### DIFF
--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -1,6 +1,4 @@
 #![recursion_limit = "128"]
-extern crate proc_macro;
-extern crate proc_macro2;
 
 use proc_macro::TokenStream;
 


### PR DESCRIPTION
# Summary

This PR removes the now unecessary `extern crate` statement inside the proc macro. The necessity to use this has been removed in 1.42.0 compiler version.