### PR TITLE
Remove the core/ directory from the cargo workspace.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Files ignored repository-wide.
 Cargo.lock
+target
 
 # Files ignored only in this directory.
 /layout.ld
 /platform
-/target

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-/Cargo.lock
+# Files ignored repository-wide.
+Cargo.lock
+
+# Files ignored only in this directory.
 /layout.ld
 /platform
 /target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ lto = true
 debug = true
 
 [workspace]
+exclude = [ "core" ]
 members = [
     "codegen",
-    "core",
     "test-runner"
 ]


### PR DESCRIPTION
Context: https://github.com/tock/libtock-rs/issues/196. When a Tock application depends on libtock-core, cargo scans through the entire workspace doing dependency resolution. This makes all dependencies of any crate in the workspace a transitive build dependency of Tock apps. libtock-core was intentionally meant to be low-dependency, so these build dependencies aren't acceptable.

Instead, this commit makes libtock-core a crate independent of a cargo workspace. In the future, if we want to split libtock-core into multiple crates, we can make core/ a workspace itself (I tested this by hand and verified it works).