### PR TITLE
Configure Bors to use GitHub Actions rather than Travis checks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
 # This workflow provides automated testing. It builds and runs tests on each PR.
 
 name: ci
-on: pull_request
+
+# We want to run CI on all pull requests. Additionally, Bors needs workflows to
+# run on the `staging` and `trying` branches.
+on:
+  pull_request:
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   ci:

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -2,7 +2,15 @@
 # request is created or modified.
 
 name: size-diff
-on: pull_request
+
+# We want to run this on all pull requests. Additionally, Bors needs workflows
+# to run on the `staging` and `trying` branches to block merges on them.
+on:
+  pull_request:
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   size-diff:

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,4 @@
 status = [
-  "continuous-integration/travis-ci/push"
+  "ci",
+  "size-diff",
 ]


### PR DESCRIPTION
The GitHub Actions workflows work better than Travis, and are a superset of the Travis checks. Travis is currently broken and I'd rather replace it with Actions than fix it. This PR should make Bors listen to GitHub actions rather than Travis.

If this works, then I'll remove the Travis config entirely in a future PR.