### PR TITLE
Specify components in `rust-toolchain` and update the toolchain to `nightly-2020-08-20`.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -10,16 +10,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          profile: minimal
-
       - name: Install dependencies
         run: |
-          rustup target add thumbv7em-none-eabi
-          rustup target add riscv32imac-unknown-none-elf
-          rustup target add riscv32imc-unknown-none-elf
           cargo install elf2tab --version 0.4.0
 
       - name: Build Hello World

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,6 @@ jobs:
         with:
           submodules: true
 
-      # Install a Rust toolchain with the components necessary to build
-      # libtock-rs and its examples. This action doesn't seem to be able to
-      # install toolchains for multiple targets, so I add the targets later in
-      # the "Build and Test" step.
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          profile: minimal
-
       # The main test step. We let the makefile do most of the work because the
       # makefile can be tested locally. We experimentally determined that -j2 is
       # optimal for the Azure Standard_DS2_v2 VM, which is the VM type used by
@@ -47,6 +38,5 @@ jobs:
       - name: Build and Test
         run: |
           cd "${GITHUB_WORKSPACE}"
-          rustup target add riscv32imc-unknown-none-elf thumbv7em-none-eabi
           make -j2 setup
           make -j2 test

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -29,15 +29,6 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2.3.0
 
-      # Install a Rust toolchain with the components necessary to run
-      # `print-sizes`. This action doesn't seem to be able to install toolchains
-      # for multiple targets, so I add the targets later in the "size report"
-      # step.
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1.0.6
-        with:
-          profile: minimal
-
       # The main diff script. Stores the sizes of the example binaries for both
       # the merge commit and the target branch. We display the diff in a
       # separate step to make it easy to navigate to in the GitHub Actions UI.
@@ -46,13 +37,11 @@ jobs:
           UPSTREAM_REMOTE_NAME="${UPSTREAM_REMOTE_NAME:-origin}"
           GITHUB_BASE_REF="${GITHUB_BASE_REF:-master}"
           cd "${GITHUB_WORKSPACE}"
-          rustup target add riscv32imc-unknown-none-elf thumbv7em-none-eabi
           make -j2 examples  # The VM this runs on has 2 logical cores.
           cargo run --release -p print_sizes >'${{runner.temp}}/merge-sizes'
           git remote set-branches "${UPSTREAM_REMOTE_NAME}" "${GITHUB_BASE_REF}"
           git fetch --depth=1 "${UPSTREAM_REMOTE_NAME}" "${GITHUB_BASE_REF}"
           git checkout "${UPSTREAM_REMOTE_NAME}/${GITHUB_BASE_REF}"
-          rustup target add riscv32imc-unknown-none-elf thumbv7em-none-eabi
           make -j2 examples
           cargo run --release -p print_sizes >'${{runner.temp}}/base-sizes'
 

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,6 @@ endif
 
 .PHONY: setup
 setup: setup-qemu
-	rustup target add thumbv7em-none-eabi
-	rustup target add riscv32imac-unknown-none-elf
-	rustup target add riscv32imc-unknown-none-elf
-	rustup component add clippy
-	rustup component add rustfmt
-	rustup component add miri
 	cargo install elf2tab --version 0.6.0
 	cargo install stack-sizes
 	cargo miri setup

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,6 +11,6 @@ custom_panic_handler = []
 custom_alloc_error_handler = []
 
 [dependencies]
-linked_list_allocator = { optional = true, version = "=0.8.1", default-features = false }
+linked_list_allocator = { optional = true, version = "0.8.6", default-features = false }
 libtock_codegen = { path = "../codegen" }
 libtock_platform = { path = "platform" }

--- a/core/src/lang_items.rs
+++ b/core/src/lang_items.rs
@@ -21,6 +21,7 @@
 use crate::syscalls;
 
 #[lang = "start"]
+#[allow(improper_ctypes_definitions)]
 extern "C" fn start<T>(main: fn() -> T, _argc: isize, _argv: *const *const u8) -> bool
 where
     T: Termination,

--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -160,6 +160,11 @@ SECTIONS {
       *(.ARM.exidx* .gnu.linkonce.armexidx.*)
     } > FLASH
     PROVIDE_HIDDEN (__exidx_end = .);
+
+    /DISCARD/ :
+    {
+      *(.eh_frame)
+    }
 }
 
 ASSERT((_stack_top_aligned - _stack_top_unaligned) == 0, "

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,8 @@
-nightly-2020-06-10
+[toolchain]
+# See https://rust-lang.github.io/rustup-components-history/ for a list of
+# recently nightlies and what components are available for them.
+channel = "nightly-2020-08-20"
+components = ["clippy", "miri", "rustfmt"]
+targets = ["thumbv7em-none-eabi",
+           "riscv32imac-unknown-none-elf",
+           "riscv32imc-unknown-none-elf"]


### PR DESCRIPTION
I had to update `linked_list_allocator` because it is not compatible with the newer compiler (`const_fn` changes). I also silenced a warning on the `start` definition.