### PR TITLE
Add a code review policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,3 @@
-# PR Workflow
-
-We use the bors-ng bot to merge PRs. In short, when someone replies `bors r+`,
-your PR has been scheduled for final tests and will be automatically merged. If
-a maintainer replies `bors delegate+`, then you have been granted the authority
-to merge your own PR (usually this will happen if there are some trivial
-changes required). For a full list of bors commands,
-[see the bors documentation](https://bors.tech/documentation/).
-
 # Tests
 
 Our aim is to provide a number of tests to be safe from regression. Currently,
@@ -52,3 +43,8 @@ The expected output on the UART console will be as follows.
 [      OK ] GPIO read/write
 [      OK ] Test suite finished with state SUCCESS
 ```
+
+# PR Review Workflow
+
+Our code review practices are documented in our [Code Review](doc/CodeReview.md)
+document.

--- a/doc/CodeReview.md
+++ b/doc/CodeReview.md
@@ -1,0 +1,36 @@
+Code Review
+===========
+
+## Code Review Practices
+
+PR to `libtock-rs` can be divided into two categories:
+
+1. **Upkeep pull requests** are minor changes to existing functionality.
+   Examples include bug fixes (that do not significantly affect APIs) and
+   documentation that describes an existing implementation.
+1. **Significant pull requests** are pull requests that are too substantial to
+   be considered upkeep pull requests. Significant pull requests may include new
+   functionality, API changes, significant refactoring, new tooling, and other
+   changes.
+
+The owners of `libtock-rs` (listed [below](#owners)) determine whether a PR is
+an upkeep PR or a significant PR. PRs should be merged by the `libtock-rs`
+owners rather than the PR's author. PRs authored by `libtock-rs` owners should
+be merged by a reviewer rather than their author.
+
+A PR may only be merged when all of the following are true:
+
+1. At least one `libtock-rs` owner (who is not the PR author) has approved the PR.
+1. All outstanding review discussions have been resolved.
+1. If the pull request is significant, a 7 day waiting period has passed since
+   the PR was opened.
+
+## Owners
+
+The owners of `libtock-rs` are:
+
+* The [Tock Core Working
+  Group](https://github.com/tock/tock/tree/master/doc/wg/core#members).
+* Alistair Francis, [alistair23](https://github.com/alistair23), Western Digital
+* [torfmaster](https://github.com/torfmaster)
+* [Woyten](https://github.com/Woyten)

--- a/doc/CodeReview.md
+++ b/doc/CodeReview.md
@@ -16,7 +16,9 @@ PR to `libtock-rs` can be divided into two categories:
 The owners of `libtock-rs` (listed [below](#owners)) determine whether a PR is
 an upkeep PR or a significant PR. PRs should be merged by the `libtock-rs`
 owners rather than the PR's author. PRs authored by `libtock-rs` owners should
-be merged by a reviewer rather than their author.
+be merged by a reviewer rather than their author. In general, PRs should be
+merged using a `bors r+` command rather than the GitHub UI (see the [bors
+documentation](https://bors.tech/documentation/) for more information on bors).
 
 A PR may only be merged when all of the following are true:
 
@@ -24,6 +26,11 @@ A PR may only be merged when all of the following are true:
 1. All outstanding review discussions have been resolved.
 1. If the pull request is significant, a 7 day waiting period has passed since
    the PR was opened.
+
+We recommend that authors of significant PRs comment on the PR when they believe
+the above criteria have been satisfied (including the waiting period). This is
+primarily to remind the owners to merge the PR. Secondarily, it should help
+identify confusion about a PR review's status.
 
 ## Owners
 


### PR DESCRIPTION
The code review policy clarifies:

1. Who "owns" libtock-rs code (who reviews PRs)
1. Who is responsible for merging PRs.
1. When a PR may be merged.

This is based on Tock's policy that is currently at https://github.com/tock/tock/blob/master/doc/CodeReview.md

[Rendered](https://github.com/jrvanwhy/libtock-rs/blob/code-review/doc/CodeReview.md)