### PR TITLE
Amend memory layout for nordic boards to match tock 1.5 release

### DIFF
--- a/boards/layout_nrf52.ld
+++ b/boards/layout_nrf52.ld
@@ -3,7 +3,7 @@
 MEMORY {
   /* The application region is 64 bytes (0x40) */
   FLASH (rx) : ORIGIN = 0x00030040, LENGTH = 0x0005FFC0
-  SRAM (rwx) : ORIGIN = 0x20002000, LENGTH = 62K
+  SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 62K
 }
 
 /*

--- a/examples-features/libtock_test.rs
+++ b/examples-features/libtock_test.rs
@@ -1,5 +1,6 @@
 // Libtock regression tests to be used with real hardware.
-// Requires P0.03 and P0.04 to be connected (on a nRF52 DK).
+// Requires P0.03 and P0.04 to be connected (on a nRF52 DK) and
+// P0.01 and P0.03 to be connected (on a nRF52840dk).
 
 #![no_std]
 extern crate alloc;


### PR DESCRIPTION
# Contents

In this PR I amend the memory layout for the nrf52dk to match the kernel size of the tock 1.5 release. This breaks compatibility with previous releases and should be merged alongside with #195 .

I also tested the nrf52840 board which is already working with the 1.5 kernel without any changes.

# Testing

I ran the test suites on both development boards. However, I did no thorough test of compatibility of `libtock-rs` with the new kernel release.