### PR TITLE
Allow warnings during local development

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,10 +6,6 @@ rrv32imc = "rriscv32imc"
 rthumbv7em = "run --release --target=thumbv7em-none-eabi --example"
 rtv7em = "rthumbv7em"
 
-# Deny warnings on all architectures. build.rustflags cannot be used here as the lower section would override its effect.
-[target.'cfg(all())']
-rustflags = ["-D", "warnings"]
-
 # Common settings for all embedded targets
 [target.'cfg(any(target_arch = "arm", target_arch = "riscv32"))']
 rustflags = [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,15 @@ jobs:
       # makefile can be tested locally. We experimentally determined that -j2 is
       # optimal for the Azure Standard_DS2_v2 VM, which is the VM type used by
       # GitHub Actions at the time of this writing.
+      #
+      # We have to append the "-D warnings" flag to .cargo/config rather than
+      # using the RUSTFLAGS environment variable because if we set RUSTFLAGS
+      # cargo will ignore the rustflags config in .cargo/config, breaking
+      # relocation.
       - name: Build and Test
         run: |
           cd "${GITHUB_WORKSPACE}"
+          echo "[target.'cfg(all())']" >> .cargo/config
+          echo 'rustflags = ["-D", "warnings"]' >> .cargo/config
           make -j2 setup
           make -j2 test


### PR DESCRIPTION
This keep's CI's behavior where it errors if libtock-rs has warnings.

This is a second attempt at PR #270. We can't specify `RUSTFLAGS` directly because doing so overrides all `rustflags` configurations in `.cargo/config`. Those `rustflags` configs are important because they configure relocation and set the linker script. Instead, I append the `"deny warnings"` config to `.cargo/config` in CI itself.

I tested this by opening two PRs in my fork: [one to test that this PR still builds](https://github.com/jrvanwhy/libtock-rs/pull/15), and [one to test it fails if a warning is present](https://github.com/jrvanwhy/libtock-rs/pull/13).

I am not terribly happy with this solution (feels really hacky rather than kinda hacky), so any alternative implementation ideas would be appreciated!