### PR TITLE
updated origin of nrf52

### DIFF
--- a/boards/layout_nrf52.ld
+++ b/boards/layout_nrf52.ld
@@ -3,7 +3,7 @@
 MEMORY {
   /* The application region is 64 bytes (0x40) */
   FLASH (rx) : ORIGIN = 0x00030040, LENGTH = 0x0005FFC0
-  SRAM (rwx) : ORIGIN = 0x20002000, LENGTH = 62K
+  SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
 }
 
 /*


### PR DESCRIPTION
Before editing this value I got a kernel panic when running examples. The panic message said that SRAM starts at 0x20004000. Since ORIGIN in layout_nrf52.ld was edited to, the examples ran fine.