### PR TITLE
boards: opentitan: Update the OpenTitan SRAM address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ os:
 cache: cargo
 
 install:
-  - make -j8 setup
+  - CI=y make -j8 setup
+  - rm -rf ~/opentitan* # Make sure this isn't left over, see https://github.com/tock/tock/pull/1978
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ setup: setup-qemu
 # patches to better support boards that Tock supports.
 .PHONY: setup-qemu
 setup-qemu:
-	$(MAKE) -C tock emulation-setup
+	$(MAKE) -C tock ci-job-qemu
 
 # Builds a Tock kernel for the HiFive board for use by QEMU tests.
 .PHONY: kernel-hifive

--- a/boards/layout_opentitan.ld
+++ b/boards/layout_opentitan.ld
@@ -10,7 +10,7 @@ MEMORY {
    * the kernel binary, check for the actual address of APP_MEMORY!
    */
   FLASH (rx) : ORIGIN = 0x20030040, LENGTH = 32M
-  SRAM (rwx) : ORIGIN = 0x10002D00, LENGTH = 512K
+  SRAM (rwx) : ORIGIN = 0x10003000, LENGTH = 512K
 }
 
 /*


### PR DESCRIPTION
Update the OpenTitan SRAM address to make current master Tock, also
update the submodule to use the latest Tock SHA.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>