### PR TITLE
Replace 'clone_from_slice' with 'copy_from_slice'

### DIFF
--- a/core/src/shared_memory.rs
+++ b/core/src/shared_memory.rs
@@ -42,5 +42,5 @@ fn safe_copy(origin: &[u8], destination: &mut [u8]) {
     let amount = origin.len().min(destination.len());
     let origin = &origin[0..amount];
     let destination = &mut destination[0..amount];
-    destination.clone_from_slice(origin);
+    destination.copy_from_slice(origin);
 }


### PR DESCRIPTION
Currently, `shared_memory::safe_copy` uses `clone_from_slice` to
perform memory copy. `clone_from_slice` iterates over each element of
slice to invoke 'clone_from'. According to [docs of `clone_from_slice`](https://doc.rust-lang.org/std/primitive.slice.html#method.clone_from_slice),
it can be more performant to use `copy_from_slice` instead when copy target implements `Copy`.
Since we're copying a `u8` slice, I thought replacing `clone_from_slice` with `copy_from_slice` would be a helpful change regarding performance.

Thank you for reviewing this PR :)