### PR TITLE
'copy_from_slice' instead of 'clone_from_slice' when copying 'u8' slices

### DIFF
--- a/src/ble_composer.rs
+++ b/src/ble_composer.rs
@@ -21,7 +21,7 @@ impl BlePayload {
         self.bytes[self.occupied] = (content.len() + 1) as u8;
         self.bytes[self.occupied + 1] = kind;
         let write = &mut self.bytes[self.occupied + 2..(self.occupied + content.len() + 2)];
-        write.clone_from_slice(content);
+        write.copy_from_slice(content);
         self.occupied += 2 + content.len();
         Ok(())
     }
@@ -44,7 +44,7 @@ impl BlePayload {
         self.bytes[self.occupied + 3] = uuid[1];
 
         let write = &mut self.bytes[self.occupied + 4..(self.occupied + content.len() + 4)];
-        write.clone_from_slice(content);
+        write.copy_from_slice(content);
         self.occupied += 4 + content.len();
         Ok(())
     }

--- a/src/ble_parser.rs
+++ b/src/ble_parser.rs
@@ -53,7 +53,7 @@ mod test {
                 0x02, 0x02, 0x01, 0x02, 0x01, 0x03, 0x03, 0x16, 0x01, 0x02, 0x04, 0xFF, 0x01, 0x02,
                 0x03,
             ];
-            slice.clone_from_slice(data);
+            slice.copy_from_slice(data);
         }
         assert_eq!(find(&buf, 0x02), Some(&[0x01][0..1]));
         assert_eq!(find(&buf, 0x01), Some(&[0x03][0..1]));
@@ -67,7 +67,7 @@ mod test {
         {
             let slice = &mut buf[8..18];
             let data = &[0x02, 0x02, 0x00, 0x00, 0x00, 0x00, 0x0, 0x16, 0x01, 0x02];
-            slice.clone_from_slice(data);
+            slice.copy_from_slice(data);
         }
     }
 
@@ -77,7 +77,7 @@ mod test {
         {
             let slice = &mut buf[8..10];
             let data = &[0x04, 0x02];
-            slice.clone_from_slice(data);
+            slice.copy_from_slice(data);
         }
         assert_eq!(find(&buf, 0xF2), None);
     }


### PR DESCRIPTION
Hello :crab: ,
this PR changes invocations of `clone_from_slice()` to `copy_from_slice()`.
`copy_from_slice()` performs memcpy, while `clone_from_slice()` performs an element-wise copy.
(`copy_from_slice()` should generally run faster than `clone_from_slice()`)

The affected call sites all copy `u8` slices, and since `u8` implements `Copy`, it is safe to use `copy_from_slice()`.

Thank you for reviewing this PR :superhero_woman: :superhero_man: :superhero: 