### PR TITLE
Add the ErrorCode type to libtock_platform.

### DIFF
--- a/core/platform/src/error_code.rs
+++ b/core/platform/src/error_code.rs
@@ -1,0 +1,25 @@
+/// An error code returned by the kernel. Tock's system calls return errors as a
+/// negative `isize`. This wraps the isize, and is useful for adding type safety
+/// to APIs.
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ErrorCode {
+    // Note: value *should* always be negative, but we do not *verify* that so
+    // unsafe code cannot rely on value being negative.
+    value: isize,
+}
+
+impl ErrorCode {
+    // Converts the given isize into an ErrorCode. Note that the isize should be
+    // negative, although that is not verified to reduce code size. We don't
+    // implement From because not every isize converts sensibly to an ErrorCode.
+    pub fn new(value: isize) -> ErrorCode {
+        ErrorCode { value }
+    }
+}
+
+impl Into<isize> for ErrorCode {
+    fn into(self) -> isize {
+        self.value
+    }
+}

--- a/core/platform/src/lib.rs
+++ b/core/platform/src/lib.rs
@@ -7,3 +7,7 @@
 //   2. The PlatformApi trait and Platform implementation.
 //   3. A system call trait so that Platform works in both real Tock apps and
 //      unit test environments.
+
+mod error_code;
+
+pub use error_code::ErrorCode;


### PR DESCRIPTION
ErrorCode is a wrapper around an isize that is useful for type safety. Its intended use case is to wrap a non-successful ReturnCode returned from a system call.