### PR TITLE
Adjust the setup-qemu and test-qemu-hifive make actions to work with the new tock version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ setup: setup-qemu
 # patches to better support boards that Tock supports.
 .PHONY: setup-qemu
 setup-qemu:
-	$(MAKE) -C tock ci-job-qemu
+	CI=true $(MAKE) -C tock ci-setup-qemu
 
 # Builds a Tock kernel for the HiFive board for use by QEMU tests.
 .PHONY: kernel-hifive
@@ -64,7 +64,7 @@ print-sizes: examples
 
 # Runs the libtock_test tests in QEMU on a simulated HiFive board.
 .PHONY: test-qemu-hifive
-test-qemu-hifive: kernel-hifive setup-qemu
+test-qemu-hifive: kernel-hifive
 	PLATFORM=hifive1 cargo rrv32imac --example libtock_test --features=alloc \
 		--features=__internal_disable_gpio_in_integration_test
 	cargo run -p test_runner


### PR DESCRIPTION
PR #207 updated the `tock` submodule. The new submodule version includes the following PR: https://github.com/tock/tock/pull/1880, which changed the `tock` Makefile actions related to QEMU setup. This updates `make setup-qemu` to work with the new Tock makefile.

Tock no longer checks if QEMU was already setup when running setup actions, so I removed `test-qemu-hifive`'s dependency on `qemu-setup`. `make setup` still depends on `qemu-setup`.