### PR TITLE
Add the QEMU test invocation to `make test`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build
 /Cargo.lock
 /layout.ld
 /platform

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/build
 /Cargo.lock
 /layout.ld
 /platform

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tock"]
+	path = tock
+	url = https://github.com/tock/tock.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,36 +13,8 @@ os:
 
 cache: cargo
 
-# Once Travis supports a version of Ubuntu that inlcudes QEMU 5.1+
-#    we can apt install QEMU for RISC-V.
-# Until then we need to build it ourselves
-before_install:
-  #   - sudo apt-get -y install qemu-system-misc
-  # addons:
-  #   apt:
-  #     update: true
-  - git clone https://github.com/alistair23/qemu.git -b riscv-tock.next
-  - pushd qemu
-  - ./configure --target-list=riscv32-softmmu
-  - make -j8
-  - sudo ln -s $PWD/riscv32-softmmu/qemu-system-riscv32 /usr/bin/
-  - popd
-
 install:
   - make setup
-  # Build Tock, it needs to be outside of the libtock-rs source
-  - pushd ../
-  - git clone https://github.com/tock/tock.git
-  - cd tock/boards/hifive1
-  # Use a known working version of Tock
-  - git checkout 152189fe077aea955332ee3c28ccbee519d8b072
-  - make
-  - popd
 
 script:
   - make test
-  # Run a QEMU instance of the HiFive1 app
-  - PLATFORM=hifive1 cargo rrv32imac --example libtock_test --features=alloc --features=__internal_disable_gpio_in_integration_test
-  - pushd test-runner
-  - cargo run
-  - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ os:
 cache: cargo
 
 install:
-  - make setup
+  - make -j8 setup
 
 script:
   - make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ lto = true
 debug = true
 
 [workspace]
+exclude = [ "tock" ]
 members = [
     "codegen",
     "core",

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ release=--release
 endif
 
 .PHONY: setup
-setup:
+setup: setup-qemu
 	rustup target add thumbv7em-none-eabi
 	rustup target add riscv32imac-unknown-none-elf
 	rustup target add riscv32imc-unknown-none-elf
@@ -40,6 +40,17 @@ setup:
 	rustup component add clippy
 	cargo install elf2tab --version 0.4.0
 	cargo install stack-sizes
+
+.PHONY: setup-qemu
+setup-qemu:
+	mkdir -p build
+	cd build                                              && \
+	git clone https://github.com/alistair23/qemu.git         \
+	          -b riscv-tock.next --depth 1                && \
+	cd qemu                                               && \
+	./configure --prefix=$(CURDIR)/build                     \
+	            --target-list=arm-softmmu,riscv32-softmmu && \
+	$(MAKE) install
 
 .PHONY: examples
 examples:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project is nascent and still under heavy development, but first steps:
 1.  Clone the repository:
 
     ```shell
-    git clone https://github.com/tock/libtock-rs
+    git clone --recursive https://github.com/tock/libtock-rs
     cd libtock-rs
     ```
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This script does the following steps for you:
 
 ## License
 
-Licensed under either of
+libtock-rs is licensed under either of
 
 - Apache License, Version 2.0
   ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
@@ -112,6 +112,8 @@ Licensed under either of
   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
+
+Submodules have their own licenses.
 
 ### Contribution
 

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn perform_tests() -> Result<(), Box<dyn std::error::Error>> {
     let mut failed_tests = Vec::new();
 
-    let  tests = Command::new("build/bin/qemu-system-riscv32")
+    let tests = Command::new("tock/tools/qemu/riscv32-softmmu/qemu-system-riscv32")
         .arg("-M")
         .arg("sifive_e,revb=true")
         .arg("-kernel")

--- a/test-runner/src/main.rs
+++ b/test-runner/src/main.rs
@@ -14,14 +14,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn perform_tests() -> Result<(), Box<dyn std::error::Error>> {
     let mut failed_tests = Vec::new();
 
-    let  tests = Command::new("qemu-system-riscv32")
+    let  tests = Command::new("build/bin/qemu-system-riscv32")
         .arg("-M")
         .arg("sifive_e,revb=true")
         .arg("-kernel")
-        .arg("../../tock/target/riscv32imac-unknown-none-elf/release/hifive1")
+        .arg("tock/target/riscv32imac-unknown-none-elf/release/hifive1")
         .arg("-device")
-        .arg("loader,file=./../target/riscv32imac-unknown-none-elf/tab/hifive1/libtock_test/rv32imac.tbf,addr=0x20040000")
+        .arg("loader,file=target/riscv32imac-unknown-none-elf/tab/hifive1/libtock_test/rv32imac.tbf,addr=0x20040000")
         .arg("-nographic")
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .kill_on_drop(true)
         .spawn()?;


### PR DESCRIPTION
Prior to this PR, there was no easy way to run `libtock_test` in QEMU. It was run as part of the Travis CI checks, but not `make test`. This PR moves that functionality into the Makefile, so that `make test` runs the QEMU tests.

Main changes in this PR:

1. Added a tock submodule pointing to the kernel version the tests are run against. This submodule is used to build Tock kernels for testing.
1. Tweaked the README to clarify that the Tock submodule has its own license (although it matches libtock-rs' license).
1. Added `make setup-qemu`, automatically run as part of `make qemu`, which compiles QEMU in a new `build` directory. This shouldn't touch the host system, although you need QEMU's dependencies for it to succeed.
1. Tweaked `test-runner` to use the QEMU and Tock kernel built by `make setup-qemu` and `make kernel-hifive`.
1. Added `test-qemu-hifive` to run `libtock_test` on an emulated hifive.
1. Added `test-qemu-hifive` as a dependency of `test` so that `make test` runs both sets of tests
1. Replaced `make examples` with a dependency on the examples, so that running parallel make jobs works correctly.