### PR TITLE
Proposal: Allow setting the stack size on build time

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ This script does the following steps for you:
 - create a TAB (tock application bundle)
 - if you have a J-Link compatible board connected: flash this TAB to your board (using tockloader)
 
+## Configuration of Memory Sizes
+
+The configuration of different memory parameters can be configured using
+environment variables:
+
+- `APP_HEAP_SIZE` sets the size of the app heap and defaults to 1024.
+- `APP_STACK_SIZE` sets the size of the app stack and default to 2048.
+- `KERNEL_HEAP_SIZE` sets the size of the kernel heap and default to 1024.
 
 ## License
 

--- a/boards/layout_hail.ld.handlebars
+++ b/boards/layout_hail.ld.handlebars
@@ -1,16 +1,16 @@
-/* Layout for the nRF52-DK, used by the examples in this repository. */
+/* Layout for the Hail board, used by the examples in this repository. */
 
 MEMORY {
   /* The application region is 64 bytes (0x40) */
   FLASH (rx) : ORIGIN = 0x00030040, LENGTH = 0x0005FFC0
-  SRAM (rwx) : ORIGIN = 0x20002000, LENGTH = 62K
+  SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
 }
 
 /*
  * Any change to STACK_SIZE should be accompanied by a corresponding change to
  * `elf2tab`'s `--stack` option
  */
-STACK_SIZE = 2048;
+STACK_SIZE = {{stack_size}};
 
 MPU_MIN_ALIGN = 8K;
 

--- a/boards/layout_hifive1.ld.handlebars
+++ b/boards/layout_hifive1.ld.handlebars
@@ -9,15 +9,15 @@ MEMORY {
    * Note that the SRAM address may need to be changed depending on
    * the kernel binary, check for the actual address of APP_MEMORY!
    */
-  FLASH (rx) : ORIGIN = 0x20030040, LENGTH = 32M
-  SRAM (rwx) : ORIGIN = 0x10002800, LENGTH = 512K
+  FLASH (rx) : ORIGIN = 0x20040040, LENGTH = 32M
+  SRAM (rwx) : ORIGIN = 0x80002400, LENGTH = 0x1C00
 }
 
 /*
  * Any change to STACK_SIZE should be accompanied by a corresponding change to
  * `elf2tab`'s `--stack` option
  */
-STACK_SIZE = 2048;
+STACK_SIZE = {{stack_size}};
 
 MPU_MIN_ALIGN = 1K;
 

--- a/boards/layout_nrf52.ld.handlebars
+++ b/boards/layout_nrf52.ld.handlebars
@@ -1,16 +1,16 @@
-/* Layout for the Hail board, used by the examples in this repository. */
+/* Layout for the nRF52-DK, used by the examples in this repository. */
 
 MEMORY {
   /* The application region is 64 bytes (0x40) */
   FLASH (rx) : ORIGIN = 0x00030040, LENGTH = 0x0005FFC0
-  SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
+  SRAM (rwx) : ORIGIN = 0x20002000, LENGTH = 62K
 }
 
 /*
  * Any change to STACK_SIZE should be accompanied by a corresponding change to
  * `elf2tab`'s `--stack` option
  */
-STACK_SIZE = 2048;
+STACK_SIZE = {{stack_size}};
 
 MPU_MIN_ALIGN = 8K;
 

--- a/boards/layout_nrf52840.ld.handlebars
+++ b/boards/layout_nrf52840.ld.handlebars
@@ -10,7 +10,7 @@ MEMORY {
  * Any change to STACK_SIZE should be accompanied by a corresponding change to
  * `elf2tab`'s `--stack` option
  */
-STACK_SIZE = 2048;
+STACK_SIZE = {{stack_size}};
 
 MPU_MIN_ALIGN = 8K;
 

--- a/boards/layout_opentitan.ld.handlebars
+++ b/boards/layout_opentitan.ld.handlebars
@@ -9,15 +9,15 @@ MEMORY {
    * Note that the SRAM address may need to be changed depending on
    * the kernel binary, check for the actual address of APP_MEMORY!
    */
-  FLASH (rx) : ORIGIN = 0x20040040, LENGTH = 32M
-  SRAM (rwx) : ORIGIN = 0x80002400, LENGTH = 0x1C00
+  FLASH (rx) : ORIGIN = 0x20030040, LENGTH = 32M
+  SRAM (rwx) : ORIGIN = 0x10002800, LENGTH = 512K
 }
 
 /*
  * Any change to STACK_SIZE should be accompanied by a corresponding change to
  * `elf2tab`'s `--stack` option
  */
-STACK_SIZE = 2048;
+STACK_SIZE = {{stack_size}};
 
 MPU_MIN_ALIGN = 1K;
 

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,15 @@
 use std::env;
 use std::fs;
 use std::fs::File;
+use std::io::prelude::*;
 use std::io::BufRead;
 use std::io::BufReader;
 use std::path::Path;
 use std::process;
 
 static LAYOUT_FILE_NAME: &str = "layout.ld";
+static APP_STACK_SIZE: &str = "APP_STACK_SIZE";
+static DEFAULT_STACK_SIZE_BYTES: &str = "2048";
 
 fn main() {
     static PLATFORM_ENV_VAR: &str = "PLATFORM";
@@ -16,15 +19,28 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed={}", PLATFORM_ENV_VAR);
     println!("cargo:rerun-if-env-changed={}", APP_HEAP_SIZE);
+    println!("cargo:rerun-if-env-changed={}", APP_STACK_SIZE);
     println!("cargo:rerun-if-env-changed={}", KERNEL_HEAP_SIZE);
     println!("cargo:rerun-if-changed={}", PLATFORM_FILE_NAME);
     println!("cargo:rerun-if-changed={}", LAYOUT_FILE_NAME);
+
+    let stack_size = read_env_var(APP_STACK_SIZE);
+    if stack_size.is_none() {
+        println!(
+            "cargo:warning=No explicit stack size specified. \
+             Using default of 2048 bytes. \
+             Set this explicitly using the \
+             environment variable {}.
+             ",
+            APP_STACK_SIZE
+        );
+    }
 
     let platform_name =
         read_env_var(PLATFORM_ENV_VAR).or_else(|| read_board_name_from_file(PLATFORM_FILE_NAME));
     if let Some(platform_name) = platform_name {
         println!("cargo:rustc-env={}={}", PLATFORM_ENV_VAR, platform_name);
-        copy_linker_file(platform_name.trim());
+        create_linker_file(platform_name.trim(), stack_size);
     } else {
         println!(
             "cargo:warning=No platform specified. \
@@ -34,13 +50,14 @@ fn main() {
 
     set_default_env(APP_HEAP_SIZE, "1024");
     set_default_env(KERNEL_HEAP_SIZE, "1024");
+    set_default_env(APP_STACK_SIZE, DEFAULT_STACK_SIZE_BYTES);
 }
 
 fn set_default_env(env_var: &str, default: &str) {
     if let Some(s) = read_env_var(env_var) {
         println!("cargo:rustc-env={}={}", env_var, s);
     } else {
-        // Just use a default of 1024 if nothing is passed in
+        // Use the provided default value if nothing is passed in
         println!("cargo:rustc-env={}={}", env_var, default);
     }
 }
@@ -63,12 +80,30 @@ fn read_board_name_from_file(file_name: &str) -> Option<String> {
     Some(board_name)
 }
 
-fn copy_linker_file(platform_name: &str) {
-    let linker_file_name = format!("boards/layout_{}.ld", platform_name);
+fn create_linker_file(platform_name: &str, stack_size: Option<String>) {
+    let linker_file_name = format!("boards/layout_{}.ld.handlebars", platform_name);
+
     let path = Path::new(&linker_file_name);
     if !path.exists() {
-        println!("Cannot find layout file {:?}", path);
+        println!("Cannot find layout template file {:?}", path);
         process::exit(1);
     }
-    fs::copy(linker_file_name, LAYOUT_FILE_NAME).unwrap();
+
+    create_linker_file_from_template(
+        path,
+        &stack_size.unwrap_or_else(|| DEFAULT_STACK_SIZE_BYTES.to_string()),
+    )
+}
+
+fn create_linker_file_from_template(path: &Path, stack_size: &str) {
+    let mut linker_template = File::open(path).expect("Failed to open file.");
+    let mut template_content = String::new();
+    linker_template
+        .read_to_string(&mut template_content)
+        .expect("Could not read linke file to string.");
+
+    let processed_template = template_content.replace("{{stack_size}}", &stack_size);
+
+    let out_path = Path::new(LAYOUT_FILE_NAME);
+    fs::write(out_path, processed_template).expect("Failed to write linker file.");
 }

--- a/tools/flash.sh
+++ b/tools/flash.sh
@@ -48,7 +48,7 @@ tab_file_name="${libtock_target_path}.tab"
 mkdir -p "${libtock_target_path}"
 cp "$1" "${elf_file_name}"
 
-elf2tab -n "${artifact}" -o "${tab_file_name}" "${elf_file_name}" --stack 2048 --app-heap $APP_HEAP_SIZE --kernel-heap $KERNEL_HEAP_SIZE --protected-region-size=64
+elf2tab -n "${artifact}" -o "${tab_file_name}" "${elf_file_name}" --stack $APP_STACK_SIZE --app-heap $APP_HEAP_SIZE --kernel-heap $KERNEL_HEAP_SIZE --protected-region-size=64
 
 if [ $tockload == "n" ]; then
 	echo "Skipping flashing for platform \"${PLATFORM}\""


### PR DESCRIPTION
# Contents

In this PR I propose a way to set the stack size on build time. I use a very simple replacement routine on build time to create the layout files of the app which sets the stack size obtained from the environment variable `APP_STACK_SIZE`.

# Advantages

I think there will be more use cases which need to change the layout file on compile time as for example multiple app support.

# Disadvantages

Changing the stack size is not possible per app, at least not trivially. If this is absolutely required one could read the required stack sizes from configuration files next to the examples. However, the main use case for the build system should be supporting to build one app in one crate depending on `libtock-rs`.

Also reading from environmental variables might not be the preferred way to configure a build system. But any change to this should come alongside with a change to the usage of the variables`PLATFORM`, `APP_HEAP` and `KERNEL_HEAP`. 

# Extensions

As `build.rs` is growing some of the functionality should be moved to a separate "build tools" crate.
Moreover, I feel that some sections of `layout_generic.ld` and the layout files themselves could be generated from primitive values like the beginning of the ram, the size of the kernel from the platform etc. so the linker files get easier to maintain.
