### PR TITLE
Add the `libtock_platform` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ exclude = [ "tock" ]
 members = [
     "codegen",
     "core",
+    "core/platform",
     "test_runner",
     "tools/print_sizes",
 ]

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,12 @@ setup: setup-qemu
 	rustup target add thumbv7em-none-eabi
 	rustup target add riscv32imac-unknown-none-elf
 	rustup target add riscv32imc-unknown-none-elf
-	rustup component add rustfmt
 	rustup component add clippy
+	rustup component add rustfmt
+	rustup component add miri
 	cargo install elf2tab --version 0.4.0
 	cargo install stack-sizes
+	cargo miri setup
 
 # Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
 # patches to better support boards that Tock supports.
@@ -82,7 +84,7 @@ examples:
 test: examples test-qemu-hifive
 	PLATFORM=nrf52 cargo fmt --all -- --check
 	PLATFORM=nrf52 cargo clippy --workspace --all-targets
-	PLATFORM=nrf52 cargo test --workspace
+	PLATFORM=nrf52 cargo miri test --workspace
 	echo '[ SUCCESS ] libtock-rs tests pass'
 
 .PHONY: analyse-stack-sizes

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,3 +13,4 @@ custom_alloc_error_handler = []
 [dependencies]
 linked_list_allocator = { optional = true, version = "=0.8.1", default-features = false }
 libtock_codegen = { path = "../codegen" }
+libtock_platform = { path = "platform" }

--- a/core/platform/Cargo.toml
+++ b/core/platform/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+categories = ["embedded", "no-std", "os"]
+description = """libtock-rs platform layer. Provides the Platform abstraction,
+                 an abstraction that extends Tock's system calls to form the
+                 basis for libtock-rs' asynchronous APIs. libtock_platform is
+                 intended for use in both TBF binaries and unit tests that run
+                 on Linux."""
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+name = "libtock_platform"
+repository = "https://www.github.com/tock/libtock/rs"
+version = "0.1.0"

--- a/core/platform/src/lib.rs
+++ b/core/platform/src/lib.rs
@@ -1,0 +1,9 @@
+#![no_std]
+
+// TODO: Implement this crate, which will be done piece-by-piece. Platform will
+// include:
+//   1. The Allowed and AllowedSlice abstractions for sharing memory with the
+//      kernel
+//   2. The PlatformApi trait and Platform implementation.
+//   3. A system call trait so that Platform works in both real Tock apps and
+//      unit test environments.


### PR DESCRIPTION
Currently, the crate is just a skeleton. I will add functionality in future PRs (I am merging an empty crate so that I can send PRs in parallel in the future).

I will be replacing the system call layer in libtock_core::syscalls with a new layer in libtock_platform. libtock_core depends on libtock_platform and will re-export its functionality. This work is tracked at https://github.com/tock/libtock-rs/issues/217