### PR TITLE
[WIP] Introduce a `libtock-platform` crate under `libtock-core`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,9 @@ exclude = [ "tock" ]
 members = [
     "codegen",
     "core",
+    "core/console",
     "core/platform",
+    "core/sync",
     "test_runner",
     "tools/print_sizes",
 ]

--- a/core/console/Cargo.toml
+++ b/core/console/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+categories = ["embedded", "no-std", "os"]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+name = "libtock_console"
+repository = "https://www.github.com/tock/libtock-rs"
+version = "0.1.0"
+
+[dependencies]
+libtock_platform = { path = "../platform" }

--- a/core/console/src/lib.rs
+++ b/core/console/src/lib.rs
@@ -1,0 +1,16 @@
+#[derive(Clone,Copy)]
+pub struct Console<P> {
+    platform: P,
+}
+
+impl<P> Console<P> {
+    pub const fn new(platform: P) -> Console<P> {
+        Console { platform }
+    }
+}
+
+impl<P: libtock_platform::PlatformApi> Console<P> {
+    pub fn check_exists(self) -> libtock_platform::ReturnCode {
+        self.platform.command(1, 0, 0, 0)
+    }
+}

--- a/core/platform/src/allows/allowed_slice.rs
+++ b/core/platform/src/allows/allowed_slice.rs
@@ -1,0 +1,78 @@
+/// `AllowedSlice` is a slice-based analogue of `Allowed`. It represents a slice
+/// that has been shared with the kernel using the `allow` system call.
+/// Unlike `Allowed`, `AllowSlice`'s methods accept an index into the shared
+/// slice, and operate on the element at that index.
+// Like Allowed, AllowedSlice does not directly use the 'b lifetime. Platform
+// uses 'b to prevent the AllowedSlice from accessing the buffer after the
+// buffer becomes invalid.
+// AllowedSlice requires T to be Copy for the same reasons as Allowed. See
+// Allowed's comments for more information.
+pub struct AllowedSlice<'b, T: Copy + 'b> {
+    // `data` points to the start of the shared slice, and `len` is the length
+    // of that slice.
+    // Safety properties:
+    //   1. The slice remains valid and usable for the lifetime of this
+    //      AllowedSlice instance.
+    //   2. Read and write accesses into the slice must be performed as a
+    //      volatile operation, as the kernel may mutate the slice at any time.
+    //   3. The shared slice may have an arbitrary bit pattern in it, so reading
+    //      from the slice is only safe if the type contained within is
+    //      AllowReadable.
+    data: core::ptr::NonNull<T>,
+    len: usize,
+
+    // Use the 'b parameter, and make AllowedSlice invariant w.r.t. T. See
+    // Allowed's comment for a more detailed description.
+    _phantom: core::marker::PhantomData<&'b mut [T]>,
+}
+
+// AllowedSlice's API mirrors that of Allowed, but with indexing on most
+// methods. Se Allowed's comments for more details.
+impl<'b, T: Copy + 'b> AllowedSlice<'b, T> {
+    // The caller (Platform) must make sure the following are true:
+    // 1. `data` points to a valid [T] slice of length `len`.
+    // 2. There are no other references to the slice.
+    // 3. The slice remains usable until the AllowedSlice's lifetime has ended.
+    #[allow(unused)] // TODO: Remove when Platform is implemented.
+    pub(crate) unsafe fn new(data: core::ptr::NonNull<T>, len: usize) -> AllowedSlice<'b, T> {
+        AllowedSlice {
+            data,
+            len,
+            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Sets the value at `index`, or does nothing if `index` is out of range.
+    pub fn set(&self, index: usize, value: T) -> Result<(), OutOfBounds> {
+        if index >= self.len {
+            return Err(OutOfBounds);
+        }
+        unsafe {
+            core::ptr::write_volatile(self.data.as_ptr().add(index), value);
+        }
+        Ok(())
+    }
+}
+
+impl<'b, T: crate::AllowReadable + Copy + 'b> AllowedSlice<'b, T> {
+    /// Returns the value at `index` without changing it.
+    pub fn get(&self, index: usize) -> Result<T, OutOfBounds> {
+        if index >= self.len {
+            return Err(OutOfBounds);
+        }
+        Ok(unsafe { core::ptr::read_volatile(self.data.as_ptr().add(index)) })
+    }
+
+    /// Returns the value at `index` without changing it. If `index` is out of
+    /// bounds, returns the provided default value.
+    pub fn get_or_default(&self, index: usize, default: T) -> T {
+        if index >= self.len {
+            return default;
+        }
+        unsafe { core::ptr::read_volatile(self.data.as_ptr().add(index)) }
+    }
+}
+
+/// An error type indicating an out-of-bounds access.
+#[derive(PartialEq)]
+pub struct OutOfBounds;

--- a/core/platform/src/allows/allowed_slice_tests.rs
+++ b/core/platform/src/allows/allowed_slice_tests.rs
@@ -1,0 +1,93 @@
+use crate::{AllowedSlice, OutOfBounds};
+use core::marker::PhantomData;
+use core::ptr::NonNull;
+
+// KernelSlice simulates a kernel's access to a slice that has been shared with
+// the kernel. It is the slice-based equivalent to KernelPtr, defined in
+// allowed_tests.rs. See KernelPtr's documentation for a description of
+// KernelSlice's purpose.
+struct KernelSlice<'b, T: Copy + 'b> {
+    data: NonNull<T>,
+    len: usize,
+
+    // Consume the 'b lifetime.
+    _phantom: PhantomData<&'b mut [T]>,
+}
+
+impl<'b, T: Copy + 'b> KernelSlice<'b, T> {
+    pub fn allow_slice(buffer: &'b mut [T]) -> (AllowedSlice<'b, T>, KernelSlice<'b, T>) {
+        let data = NonNull::new(buffer.as_mut_ptr()).unwrap();
+        let len = buffer.len();
+        let _ = buffer;
+        let allowed_slice = unsafe { AllowedSlice::new(data, len) };
+        let kernel_slice = KernelSlice {
+            data,
+            len,
+            _phantom: PhantomData,
+        };
+        (allowed_slice, kernel_slice)
+    }
+
+    // Copies the value out of the given entry in the buffer and returns it.
+    pub fn get(&self, index: usize) -> T {
+        assert!(index < self.len);
+        unsafe { core::ptr::read(self.data.as_ptr().add(index)) }
+    }
+}
+
+#[test]
+fn set() {
+    let mut buffer = [0, 1, 2];
+    let (allowed_slice, kernel_slice) = KernelSlice::allow_slice(&mut buffer);
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+
+    assert!(allowed_slice.set(4, 4) == Err(OutOfBounds));
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+
+    assert!(allowed_slice.set(1, 4) == Ok(()));
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 4);
+    assert_eq!(kernel_slice.get(2), 2);
+}
+
+#[test]
+fn get() {
+    let mut buffer = [0, 1, 2];
+    let (allowed_slice, kernel_slice) = KernelSlice::allow_slice(&mut buffer);
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+
+    assert!(allowed_slice.get(4).is_err());
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+
+    assert!(allowed_slice.get(1) == Ok(1));
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+}
+
+#[test]
+fn get_or_default() {
+    let mut buffer = [0, 1, 2];
+    let (allowed_slice, kernel_slice) = KernelSlice::allow_slice(&mut buffer);
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+
+    assert_eq!(allowed_slice.get_or_default(4, 3), 3);
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+
+    assert_eq!(allowed_slice.get_or_default(1, 4), 1);
+    assert_eq!(kernel_slice.get(0), 0);
+    assert_eq!(kernel_slice.get(1), 1);
+    assert_eq!(kernel_slice.get(2), 2);
+}

--- a/core/platform/src/allows/mod.rs
+++ b/core/platform/src/allows/mod.rs
@@ -1,8 +1,12 @@
 mod allow_readable;
 mod allowed;
+mod allowed_slice;
 
 pub use allow_readable::AllowReadable;
 pub use allowed::Allowed;
+pub use allowed_slice::{AllowedSlice, OutOfBounds};
 
+#[cfg(test)]
+mod allowed_slice_tests;
 #[cfg(test)]
 mod allowed_tests;

--- a/core/platform/src/async_traits.rs
+++ b/core/platform/src/async_traits.rs
@@ -1,0 +1,59 @@
+//! `async_traits` provides the `AsyncCall`, `Callback`, and `StaticCallback`
+//! traits. These traits form the basis for `libtock_core`'s asynchronous API
+//! structure.
+//!
+//! In general, an `AsyncCall` is used to initiate an asynchronous operation.
+//! When the operation is complete, a `Callback` or `StaticCall` is used to
+//! inform the client of the operation's completion. Clients may then issue
+//! additional `AsyncCall` invocations from within the response callback.
+//!
+//! Note that callbacks should not be issued from within the `AsyncCall` call;
+//! doing so causes reentrancy and stack utilization issues. This is enforced
+//! through use of the CallbackContext type parameter.
+//!
+//! These traits are designed to be implemented on zero sized types (ZSTs) that
+//! refer indirectly to the objects that implement the corresponding
+//! functionality. As a result, they require `Copy` and take `self` by value. In
+//! many cases, these traits will be implemented on references to objects rather
+//! than on the objects themselves. For example, a `Console` driver would
+//! implement `AsyncCall` on `&Console`, not on `Console` itself, as `Console`
+//! would not be a `Copy` type.
+
+/// Represents a call that starts an asynchronous operation. The `start` request
+/// can return a payload synchronously; this may be used to return a "failed to
+/// start"-style error message.
+pub trait AsyncCall<Request, SyncResponse>: Copy {
+    fn start(self, request: Request) -> SyncResponse;
+}
+
+/// A callback reporting the results of an asynchronous operation. Like
+/// AsyncCall, this callback may carry data, and as such `Callback` may be
+/// implemented on reference types.
+pub trait Callback<AsyncResponse>: Copy {
+    fn callback(self, context: CallbackContext, response: AsyncResponse);
+}
+
+/// A marker type indicating this method executes as a callback. In this case,
+/// callbacks refer either to kernel callbacks (those resulting from a
+/// `subscribe` sysem call) or to deferred callbacks. In both cases, the
+/// `Platform` implementation provides the `CallbackContext`.
+///
+/// `CallbackContext` is `Copy` so it is easy to pass into function invocations.
+// The lifetime parameter 'c exists to prevent a CallbackContext from being
+// moved into a location that outlives the callback's execution.
+#[derive(Clone, Copy)]
+pub struct CallbackContext<'c> {
+    // This serves two purposes. First, it is `pub(crate)`, so user code cannot
+    // construct the CallbackContext. Second, it uses the lifetime parameter to
+    // avoid an "unused lifetime parameter" error.
+    pub(crate) _private: core::marker::PhantomData<&'c ()>,
+}
+
+/// A variation of callback that is not allowed to carry data. This conveys the
+/// callback entirely via the type system. This is used in places that cannot
+/// carry runtime data, such as the system call API, but generally requires the
+/// client to store the data it needs in a `static` location. As such, APIs
+/// should prefer to support `Callback` wherever possible.
+pub trait StaticCallback<AsyncResponse> {
+    fn callback(context: CallbackContext, response: AsyncResponse);
+}

--- a/core/platform/src/lib.rs
+++ b/core/platform/src/lib.rs
@@ -9,9 +9,15 @@
 //      unit test environments. [DONE]
 
 mod allows;
+mod async_traits;
 mod error_code;
+mod platform_api;
+mod return_code;
 mod syscalls;
 
-pub use allows::{AllowReadable, Allowed};
+pub use allows::{AllowReadable, Allowed, AllowedSlice, OutOfBounds};
+pub use async_traits::{AsyncCall, Callback, CallbackContext, StaticCallback};
 pub use error_code::ErrorCode;
+pub use platform_api::PlatformApi;
+pub use return_code::ReturnCode;
 pub use syscalls::{MemopNoArg, MemopWithArg, Syscalls};

--- a/core/platform/src/platform_api.rs
+++ b/core/platform/src/platform_api.rs
@@ -1,0 +1,49 @@
+//! PlatformApi is a trait presenting a safe interface to Tock's system API as
+//! well as a deferred call mechanism. It is implemented by the Platform type in
+//! this crate.
+//!
+//! PlatformApi exists so that code that uses Platform's API only needs one type
+//! parameter, rather than the two required by Platform.
+
+// A lifetime (for buffers) is omitted because it is extremely annoying to use
+// as a generic constraint: you need drivers to have a 'k generic argument to
+// pass into the PlatformApi<'k> constraint, but then you get errors about 'k
+// being unused.
+// TODO: Remove the lifetime parameter on Allowed and AllowedSlice.
+pub trait PlatformApi: Copy {
+    // Shares a value with the kernel. The value becomes a read-write shared
+    // buffer between userspace and the kernel.
+    fn allow<T: Copy>(
+        self,
+        driver: usize,
+        minor: usize,
+        buffer: &'static mut T,
+    ) -> Result<crate::Allowed<'static, T>, crate::ErrorCode>;
+
+    // Shares a slice with the kernel. The shared slice becomes a read-write
+    // shared buffer between userspace and the kernel.
+    fn allow_slice<T: Copy>(
+        self,
+        driver: usize,
+        minor: usize,
+        buffer: &'static mut [T],
+    ) -> Result<crate::AllowedSlice<'static, T>, crate::ErrorCode>;
+
+    // Instructs a driver to perform a specific action. If the action is
+    // asynchronous, its completion will be signalled by calling a callback
+    // registered using `subscribe`.
+    fn command(
+        self,
+        driver: usize,
+        command_number: usize,
+        argument1: usize,
+        argument2: usize
+    ) -> crate::ReturnCode;
+
+    // TODO: Finish PlatformApi
+
+    // Executes a single callback. Will run a deferred callback if one is
+    // available, or wait for one kernel callback if no deferred callback is
+    // queued.
+    fn run_callback(self);
+}

--- a/core/platform/src/return_code.rs
+++ b/core/platform/src/return_code.rs
@@ -1,0 +1,97 @@
+// TODO: Add unit tests
+
+use crate::ErrorCode;
+
+/// ReturnCode is a lightweight wrapper around the kernel's return values. It is
+/// the size of an `isize` but contains methods expressing the semantics of the
+/// kernel's ReturnCode (see
+/// https://github.com/tock/tock/blob/master/kernel/src/returncode.rs). In
+/// particular, a negative value represents an error condition while a
+/// nonnegative value represents a success.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ReturnCode {
+    value: isize,
+}
+
+// This API is largely based off Result's API. Code that wants to match on this
+// like a result can convert it to a result using .as_result().
+impl ReturnCode {
+    /// Creates a new `ReturnCode` using the provided kernel return value.
+    pub fn new(value: isize) -> ReturnCode {
+        ReturnCode { value }
+    }
+
+    /// Converts the `ReturnCode` into a `Result`.
+    pub fn as_result(self) -> Result<isize, ErrorCode> {
+        if self.value >= 0 {
+            Ok(self.value)
+        } else {
+            Err(ErrorCode::new(self.value))
+        }
+    }
+
+    /// Returns the value in the form the kernel returned it (an `isize`).
+    pub fn value(self) -> isize {
+        self.value
+    }
+
+    // -------------------------------------------------------------------------
+    // Methods below this line are copied directly from Result's interface.
+    // -------------------------------------------------------------------------
+
+    /// Returns `true` if this `ReturnCode` represents a success, `false` if it
+    /// represents an error.
+    pub fn is_ok(self) -> bool {
+        self.value >= 0
+    }
+
+    /// Returns `true` if this `ReturnCode` represents a failure, `false` if it
+    /// represents a success.
+    pub fn is_err(self) -> bool {
+        self.value < 0
+    }
+
+    /// Returns the contained value if this represents a success, and `None` if
+    /// it represents an error.
+    pub fn ok(self) -> Option<isize> {
+        if self.value >= 0 {
+            Some(self.value)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the error code if this represents an error, and `None` if it
+    /// represents a success.
+    pub fn err(self) -> Option<ErrorCode> {
+        if self.value < 0 {
+            Some(ErrorCode::new(self.value))
+        } else {
+            None
+        }
+    }
+
+    /// Applies a function to the contained value (if the value is a success),
+    /// or returns the provided default (if the value is an error).
+    pub fn map_or<U, F: FnOnce(isize) -> U>(self, default: U, f: F) -> U {
+        if self.value >= 0 {
+            f(self.value)
+        } else {
+            default
+        }
+    }
+
+    /// Map a ReturnCode to a U by applying value_f to a success value or
+    /// error_f to an error value.
+    pub fn map_or_else<U, D: FnOnce(ErrorCode) -> U, F: FnOnce(isize) -> U>(
+        self,
+        error_f: D,
+        value_f: F,
+    ) -> U {
+        if self.value >= 0 {
+            value_f(self.value)
+        } else {
+            error_f(ErrorCode::new(self.value))
+        }
+    }
+}

--- a/core/sync/Cargo.toml
+++ b/core/sync/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+categories = ["embedded", "no-std", "os"]
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+name = "libtock_sync"
+repository = "https://www.github.com/tock/libtock-rs"
+version = "0.1.0"
+
+[dependencies]
+libtock_platform = { path = "../platform" }

--- a/core/sync/src/lib.rs
+++ b/core/sync/src/lib.rs
@@ -1,0 +1,27 @@
+use libtock_platform::{Callback, CallbackContext, PlatformApi};
+
+pub struct SyncAdapter<AsyncResponse, Platform: PlatformApi> {
+    platform: Platform,
+    response: core::cell::Cell<Option<AsyncResponse>>,
+}
+
+impl<AsyncResponse, Platform: PlatformApi> SyncAdapter<AsyncResponse, Platform> {
+    pub fn new(platform: Platform) -> SyncAdapter<AsyncResponse, Platform> {
+        SyncAdapter { platform, response: core::cell::Cell::new(None) }
+    }
+
+    pub fn wait(&self) -> AsyncResponse {
+        loop {
+            if let Some(response) = self.response.take() {
+                return response;
+            }
+            self.platform.run_callback();
+        }
+    }
+}
+
+impl<AsyncResponse, Platform: PlatformApi> Callback<AsyncResponse> for &SyncAdapter<AsyncResponse, Platform> {
+    fn callback(self, _context: CallbackContext, response: AsyncResponse) {
+        self.response.set(Some(response));
+    }
+}


### PR DESCRIPTION
I intended to complete the `libtock-platform` crate before sending this PR for review, but I think it is growing too large to send without first discussing the design. Instead, I am sending it as a draft PR so we can discuss the design before I send a polished PR out.

This PR is part of a larger reorganization of `libtock-core` that I am trying to work on. In general, I would like to do the following:

1. Split up the functionality of `libtock-core` into multiple crates that live in the `core/` directory. `libtock-core` would remain as a crate that aggregates all the functionality, so that applications only need to use one crate directly. Examples and integration tests would live in `core/examples` and `core/tests`, so they can depend on `libtock-core`'s cumulative functionality.
1. Allow for unit tests for each sub-crate that run on the host system. `libtock-platform` has unit tests that run on the host system via a trivial `cargo test`. These tests are easier and faster to run that on-device tests, and can be run under `cargo miri` for undefined behavior detection. This is the idea discussed at https://github.com/tock/libtock-rs/issues/132#issuecomment-578282323
1. Solve the soundness issues with the syscall API/platform layer (previously discussed in #129 and #143).

The `libtock-platform` crate I introduce here contains the following:

1. A trait (`Syscalls`) representing raw system calls. There is no implementation of this trait in `libtock-platform`, as `libtock-platform` is OS-independent. Instead, separate crates (probably `libtock-runtime` and a testing crate) will provide implementations of `Syscalls`.
1. A `Platform` struct that provides a higher-level interface over the `Syscalls` trait, supporting an asynchronous execution model similar to that used by the Tock kernel. `Platform` is not implemented yet. Its API is presented in the form of the `PlatformApi` trait, which is currently partially written, so that other `libtock-core` components can easily be generic over the platform type.
1. `ErrorCode` and `ReturnCode` types that form efficient abstractions around the kernel's `ReturnCode` type.
1. Traits based on the prototyping I documented at https://github.com/tock/design-explorations/tree/master/zst_pointer_async for asynchronous APIs: `StaticCallback`, `AsyncCall`, and `Callback`. These should allow for `libtock-core` to provide a generic adapter for synchronous APIs and a futures-based adapter for synchronous APIs, plus prevent a recursion issue the Tock kernel has experienced.

In a later PR, I will implement `libtock-runtime`, which will provide the real `Syscalls` implementation and entry point for `libtock-core`. I will probably pull the `panic_handler`, `start` implementation, and allocator into separate crates so that applications can switch between them. `libtock-core` will pull in everything by default for clients that want the convenience.

Btw, please ignore that I commented out the `-D warnings` flag in `.cargo/config`, that flag was getting in the way of my development and testing. I'll remove it when I'm done implementing the major functionality.