### PR TITLE
console: Add support for println! and print!

### DIFF
--- a/examples-features/alloc_error.rs
+++ b/examples-features/alloc_error.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use core::alloc::Layout;
-use core::fmt::Write;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
@@ -22,8 +22,8 @@ fn main() -> TockResult<()> {
 #[alloc_error_handler]
 unsafe fn alloc_error_handler(_: Layout) -> ! {
     if let Ok(drivers) = libtock::retrieve_drivers() {
-        let mut console = drivers.console.create_console();
-        let _ = writeln!(console, "alloc_error_handler called");
+        drivers.console.create_console();
+        println!("alloc_error_handler called");
     }
     loop {
         syscalls::raw::yieldk();

--- a/examples-features/libtock_test.rs
+++ b/examples-features/libtock_test.rs
@@ -12,11 +12,11 @@ use core::mem;
 use core::pin::Pin;
 use core::task::Context;
 use core::task::Poll;
-use libtock::console::Console;
 use libtock::console::ConsoleDriver;
 use libtock::gpio::GpioDriverFactory;
 use libtock::gpio::GpioState;
 use libtock::gpio::ResistorMode;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::DriverContext;
 use libtock::timer::Duration;
@@ -59,16 +59,13 @@ async fn libtock_test(
 }
 
 struct LibtockTest {
-    console: Console,
     success: bool,
 }
 
 impl LibtockTest {
     fn initialize(console: ConsoleDriver) -> Self {
-        Self {
-            console: console.create_console(),
-            success: true,
-        }
+        console.create_console();
+        Self { success: true }
     }
 
     fn console(&mut self) -> TockResult<()> {
@@ -170,12 +167,12 @@ impl LibtockTest {
     }
 
     fn log_success(&mut self, message: &str) -> TockResult<()> {
-        writeln!(&mut self.console, "[      OK ] {}", message)?;
+        println!("[      OK ] {}", message);
         Ok(())
     }
 
     fn log_failure(&mut self, message: &str) -> TockResult<()> {
-        writeln!(&mut self.console, "[ FAILURE ] {}", message)?;
+        println!("[ FAILURE ] {}", message);
         self.success = false;
         Ok(())
     }

--- a/examples-features/panic.rs
+++ b/examples-features/panic.rs
@@ -2,8 +2,8 @@
 
 #![no_std]
 
-use core::fmt::Write;
 use core::panic::PanicInfo;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
@@ -15,8 +15,8 @@ async fn main() -> TockResult<()> {
 #[panic_handler]
 unsafe fn panic_handler(_info: &PanicInfo) -> ! {
     if let Ok(drivers) = libtock::retrieve_drivers() {
-        let mut console = drivers.console.create_console();
-        let _ = writeln!(console, "panic_handler called");
+        drivers.console.create_console();
+        println!("panic_handler called");
     }
     loop {
         syscalls::raw::yieldk();

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use core::fmt::Write;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
@@ -11,10 +11,10 @@ async fn main() -> TockResult<()> {
     let adc_driver = drivers.adc.init_driver()?;
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     let mut callback = |channel, value| {
-        writeln!(console, "channel: {}, value: {}", channel, value).unwrap();
+        println!("channel: {}, value: {}", channel, value);
     };
 
     let _subscription = adc_driver.subscribe(&mut callback)?;

--- a/examples/adc_buffer.rs
+++ b/examples/adc_buffer.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use core::fmt::Write;
 use libtock::adc::AdcBuffer;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
@@ -11,7 +11,7 @@ async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
 
     let adc_driver = drivers.adc.init_driver()?;
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     let mut adc_buffer = AdcBuffer::default();
     let mut temp_buffer = [0; libtock::adc::BUFFER_SIZE];
@@ -20,7 +20,7 @@ async fn main() -> TockResult<()> {
 
     let mut callback = |_, _| {
         adc_buffer.read_bytes(&mut temp_buffer[..]);
-        writeln!(console, "First sample in buffer: {}", temp_buffer[0]).unwrap();
+        println!("First sample in buffer: {}", temp_buffer[0]);
     };
 
     let _subscription = adc_driver.subscribe(&mut callback)?;

--- a/examples/button_read.rs
+++ b/examples/button_read.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use core::fmt::Write;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
@@ -11,16 +11,11 @@ async fn main() -> TockResult<()> {
     let buttons_driver = drivers.buttons.init_driver()?;
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     loop {
         for button in buttons_driver.buttons() {
-            writeln!(
-                console,
-                "button {}: {:?}",
-                button.button_num(),
-                button.read()?
-            )?;
+            println!("button {}: {:?}", button.button_num(), button.read()?);
         }
         timer_driver.sleep(Duration::from_ms(500)).await?;
     }

--- a/examples/button_subscribe.rs
+++ b/examples/button_subscribe.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
 use core::cell::Cell;
-use core::fmt::Write;
 use libtock::buttons::ButtonState;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
@@ -13,7 +13,7 @@ async fn main() -> TockResult<()> {
     let buttons_driver = drivers.buttons.init_driver()?;
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     let pressed_count = Cell::new(0usize);
     let released_count = Cell::new(0usize);
@@ -30,12 +30,11 @@ async fn main() -> TockResult<()> {
     }
 
     loop {
-        writeln!(
-            console,
+        println!(
             "pressed: {}, released: {}",
             pressed_count.get(),
             released_count.get()
-        )?;
+        );
         timer_driver.sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/ctap.rs
+++ b/examples/ctap.rs
@@ -1,38 +1,39 @@
 #![no_std]
 /// This is a very basic CTAP example
 /// This example only calls the CTAP driver calls, it does not implement CTAP
-use core::fmt::Write;
 use libtock::ctap::{CtapRecvBuffer, CtapSendBuffer};
 use libtock::result::TockResult;
 use libtock::syscalls;
+use libtock::{print, println};
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
-    let mut console = drivers.console.create_console();
-    writeln!(console, "Starting CTAP example")?;
+    drivers.console.create_console();
+    println!("Starting CTAP example");
     let ctap_driver = drivers.ctap.init_driver()?;
 
-    writeln!(console, "Creating recv buffer")?;
+    println!("Creating recv buffer");
     let mut recv_buffer = CtapRecvBuffer::default();
     let recv_buffer = ctap_driver.init_recv_buffer(&mut recv_buffer)?;
-    writeln!(console, "  done")?;
+    println!("  done");
 
-    writeln!(console, "Creating send buffer")?;
+    println!("Creating send buffer");
     let mut send_buffer = CtapSendBuffer::default();
     let _send_buffer = ctap_driver.init_send_buffer(&mut send_buffer)?;
-    writeln!(console, "  done")?;
+    println!("  done");
 
     let mut temp_buffer = [0; libtock::ctap::RECV_BUFFER_SIZE];
 
-    writeln!(console, "Setting callback and running")?;
+    println!("Setting callback and running");
     let mut callback = |_, _| {
-        writeln!(console, "CTAP Complete, printing data").unwrap();
+        println!("CTAP Complete, printing data");
         recv_buffer.read_bytes(&mut temp_buffer[..]);
 
         for buf in temp_buffer.iter().take(libtock::ctap::RECV_BUFFER_SIZE) {
-            write!(console, "{:x}", *buf).unwrap();
+            print!("{:x}", *buf);
         }
+        println!();
 
         let _ret = ctap_driver.allow_receive();
     };

--- a/examples/gpio_read.rs
+++ b/examples/gpio_read.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use core::fmt::Write;
 use libtock::gpio::ResistorMode;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
@@ -13,12 +13,12 @@ async fn main() -> TockResult<()> {
     let mut gpio_driver = drivers.gpio.init_driver()?;
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     let mut gpio = gpio_driver.gpios().next().unwrap();
     let gpio_in = gpio.enable_input(ResistorMode::PullDown)?;
     loop {
-        writeln!(console, "{:?}", gpio_in.read()?)?;
+        println!("{:?}", gpio_in.read()?);
         timer_driver.sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,16 +4,16 @@
 
 #![no_std]
 
-use core::fmt::Write;
+use libtock::println;
 use libtock::result::TockResult;
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let drivers = libtock::retrieve_drivers()?;
 
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
-    writeln!(console, "Hello Tock World")?;
+    println!("Hello Tock World");
 
     Ok(())
 }

--- a/examples/hmac.rs
+++ b/examples/hmac.rs
@@ -1,23 +1,23 @@
 #![no_std]
 
-use core::fmt::Write;
 use libtock::hmac::{HmacDataBuffer, HmacDestBuffer, HmacKeyBuffer};
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::syscalls;
 
 #[libtock::main]
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
-    let mut console = drivers.console.create_console();
-    writeln!(console, "Starting HMAC example")?;
+    drivers.console.create_console();
+    println!("Starting HMAC example");
     let hmac_driver = drivers.hmac.init_driver()?;
 
-    writeln!(console, "Loading in 0 key")?;
+    println!("Loading in 0 key");
     let mut key_buffer = HmacKeyBuffer::default();
     let _key_buffer = hmac_driver.init_key_buffer(&mut key_buffer)?;
-    writeln!(console, "  done")?;
+    println!("  done");
 
-    writeln!(console, "Creating data buffer")?;
+    println!("Creating data buffer");
     let mut data_buffer = HmacDataBuffer::default();
     let data: &[u8; 72] =
         b"A language empowering everyone to build reliable and efficient software.";
@@ -26,22 +26,22 @@ async fn main() -> TockResult<()> {
         data_buffer.buffer[i] = *d;
     }
     let _data_buffer = hmac_driver.init_data_buffer(&mut data_buffer)?;
-    writeln!(console, "  done")?;
+    println!("  done");
 
-    writeln!(console, "Creating dest buffer")?;
+    println!("Creating dest buffer");
     let mut dest_buffer = HmacDestBuffer::default();
     let dest_buffer = hmac_driver.init_dest_buffer(&mut dest_buffer)?;
-    writeln!(console, "  done")?;
+    println!("  done");
 
     let mut temp_buffer = [0; libtock::hmac::DEST_BUFFER_SIZE];
 
-    writeln!(console, "Setting callback and running")?;
+    println!("Setting callback and running");
     let mut callback = |_result, _digest| {
-        writeln!(console, "HMAC Complete, printing digest").unwrap();
+        println!("HMAC Complete, printing digest");
         dest_buffer.read_bytes(&mut temp_buffer[..]);
 
         for buf in temp_buffer.iter().take(libtock::hmac::DEST_BUFFER_SIZE) {
-            write!(console, "{:x}", *buf).unwrap();
+            println!("{:x}", *buf);
         }
     };
 

--- a/examples/sensors.rs
+++ b/examples/sensors.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use core::fmt::Write;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::sensors::Sensor;
 use libtock::timer::Duration;
@@ -11,29 +11,13 @@ async fn main() -> TockResult<()> {
 
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     loop {
-        writeln!(
-            console,
-            "Humidity:    {}\n",
-            drivers.humidity_sensor.read()?
-        )?;
-        writeln!(
-            console,
-            "Temperature: {}\n",
-            drivers.temperature_sensor.read()?
-        )?;
-        writeln!(
-            console,
-            "Light:       {}\n",
-            drivers.ambient_light_sensor.read()?
-        )?;
-        writeln!(
-            console,
-            "Accel:       {}\n",
-            drivers.ninedof.read_acceleration()?
-        )?;
+        println!("Humidity:    {}\n", drivers.humidity_sensor.read()?);
+        println!("Temperature: {}\n", drivers.temperature_sensor.read()?);
+        println!("Light:       {}\n", drivers.ambient_light_sensor.read()?);
+        println!("Accel:       {}\n", drivers.ninedof.read_acceleration()?);
         timer_driver.sleep(Duration::from_ms(500)).await?;
     }
 }

--- a/examples/temperature.rs
+++ b/examples/temperature.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use core::fmt::Write;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
@@ -11,11 +11,11 @@ async fn main() -> TockResult<()> {
     let mut temperature_driver = drivers.temperature.init_driver()?;
     let mut timer_driver = drivers.timer.create_timer_driver();
     let timer_driver = timer_driver.activate()?;
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     loop {
         let temperature = temperature_driver.measure_temperature().await?;
-        writeln!(console, "Temperature: {}", temperature)?;
+        println!("Temperature: {}", temperature);
         timer_driver.sleep(Duration::from_ms(1000)).await?;
     }
 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,10 +1,9 @@
 #![no_std]
+use libtock::println;
 /**
  * This example shows a repeated timer combined with reading and displaying the current time in
  * clock ticks.
  **/
-use core::fmt::Write;
-use libtock::console::Console;
 use libtock::result::TockResult;
 use libtock::timer::DriverContext;
 use libtock::timer::Duration;
@@ -15,12 +14,12 @@ const DELAY_MS: usize = 500;
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
 
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     let mut previous_ticks = None;
 
     for i in 0.. {
-        print_now(&mut console, &mut drivers.timer, &mut previous_ticks, i)?;
+        print_now(&mut drivers.timer, &mut previous_ticks, i)?;
         let mut timer_driver = drivers.timer.create_timer_driver();
         let timer_driver = timer_driver.activate()?;
 
@@ -31,7 +30,6 @@ async fn main() -> TockResult<()> {
 }
 
 fn print_now(
-    console: &mut Console,
     timer_context: &mut DriverContext,
     previous_ticks: &mut Option<isize>,
     i: usize,
@@ -41,8 +39,7 @@ fn print_now(
     let current_clock = timer.get_current_clock()?;
     let ticks = current_clock.num_ticks();
     let frequency = timer.clock_frequency().hz();
-    writeln!(
-        console,
+    println!(
         "[{}] Waited roughly {}. Now is {} = {:#010x} ticks ({:?} ticks since last time at {} Hz)",
         i,
         PrettyTime::from_ms(i * DELAY_MS),
@@ -50,7 +47,7 @@ fn print_now(
         ticks,
         previous_ticks.map(|previous| ticks - previous),
         frequency
-    )?;
+    );
     *previous_ticks = Some(ticks);
     Ok(())
 }

--- a/examples/timer_subscribe.rs
+++ b/examples/timer_subscribe.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
-use core::fmt::Write;
 use futures::future;
+use libtock::println;
 use libtock::result::TockResult;
 use libtock::timer::Duration;
 
@@ -9,14 +9,10 @@ use libtock::timer::Duration;
 async fn main() -> TockResult<()> {
     let mut drivers = libtock::retrieve_drivers()?;
 
-    let mut console = drivers.console.create_console();
+    drivers.console.create_console();
 
     let mut with_callback = drivers.timer.with_callback(|_, _| {
-        writeln!(
-            console,
-            "This line is printed 2 seconds after the start of the program.",
-        )
-        .unwrap();
+        println!("This line is printed 2 seconds after the start of the program.");
     });
 
     let mut timer = with_callback.init()?;

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -3,32 +3,18 @@
 mod low_level_debug;
 
 use crate::drivers;
+use crate::println;
 use libtock_core::debug as core_debug;
 
 pub use low_level_debug::*;
-
-pub fn println() {
-    let buffer = [b'\n'];
-    let drivers = unsafe { drivers::retrieve_drivers_unsafe() };
-    let mut console = drivers.console.create_console();
-    let _ = console.write(&buffer);
-}
-
-pub fn print_as_hex(value: usize) {
-    let mut buffer = [b'\n'; 11];
-    write_as_hex(&mut buffer, value);
-    let drivers = unsafe { drivers::retrieve_drivers_unsafe() };
-    let mut console = drivers.console.create_console();
-    let _ = console.write(buffer);
-}
 
 pub fn print_stack_pointer() {
     let mut buffer = [b'\n'; 15];
     buffer[0..4].clone_from_slice(b"SP: ");
     write_as_hex(&mut buffer[4..15], core_debug::get_stack_pointer());
     let drivers = unsafe { drivers::retrieve_drivers_unsafe() };
-    let mut console = drivers.console.create_console();
-    let _ = console.write(buffer);
+    drivers.console.create_console();
+    println!("{:?}", buffer);
 }
 
 #[inline(always)]
@@ -49,8 +35,8 @@ pub unsafe fn dump_address(address: *const usize) {
     }
     buffer[27] = b'\n';
     let drivers = drivers::retrieve_drivers_unsafe();
-    let mut console = drivers.console.create_console();
-    let _ = console.write(&buffer);
+    drivers.console.create_console();
+    println!("{:?}", buffer);
 }
 
 /// Dumps arbitrary memory regions.


### PR DESCRIPTION
Currently we have a cluncky way of printing by calling the following:

    writeln!(console, "My message")?;

Although this works, it means we need to keep track of the console
struct. This makes it difficult to support printing in third party
libraries. This also means that we don't follow the Rust convention of
supporting `print!` and `println!` macros.

This patch makes the console object a global static so that we can
support the `print!` and `println!` macros. All current users are converted
to use this new method.

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>