### PR TITLE
Block async-std >= 1.7.0 from being pulled in to fix the CI.

### DIFF
--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -11,7 +11,10 @@ structopt = { version = "0.3", default-features = false }
 futures = "0.3.4"
 
 [dependencies.async-std]
-version = "1.5.0"
+# async-std 1.7 pulls in crossbeam_utils 1.8, which does not work with the
+# nightly Rust toolchain we use. Temporarily block async-std 1.7 until we can
+# update our Rust toolchain.
+version = "1.5.0, <1.7"
 features = ["attributes"]
 
 [dependencies.tokio]


### PR DESCRIPTION
`test_runner` depends on async-std. async-std depends on crossbeam_utils. crossbeam_utils 1.8 does not work with our nightly Rust (due to `const_fn`-related churn). The existing dependency allows Cargo to pull in async-std 1.7, which pulls in crossbeam_utils 1.8 and breaks our build. By limiting async-std's version to <1.7, this prevents crossbeam_utils 1.8 from being pulled in, keeping our build working.

I tried to update our nightly Rust version to fix this, but encountered several issues that will take some time to solve. This fix is intended to last until we update to a newer Rust nightly.