### PR TITLE
Allow warnings in local builds, only fail on warnings in CI.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,10 +6,6 @@ rrv32imc = "rriscv32imc"
 rthumbv7em = "run --release --target=thumbv7em-none-eabi --example"
 rtv7em = "rthumbv7em"
 
-# Deny warnings on all architectures. build.rustflags cannot be used here as the lower section would override its effect.
-[target.'cfg(all())']
-rustflags = ["-D", "warnings"]
-
 # Common settings for all embedded targets
 [target.'cfg(any(target_arch = "arm", target_arch = "riscv32"))']
 rustflags = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,15 @@ jobs:
       # makefile can be tested locally. We experimentally determined that -j2 is
       # optimal for the Azure Standard_DS2_v2 VM, which is the VM type used by
       # GitHub Actions at the time of this writing.
+      #
+      # We have to append the "-D warnings" flag to .cargo/config rather than
+      # using the RUSTFLAGS environment variable because if we set RUSTFLAGS
+      # cargo will ignore the rustflags config in .cargo/config, breaking
+      # relocation.
       - name: Build and Test
         run: |
           cd "${GITHUB_WORKSPACE}"
+          echo "[target.'cfg(all())']" >> .cargo/config
+          echo 'rustflags = ["-D", "warnings"]' >> .cargo/config
           make -j2 setup
           make -j2 test


### PR DESCRIPTION
This is to eliminate a frustration I have had while working on libtock-rs. I frequently develop several new pieces before writing code that uses them, and the existing configuration makes `cargo check` fail. I have been manually commenting out the `rustflags` config in `.cargo/config`, but that introduces toil and I have to revert that change before sending each PR.

With this change, the CI workflow will still error if a warning is present. I expect contributors to continue running `make test` before sending PRs, and to fix any warnings. Of course, this does slightly increase the risk that someone sends a PR that fails in CI because they didn't notice the warning.

Feel free to let me know whether you think this is a positive or negative change!