### PR TITLE
Add the .sdata section to the app binary.

### DIFF
--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -113,6 +113,7 @@ SECTIONS {
         . = ALIGN(4); /* Make sure we're word-aligned here */
         _data = .;
         KEEP(*(.data*))
+        *(.sdata*) /* RISC-V small-pointer data section */
         . = ALIGN(4); /* Make sure we're word-aligned at the end of flash */
     } > SRAM
 


### PR DESCRIPTION
RISC-V has the `.sdata` section, which is supposed to be for commonly-accessed global variables. Previously, we discarded this section in the linker script. Discarding this section resulted in missing global variables.

I originally discovered this when I tried to print a string of less than 9 bytes and it was not working. I reported it as a kernel bug at https://github.com/tock/tock/issues/2132, then later realized the issue was in the libtock-rs linker script rather than the kernel.

I added a test to libtock_test that catches this issue (I verified by hand that the test fails if I don't fix the linker script).