### PR TITLE
Add a heap feature to libtock-rs/core.

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 edition = "2018"
 
 [features]
-alloc = [ "linked_list_allocator" ]
+alloc = ["alloc_init", "linked_list_allocator"]
+alloc_init = []
 custom_panic_handler = []
 custom_alloc_error_handler = []
 

--- a/core/src/alloc.rs
+++ b/core/src/alloc.rs
@@ -4,7 +4,12 @@ use core::ptr;
 use core::ptr::NonNull;
 use linked_list_allocator::Heap;
 
-pub static mut HEAP: Heap = Heap::empty();
+static mut HEAP: Heap = Heap::empty();
+
+#[no_mangle]
+unsafe fn alloc_init(app_heap_start: usize, app_heap_size: usize) {
+    HEAP.init(app_heap_start, app_heap_size);
+}
 
 struct TockAllocator;
 

--- a/core/src/alloc.rs
+++ b/core/src/alloc.rs
@@ -7,7 +7,7 @@ use linked_list_allocator::Heap;
 static mut HEAP: Heap = Heap::empty();
 
 #[no_mangle]
-unsafe fn alloc_init(app_heap_start: usize, app_heap_size: usize) {
+unsafe fn libtock_alloc_init(app_heap_start: usize, app_heap_size: usize) {
     HEAP.init(app_heap_start, app_heap_size);
 }
 

--- a/core/src/entry_point/mod.rs
+++ b/core/src/entry_point/mod.rs
@@ -127,8 +127,8 @@ unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, app_heap_star
     // Tell the kernel the new app heap break.
     memop::set_brk(app_heap_end as *const u8);
 
-    #[cfg(feature = "alloc")]
-    crate::alloc::HEAP.init(app_heap_start, app_heap_size);
+    #[cfg(feature = "alloc_init")]
+    crate::alloc_init(app_heap_start, app_heap_size);
 
     main(0, ptr::null());
 

--- a/core/src/entry_point/mod.rs
+++ b/core/src/entry_point/mod.rs
@@ -128,7 +128,7 @@ unsafe extern "C" fn rust_start(app_start: usize, stacktop: usize, app_heap_star
     memop::set_brk(app_heap_end as *const u8);
 
     #[cfg(feature = "alloc_init")]
-    crate::alloc_init(app_heap_start, app_heap_size);
+    crate::libtock_alloc_init(app_heap_start, app_heap_size);
 
     main(0, ptr::null());
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,11 @@ mod entry_point;
 #[cfg(any(target_arch = "arm", target_arch = "riscv32"))]
 mod lang_items;
 
+#[cfg(feature = "alloc_init")]
+extern "Rust" {
+    fn alloc_init(app_heap_start: usize, app_heap_size: usize);
+}
+
 pub mod callback;
 pub mod debug;
 pub mod memop;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,7 +10,7 @@ mod lang_items;
 
 #[cfg(feature = "alloc_init")]
 extern "Rust" {
-    fn alloc_init(app_heap_start: usize, app_heap_size: usize);
+    fn libtock_alloc_init(app_heap_start: usize, app_heap_size: usize);
 }
 
 pub mod callback;


### PR DESCRIPTION
This pull request adds a `heap` feature to the core crate of libtock-rs. This allows to configure the core crate to only enable and initialize the `HEAP` variable, while leaving the choice of defining a custom allocator.

Indeed, the `HEAP` is conveniently initialized in the entry point with the app's heap start/size.

An example use case is in OpenSK (see this pull request https://github.com/google/OpenSK/pull/123), where the custom allocator can print some debugging information about allocations & deallocation to the console - while the heap implementation is the same as the default of libtock-rs (i.e. `linked_list_allocator`).

---

An alternative to this feature could be to somehow communicate the app's heap start/size to the `main` function, so that each app can initialize its own allocator when the `alloc` feature is off.