### PR TITLE
MSP432 platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ flash-imxrt1050:
 msp432:
 	PLATFORM=msp432 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
 
-.PHONY: msp432
+.PHONY: flash-msp432
 flash-msp432:
 	PLATFORM=msp432 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
 

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,13 @@ imxrt1050:
 flash-imxrt1050:
 	PLATFORM=imxrt1050 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
 
+.PHONY: msp432
+msp432:
+	PLATFORM=msp432 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
+
+.PHONY: msp432
+flash-msp432:
+	PLATFORM=msp432 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
 
 .PHONY: clean
 clean:

--- a/boards/layout_msp432.ld
+++ b/boards/layout_msp432.ld
@@ -1,0 +1,15 @@
+MEMORY {
+  /* The application region is 64 bytes (0x40) */
+  FLASH (rx) : ORIGIN = 0x00020040, LENGTH = 0x0001FFC0
+  SRAM (rwx) : ORIGIN = 0x20004000, LENGTH = 0x2000
+}
+
+/*
+ * Any change to STACK_SIZE should be accompanied by a corresponding change to
+ * `elf2tab`'s `--stack` option
+ */
+STACK_SIZE = 2048;
+
+MPU_MIN_ALIGN = 8K;
+
+INCLUDE layout_generic.ld

--- a/tools/flash.sh
+++ b/tools/flash.sh
@@ -45,6 +45,11 @@ case "${PLATFORM}" in
         binary_name=cortex-m7.elf
         tockload=n
         ;;
+    "msp432")
+        tockloader_flags=""
+        binary_name=cortex-m4.elf
+        tockload=n
+        ;;
     "opentitan")
         tockloader_flags=""
         binary_name=rv32imc.elf


### PR DESCRIPTION
### Summary

Since around two weeks the tock-kernel supports the MSP432 platform, so this PR adds MSP432-support for the userspace.
I only adopted the flash-script and the makefile and added a linker-script for the board.

Flashing apps is currently only possible with openOCD, the makefile in the kernel provides a target to do this.