### PR TITLE
Add documentation describing `libtock-rs`'s unaudited third-party dependencies.

### DIFF
--- a/doc/Dependencies.md
+++ b/doc/Dependencies.md
@@ -1,14 +1,21 @@
 Third Party Dependencies
 ========================
 
+This document is about dependencies that are required to build applications
+using `libtock-rs`. Dependencies required to run `libtock-rs`' tests (such as
+`make`) are outside the scope of this document.
+
 ## Unaudited Required Dependencies
 
-`libtock-rs` has the following required dependencies, none of which are
+`libtock-rs` has the following required build dependencies, none of which are
 currently audited:
 
-* [`libcore`](https://github.com/rust-lang/rust/tree/master/src/libcore),
-  included as part of the Rust toolchain and implicitly added by the Rust
-  compiler.
+* The Rust toolchain, including
+  [`cargo`](https://github.com/rust-lang/cargo),
+  [`rustc`](https://github.com/rust-lang/rust/tree/master/src/rustc), and
+  [`libcore`](https://github.com/rust-lang/rust/tree/master/src/libcore). The
+  specific toolchain version used is specified by the `rust-toolchain` file at
+  the root of the repository.
 * [`syn`](https://crates.io/crates/syn), pulled in by `libtock_codegen`.
 * [`quote`](https://crates.io/crates/quote), pulled in by `libtock_codegen`.
 * [`proc-macro2`](https://crates.io/crates/proc-macro2), pulled in by

--- a/doc/Dependencies.md
+++ b/doc/Dependencies.md
@@ -2,7 +2,9 @@ Third Party Dependencies
 ========================
 
 This document is about dependencies that are required to build applications
-using `libtock-rs`. Dependencies required to run `libtock-rs`' tests (such as
+using `libtock-rs`. These dependencies are not contained in the libtock-rs
+repository, but are used by libtock-rs when libtock-rs is used as a dependency
+of an application. Dependencies required to run `libtock-rs`' tests (such as
 `make`) are outside the scope of this document.
 
 ## Unaudited Required Dependencies

--- a/doc/Dependencies.md
+++ b/doc/Dependencies.md
@@ -1,0 +1,20 @@
+Third Party Dependencies
+========================
+
+## Unaudited Required Dependencies
+
+`libtock-rs` has the following required dependencies, none of which are
+currently audited:
+
+* [`libcore`](https://github.com/rust-lang/rust/tree/master/src/libcore),
+  included as part of the Rust toolchain and implicitly added by the Rust
+  compiler.
+* [`syn`](https://crates.io/crates/syn), pulled in by `libtock_codegen`.
+* [`quote`](https://crates.io/crates/quote), pulled in by `libtock_codegen`.
+* [`proc-macro2`](https://crates.io/crates/proc-macro2), pulled in by
+  `libtock_codegen`.
+
+## Avoiding Optional Dependencies
+
+To avoid pulling in optional dependencies, users should use `libtock-core`
+instead of `libtock`. `libtock-core` is in the `core/` directory.


### PR DESCRIPTION
This document is required by [Tock's threat model](https://github.com/tock/tock/blob/master/doc/threat_model/Code_Review.md).

[Rendered](https://github.com/jrvanwhy/libtock-rs/blob/threat-model-doc/doc/Dependencies.md)