### PR TITLE
boards: opentitan: Update the SRAM layout

### DIFF
--- a/boards/layout_opentitan.ld
+++ b/boards/layout_opentitan.ld
@@ -10,7 +10,7 @@ MEMORY {
    * the kernel binary, check for the actual address of APP_MEMORY!
    */
   FLASH (rx) : ORIGIN = 0x20030040, LENGTH = 32M
-  SRAM (rwx) : ORIGIN = 0x10002800, LENGTH = 512K
+  SRAM (rwx) : ORIGIN = 0x10002D00, LENGTH = 512K
 }
 
 /*


### PR DESCRIPTION
As Tock for OT has gotten larger the SRAM allocated for apps has moved
up in memory. Let's update the linker script to better match what Tock
is allocating.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>