### PR TITLE
boards: Set stack size from within apps

### DIFF
--- a/boards/layout_apollo3.ld
+++ b/boards/layout_apollo3.ld
@@ -6,12 +6,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x10002000, LENGTH = 0x2000
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_hail.ld
+++ b/boards/layout_hail.ld
@@ -6,12 +6,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_hifive1.ld
+++ b/boards/layout_hifive1.ld
@@ -13,12 +13,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x80002400, LENGTH = 0x1C00
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 1K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_imxrt1050.ld
+++ b/boards/layout_imxrt1050.ld
@@ -6,12 +6,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 112K
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_msp432.ld
+++ b/boards/layout_msp432.ld
@@ -4,12 +4,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 0x2000
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_nrf52.ld
+++ b/boards/layout_nrf52.ld
@@ -6,12 +6,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_nrf52840.ld
+++ b/boards/layout_nrf52840.ld
@@ -6,12 +6,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_nucleo_f429zi.ld
+++ b/boards/layout_nucleo_f429zi.ld
@@ -6,12 +6,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 112K
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_nucleo_f446re.ld
+++ b/boards/layout_nucleo_f446re.ld
@@ -6,12 +6,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 176K
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 8K;
 
 INCLUDE layout_generic.ld

--- a/boards/layout_opentitan.ld
+++ b/boards/layout_opentitan.ld
@@ -13,12 +13,6 @@ MEMORY {
   SRAM (rwx) : ORIGIN = 0x10004000, LENGTH = 512K
 }
 
-/*
- * Any change to STACK_SIZE should be accompanied by a corresponding change to
- * `elf2tab`'s `--stack` option
- */
-STACK_SIZE = 2048;
-
 MPU_MIN_ALIGN = 1K;
 
 INCLUDE layout_generic.ld

--- a/core/examples/empty_main.rs
+++ b/core/examples/empty_main.rs
@@ -4,6 +4,11 @@
 
 #![no_std]
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x400] = [0; 0x400];
+
 // If you don't *use* anything from libtock_core directly, cargo will not link
 // it into the executable. However, we still need the runtime and lang items.
 // Therefore a libtock_core app that doesn't directly mention anything in

--- a/examples-features/alloc_error.rs
+++ b/examples-features/alloc_error.rs
@@ -11,6 +11,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 fn main() -> TockResult<()> {
     let mut vec = Vec::new();

--- a/examples-features/ble_scanning.rs
+++ b/examples-features/ble_scanning.rs
@@ -5,6 +5,11 @@ use libtock::result::TockResult;
 use libtock::simple_ble;
 use serde::Deserialize;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[derive(Deserialize)]
 struct LedCommand {
     pub nr: u8,

--- a/examples-features/ctap.rs
+++ b/examples-features/ctap.rs
@@ -4,6 +4,11 @@
 #![no_std]
 #![feature(alloc_error_handler)]
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x5000] = [0; 0x5000];
+
 extern crate alloc;
 
 use core::alloc::Layout;

--- a/examples-features/libtock_test.rs
+++ b/examples-features/libtock_test.rs
@@ -22,6 +22,11 @@ use libtock::result::TockResult;
 use libtock::timer::DriverContext;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples-features/panic.rs
+++ b/examples-features/panic.rs
@@ -7,6 +7,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     panic!("Bye world!");

--- a/examples-features/simple_ble.rs
+++ b/examples-features/simple_ble.rs
@@ -7,6 +7,11 @@ use libtock::simple_ble::BleAdvertisingDriver;
 use libtock::timer::Duration;
 use serde::Serialize;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[derive(Serialize)]
 struct LedCommand {
     pub nr: u8,

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -4,6 +4,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -5,6 +5,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 /// Reads a 128 byte sample into a buffer and prints the first value to the console.
 async fn main() -> TockResult<()> {

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -3,6 +3,11 @@
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x400] = [0; 0x400];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/blink_random.rs
+++ b/examples/blink_random.rs
@@ -4,6 +4,11 @@ use libtock::leds::LedsDriver;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x400] = [0; 0x400];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/button_leds.rs
+++ b/examples/button_leds.rs
@@ -4,6 +4,11 @@ use futures::future;
 use libtock::buttons::ButtonState;
 use libtock::result::TockResult;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -4,6 +4,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -6,6 +6,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/ctap.rs
+++ b/examples/ctap.rs
@@ -6,6 +6,11 @@ use libtock::result::TockResult;
 use libtock::syscalls;
 use libtock::{print, println};
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -3,6 +3,11 @@
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 // Example works on P0.03
 #[libtock::main]
 async fn main() -> TockResult<()> {

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -5,6 +5,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 // example works on p0.03
 #[libtock::main]
 async fn main() -> TockResult<()> {

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -7,6 +7,11 @@
 use libtock::println;
 use libtock::result::TockResult;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x400] = [0; 0x400];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let drivers = libtock::retrieve_drivers()?;

--- a/examples/hmac.rs
+++ b/examples/hmac.rs
@@ -5,6 +5,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -5,6 +5,11 @@ use libtock::result::TockResult;
 use libtock::sensors::Sensor;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/seven_segment.rs
+++ b/examples/seven_segment.rs
@@ -4,6 +4,11 @@ use libtock::electronics::ShiftRegister;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 fn number_to_bits(n: u8) -> [bool; 8] {
     match n {
         1 => [false, false, false, true, false, true, false, false],

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -4,6 +4,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -8,6 +8,11 @@ use libtock::result::TockResult;
 use libtock::timer::DriverContext;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 const DELAY_MS: usize = 500;
 
 #[libtock::main]

--- a/examples/timer_parallel.rs
+++ b/examples/timer_parallel.rs
@@ -6,6 +6,11 @@ use libtock::result::TockResult;
 use libtock::timer::Duration;
 use libtock::timer::ParallelSleepDriver;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 async fn blink(
     timer_driver: &ParallelSleepDriver<'_>,
     duration: Duration<usize>,

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -5,6 +5,11 @@ use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
+/// Dummy buffer that causes the linker to reserve enough space for the stack.
+#[no_mangle]
+#[link_section = ".stack_buffer"]
+pub static mut STACK_MEMORY: [u8; 0x800] = [0; 0x800];
+
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;

--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -14,7 +14,6 @@
  *         FLASH (rx) : ORIGIN = 0x10030, LENGTH = 0x0FFD0
  *         SRAM (RWX) : ORIGIN = 0x20000, LENGTH = 0x10000
  *     }
- *     STACK_SIZE = 2048;
  *     MPU_MIN_ALIGN = 8K;
  *     INCLUDE ../libtock-rs/layout.ld
  */
@@ -64,7 +63,7 @@ SECTIONS {
          * .rel.data section */
         LONG(LOADADDR(.endflash) - _beginning);
         /* The size of the stack requested by this application */
-        LONG(STACK_SIZE);
+        LONG(_stack_top_aligned - _sstack);
         /* Pad the header out to a multiple of 32 bytes so there is not a gap
          * between the header and subsequent .data section. It's unclear why,
          * but LLD is aligning sections to a multiple of 32 bytes. */
@@ -96,12 +95,11 @@ SECTIONS {
          * TBF header if needed.
          */
         _sram_origin = .;
-
-        . = . + STACK_SIZE;
-
-	_stack_top_unaligned = .;
+        _sstack = .;
+         KEEP(*(.stack_buffer))
+         _stack_top_unaligned = .;
         . = ALIGN(8);
-	_stack_top_aligned = .;
+        _stack_top_aligned = .;
     } > SRAM
 
     /* Data section, static initialized variables
@@ -165,4 +163,4 @@ SECTIONS {
 }
 
 ASSERT((_stack_top_aligned - _stack_top_unaligned) == 0, "
-STACK_SIZE must be 8 byte multiple")
+the stack size must be 8 byte multiple")

--- a/tools/flash.sh
+++ b/tools/flash.sh
@@ -68,7 +68,9 @@ tab_file_name="${libtock_target_path}.tab"
 mkdir -p "${libtock_target_path}"
 cp "$1" "${elf_file_name}"
 
-elf2tab -n "${artifact}" -o "${tab_file_name}" "${elf_file_name}" --stack 2048 --app-heap $APP_HEAP_SIZE --kernel-heap $KERNEL_HEAP_SIZE --protected-region-size=64
+STACK_SIZE=$(nm --print-size --size-sort --radix=d "${elf_file_name}" | grep STACK_MEMORY | cut -d " " -f 2)
+
+elf2tab -n "${artifact}" -o "${tab_file_name}" "${elf_file_name}" --stack ${STACK_SIZE} --app-heap $APP_HEAP_SIZE --kernel-heap $KERNEL_HEAP_SIZE --protected-region-size=64
 
 if [ $tockload == "n" ]; then
 	echo "Skipping flashing for platform \"${PLATFORM}\""


### PR DESCRIPTION
Stack size isn't board specific, but more app specific. So let's set the
stack size from within apps.

This follows what TockOS does and sets a buffer for the stack. We then
parse that buffer when running elf2tab to use that value.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>