### PR TITLE
Fix the broken Travis CI:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,11 @@ edition = "2018"
 alloc = ["libtock_core/alloc"]
 custom_panic_handler = ["libtock_core/custom_panic_handler"]
 custom_alloc_error_handler = ["libtock_core/custom_alloc_error_handler"]
+# In the QEMU-emulated HiFive1 target, we do not have connected GPIO pins or a
+# working timer interface. These features allow the test's user to disable these
+# tests in environments where they will not pass.
 __internal_disable_gpio_in_integration_test = []
+__internal_disable_timer_in_integration_test = []
 
 [dependencies]
 libtock_core = { path = "core" }

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ print-sizes: examples
 .PHONY: test-qemu-hifive
 test-qemu-hifive: kernel-hifive
 	PLATFORM=hifive1 cargo rrv32imac --example libtock_test --features=alloc \
-		--features=__internal_disable_gpio_in_integration_test
+		--features=__internal_disable_gpio_in_integration_test \
+		--features=__internal_disable_timer_in_integration_test
 	cargo run -p test_runner
 
 .PHONY: examples

--- a/examples-features/libtock_test.rs
+++ b/examples-features/libtock_test.rs
@@ -51,6 +51,7 @@ async fn libtock_test(
     test.formatting()?;
     test.heap()?;
     test.drivers_only_instantiable_once()?;
+    #[cfg(not(feature = "__internal_disable_timer_in_integration_test"))]
     test.callbacks(timer).await?;
     #[cfg(not(feature = "__internal_disable_gpio_in_integration_test"))]
     test.gpio(gpio)?;
@@ -113,6 +114,10 @@ impl LibtockTest {
         )
     }
 
+    #[cfg_attr(
+        feature = "__internal_disable_timer_in_integration_test",
+        allow(dead_code)
+    )]
     async fn callbacks(&mut self, timer_context: &mut DriverContext) -> TockResult<()> {
         let mut callback_hit = false;
         let mut with_callback = timer_context.with_callback(|_, _| callback_hit = true);


### PR DESCRIPTION
1. Update the `tock` submodule to a version that includes
   https://github.com/tock/tock/pull/2024, which fixes the OpenTitan BootROM
   download code, as well as https://github.com/tock/tock/pull/2038, which fixes
   a HiFive1 kernel bug.
2. Disable the callback test. HiFive1 doesn't have a working timer driver. The
   callback test only worked before because of some other callback, which
   doesn't seem to occur with the new kernel.

Fixes #225 