### PR TITLE
linker: add sram origin symbol

### DIFF
--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -88,6 +88,15 @@ SECTIONS {
     /* Application stack */
     .stack (NOLOAD) :
     {
+        /* elf2tab requires that the `_SRAM_ORIGIN` symbol be present to
+         * mark the first address in the SRAM memory. Since ELF files do
+         * not really need to specify this address as they only care about
+         * loading into flash, we need to manually mark this address for
+         * elf2tab. elf2tab will use it to add a fixed address header in the
+         * TBF header if needed.
+         */
+        _SRAM_ORIGIN = .;
+
         . = . + STACK_SIZE;
 
 	_stack_top_unaligned = .;

--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -88,14 +88,14 @@ SECTIONS {
     /* Application stack */
     .stack (NOLOAD) :
     {
-        /* elf2tab requires that the `_SRAM_ORIGIN` symbol be present to
+        /* elf2tab requires that the `_sram_origin` symbol be present to
          * mark the first address in the SRAM memory. Since ELF files do
          * not really need to specify this address as they only care about
          * loading into flash, we need to manually mark this address for
          * elf2tab. elf2tab will use it to add a fixed address header in the
          * TBF header if needed.
          */
-        _SRAM_ORIGIN = .;
+        _sram_origin = .;
 
         . = . + STACK_SIZE;
 


### PR DESCRIPTION
This allows elf2tab to determine what the start of RAM address is when generating a fixed address header in the TBF.

See https://github.com/tock/elf2tab/pull/23 and https://github.com/tock/tock/pull/1845.