### PR TITLE
Remove `test_runner`'s dependence on `async-std` and `tokio`.

### DIFF
--- a/test_runner/Cargo.toml
+++ b/test_runner/Cargo.toml
@@ -3,20 +3,3 @@ name = "test_runner"
 version = "0.1.0"
 authors = ["torfmaster <briefe@kebes.de>"]
 edition = "2018"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-structopt = { version = "0.3", default-features = false }
-futures = "0.3.4"
-
-[dependencies.async-std]
-# async-std 1.7 pulls in crossbeam_utils 1.8, which does not work with the
-# nightly Rust toolchain we use. Temporarily block async-std 1.7 until we can
-# update our Rust toolchain.
-version = "1.5.0, <1.7"
-features = ["attributes"]
-
-[dependencies.tokio]
-version = "0.2.12"
-features = ["process", "rt-threaded", "macros", "io-util", "time"]


### PR DESCRIPTION
`test_runner` used both `async-std` and `tokio` to implement a timeout on test execution. This brought in a *large* dependency tree. Some of the crates in that dependency tree (e.g. `value-bag`) assume that if you're on nightly Rust, you have an up to date compiler. At the moment, this is breaking `libtock-rs`' CI: `value-bag` does not build with the toolchain `libtock-rs` uses.

I tried to update the compiler, but newer compilers SIGSEGV on `libtock-rs`. Rather than investigating that (which will likely be very time-consuming), I decided to remove `libtock-rs`' dependency on `value-bag`. This required removing `test_runner`'s dependency on both `tokio` and `async-std`.

I replaced the timeout functionality by spawning a second thread that waits for 10 seconds then kills QEMU.