### PR TITLE
Update the design of `RawSyscalls` based on TRD changes.

### DIFF
--- a/core/platform/src/lib.rs
+++ b/core/platform/src/lib.rs
@@ -11,7 +11,7 @@ mod syscalls_impl;
 pub use async_traits::{CallbackContext, FreeCallback, Locator, MethodCallback};
 pub use command_return::CommandReturn;
 pub use error_code::ErrorCode;
-pub use raw_syscalls::{OneArgMemop, RawSyscalls, YieldType, ZeroArgMemop};
+pub use raw_syscalls::RawSyscalls;
 pub use return_variant::ReturnVariant;
 pub use syscalls::Syscalls;
 

--- a/core/platform/src/raw_syscalls.rs
+++ b/core/platform/src/raw_syscalls.rs
@@ -3,242 +3,51 @@
 
 /// `RawSyscalls` allows a fake Tock kernel to be injected into components for
 /// unit testing. It is implemented by `libtock_runtime::TockSyscalls` and
-/// `libtock_unittest::FakeSyscalls`. **Components should not use `RawSyscalls`
+/// `libtock_unittest::fake::Kernel`. **Components should not use `RawSyscalls`
 /// directly; instead, use the `Syscalls` trait, which provides higher-level
 /// interfaces to the system calls.**
+// -----------------------------------------------------------------------------
+// Full documentation for everything in this file is in doc/RawSyscallsDesign.md
+// at the root of this repository.
+// -----------------------------------------------------------------------------
+use crate::ReturnVariant;
 
-// RawSyscalls is designed to minimize the amount of handwritten assembly code
-// needed without generating unnecessary instructions. This comment describes
-// the thought process that led to the choice of methods for RawSyscalls. There
-// are a few major considerations affecting its design:
-//
-//     1. Most system calls only clobber r0-r4 (*), while yield has a far longer
-//        clobber list. As such, yield must have its own assembly
-//        implementation.
-//     2. The compiler is unable to optimize away unused arguments. For example,
-//        memop's "get process RAM start address" operation only needs r0 set,
-//        while memop's "break" operation needs both r0 and r1 set. If our
-//        inline assembly calls "get process RAM start address" but sets both r0
-//        and r1, the compiler doesn't know that r1 will be
-//        ignored so setting that register will not be optimized away. Therefore
-//        we want to set the minimum number of argument registers possible.
-//     3. The cost of specifying unused return registers is only that of
-//        unnecessarily marking a register as clobbered. Explanation: After
-//        inlining, an unused register is marked as "changed by the assembly"
-//        but can immediately be re-used by the compiler, which is the same as a
-//        clobbered register. System calls should generally be
-//        inlined -- and even if they aren't, the unused return values will
-//        probably be passed in caller-saved registers (this is true for the C
-//        ABI, so probably true for the Rust ABI), which are treated as
-//        clobbered regardless.
-//
-// (*) When this file refers to registers, it uses the same naming convention as
-// the Tock 2.0 syscalls TRD. Registers r0-r4 correspond to ARM registers r0-r4
-// and RISC-V registers a0-a4.
-//
-// Currently, yield takes exactly one argument (to specify what yield type to
-// do). Therefore we only need one raw yield call.
-//
-// Based on these considerations, it would make sense to have the following
-// methods:
-//     yield
-//     zero_arg_syscall
-//     one_arg_syscall
-//     two_arg_syscall
-//     three_arg_syscall
-//     four_arg_syscall
-//
-// However, there are no system calls that take 0 or 3 arguments, so we do not
-// need the corresponding methods. This leaves yield, 1-arg, 2-arg, and 4-arg
-// system calls.
-//
-// The 1-arg and 2-arg system calls are only used for memop. Memop currently has
-// the property that none of its operations can lead to undefined behavior.
-// Therefore, we can rename the 1-arg and 2-arg system calls to zero_arg_memop
-// and one_arg_memop and make them safe methods (the argument counts change
-// because the number of system call arguments is one greater than the number of
-// arguments passed to the specific op).
-//
-// This only leaves four_arg_syscall, which is used to implement subscribe,
-// command, read-write allow, and read-only allow.
-//
-// Therefore the final design has 4 methods:
-//     yield
-//     zero_arg_memop
-//     one_arg_memop
-//     four_arg_syscall
-//
-// If a new system call class that uses fewer than four arguments is added, then
-// the above list will need to be revised.
-//
-// Note that `command` always needs to use four_arg_syscall, even when calling a
-// command with fewer arguments, because we don't want to leak the
-// (possibly secret) values in the r2 and r3 registers to untrusted capsules.
-// Yield and memop do not have this concern and can leave arbitrary data in r2
-// and r3, because they are implemented by the core kernel, which is trusted.
-//
-// The success type for Memop calls depends on the operation performed. However,
-// all *currently defined* memop operations return either Success or Success
-// with u32. Therefore, the memop implementations only need to mark r0 and r1 as
-// clobbered, not r2 and r3. This choice of clobbers will need to be revisited
-// if and when a memop operation that returns more data is added.
-//
-// The decision of where to use u32 and usize can be a bit tricky. The Tock
-// syscall ABI is currently only specified for 32-bit systems, so on real Tock
-// systems both types match the size of a register, but the unit test
-// environment can be either 32 bit or 64 bit. This interface uses usize for
-// values that can contain pointers, so that pointers are not truncated in the
-// unit test environment. To keep types as consistent as possible, it uses u32
-// for all values that cannot be pointers.
 pub trait RawSyscalls {
-    // raw_yield should:
-    //     1. Call syscall class 0
-    //     2. Use register r0 for input and output as an inlateout register,
-    //        passing in r0_in and returning its value.
-    //     3. Mark all caller-saved registers as lateout clobbers.
-    //     4. NOT provide any of the following options:
-    //            pure             (yield has side effects)
-    //            nomem            (a callback can read + write globals)
-    //            readonly         (a callback can write globals)
-    //            preserves_flags  (a callback can change flags)
-    //            noreturn         (yield is expected to return)
-    //            nostack          (a callback needs the stack)
-    //
-    // Design note: This is safe because the yield types that currently exist
-    // are safe. If an unsafe yield type is added, we will need to make
-    // raw_yield unsafe. Although raw_yield shouldn't be called by code outside
-    // this crate, it can be, so that is a backwards-incompatible change. We
-    // pass YieldType rather than a usize because if we used usize directly then
-    // this API becomes unsound if the kernel adds support for an unsafe yield
-    // type (or even one that takes one more argument).
-    /// `raw_yield` should only be called by `libtock_platform`.
-    fn raw_yield(r0_in: YieldType) -> u32;
-
-    // four_arg_syscall is used to invoke the subscribe, command, read-write
-    // allow, and read-only allow system calls.
-    //
-    // four_arg_syscall's inline assembly should have the following properties:
-    //     1. Calls the syscall class specified by class
-    //     2. Passes r0-r3 in the corresponding registers as inlateout
-    //        registers. Returns r0-r3 in order.
-    //     3. Does not mark any registers as clobbered.
-    //     4. Has all of the following options:
-    //            preserves_flags  (these system calls do not touch flags)
-    //            nostack          (these system calls do not touch the stack)
-    //     5. Does NOT have any of the following options:
-    //            pure      (these system calls have side effects)
-    //            nomem     (the compiler needs to write to globals before allow)
-    //            readonly  (rw allow can modify memory)
-    //            noreturn  (all these system calls are expected to return)
-    //
-    // Note that subscribe's application data argument can potentially contain a
-    // pointer, so r3 can contain a pointer (in addition to r1 and r2, which
-    // more obviously contain pointers for subscribe and memop).
-    //
-    // For subscribe(), the callback pointer should be either 0 (for the null
-    // callback) or an `unsafe extern fn(u32, u32, u32, usize)`.
-    /// `four_arg_syscall` should only be called by `libtock_platform`.
-    ///
+    // Calls yield-no-wait, passing `flag` to the kernel. The kernel will set
+    // the value that flag points to based on whether a callback was executed.
     /// # Safety
-    /// `four_arg_syscall` must NOT be used to invoke yield. Otherwise, it has
-    /// the same safety invariants as the underlying system call, which varies
-    /// depending on the system call class.
+    /// Will write a 0 or 1 into flag's pointee.
+    unsafe fn raw_yield_no_wait(flag: *mut u8);
+
+    fn raw_yield_wait();
+
+    // `one_arg_syscall` supports calling Exit and Memop operations that do not
+    // need an argument.
+    /// # Safety
+    /// This is a direct wrapper around a raw system call, and produces
+    /// undefined behavior exactly when the underlying system call produces
+    /// undefined behavior.
+    unsafe fn one_arg_syscall(op: u32, class: u8) -> (ReturnVariant, usize);
+
+    // `two_arg_syscall` supports calling Exit and Memop operations that need an
+    // argument.
+    /// # Safety
+    /// This is a direct wrapper around a raw system call, and produces
+    /// undefined behavior exactly when the underlying system call produces
+    /// undefined behavior.
+    unsafe fn two_arg_syscall(op: u32, r1: usize, class: u8) -> (ReturnVariant, usize);
+
+    // `four_arg_syscall` supports calling the Command, Read-Only Allow,
+    // Read-Write Allow, and Subscribe system calls.
+    /// # Safety
+    /// This is a direct wrapper around a raw system call, and produces
+    /// undefined behavior exactly when the underlying system call produces
+    /// undefined behavior.
     unsafe fn four_arg_syscall(
         r0: u32,
         r1: u32,
         r2: usize,
         r3: usize,
         class: u8,
-    ) -> (u32, usize, usize, usize);
-
-    // zero_arg_memop is used to invoke memop operations that do not accept an
-    // argument register. Because there are no memop commands that set r2 or r3,
-    // this only needs to return r0 and r1.
-    //
-    // Memop commands may panic in the unit test environment, as not all memop
-    // calls can be sensibly implemented in that environment.
-    //
-    // zero_arg_memop's inline assembly should have the following properties:
-    //     1. Calls syscall class 5
-    //     2. Specifies r0 as an inlateout register, and r1 as a lateout
-    //        register.
-    //     3. Does not mark any registers as clobbered.
-    //     4. Has all of the following options:
-    //            preserves_flags
-    //            nostack
-    //            nomem            (it is okay for the compiler to cache globals
-    //                              across memop calls)
-    //     5. Does NOT have any of the following options:
-    //            pure      (two invocations of the same memop can return
-    //                       different values)
-    //            readonly  (incompatible with nomem)
-    //            noreturn
-    //
-    // Design note: like raw_yield, this is safe because memops that currently
-    // exist are safe. zero_arg_memop takes a ZeroArgMemop rather than a u32 so
-    // that if the kernel adds an unsafe memop -- or one that can clobber r2/r3
-    // --  this API doesn't become unsound.
-    /// `four_arg_syscall` should only be called by `libtock_platform`.
-    fn zero_arg_memop(r0_in: ZeroArgMemop) -> (u32, usize);
-
-    // one_arg_memop is used to invoke memop operations that take an argument.
-    // Because there are no memop operations that set r2 or r3, this only needs
-    // to return r0 and r1.
-    //
-    // one_arg_memop's inline assembly should:
-    //     1. Call syscall class 5
-    //     2. Specify r0 and r1 as inlateout registers, and return (r0, r1)
-    //     3. Not mark any registers as clobbered.
-    //     4. Have all of the following options:
-    //            preserves_flags
-    //            nostack
-    //            nomem            (the compiler can cache globals across memop
-    //                              calls)
-    //     5. Does NOT have any of the following options:
-    //            pure      Two invocations of sbrk can return different values
-    //            readonly  Incompatible with nomem
-    //            noreturn
-    //
-    // Design note: like raw_yield, this is safe because memops that currently
-    // exist are safe. zero_arg_memop takes a ZeroArgMemop rather than a u32 so
-    // that if the kernel adds an unsafe memop -- or one that can clobber r2/r3
-    // -- this API doesn't become unsound.
-    /// `four_arg_syscall` should only be called by `libtock_platform`.
-    fn one_arg_memop(r0_in: OneArgMemop, r1: usize) -> (u32, usize);
-}
-
-#[non_exhaustive]
-#[repr(u32)]
-pub enum OneArgMemop {
-    Brk = 0,
-    Sbrk = 1,
-    FlashRegionStart = 8,
-    FlashRegionEnd = 9,
-    SpecifyStackTop = 10,
-    SpecifyHeapStart = 11,
-    // Note: before adding new memop operations, make sure the assumptions in
-    // the design notes on `one_arg_memop` are valid for the new operation type.
-}
-
-// TODO: When the numeric values (0 and 1) are assigned to the yield types,
-// specify those values here.
-#[non_exhaustive]
-#[repr(u32)]
-pub enum YieldType {
-    Wait,
-    NoWait,
-}
-
-#[non_exhaustive]
-#[repr(u32)]
-pub enum ZeroArgMemop {
-    MemoryStart = 2,
-    MemoryEnd = 3,
-    FlashStart = 4,
-    FlashEnd = 5,
-    GrantStart = 6,
-    FlashRegions = 7,
-    // Note: before adding new memop operations, make sure the assumptions in
-    // the design notes on `zero_arg_memop` are valid for the new operation
-    // type.
+    ) -> (ReturnVariant, usize, usize, usize);
 }

--- a/core/platform/src/raw_syscalls.rs
+++ b/core/platform/src/raw_syscalls.rs
@@ -15,10 +15,9 @@ use crate::ReturnVariant;
 pub trait RawSyscalls {
     // Calls yield-no-wait, passing `flag` to the kernel. The kernel will set
     // the value that flag points to based on whether a callback was executed.
-    /// # Safety
-    /// Will write a 0 or 1 into flag's pointee.
-    unsafe fn raw_yield_no_wait(flag: *mut u8);
+    fn raw_yield_no_wait(flag: &mut u8);
 
+    // Calls tho `yield-wait` form of the Yield system call.
     fn raw_yield_wait();
 
     // `one_arg_syscall` supports calling Exit and Memop operations that do not

--- a/core/platform/src/return_variant.rs
+++ b/core/platform/src/return_variant.rs
@@ -1,11 +1,14 @@
 /// `ReturnVariant` describes what value type the kernel has returned.
 // ReturnVariant is not an enum so that it can be converted from a u32 for free.
+// It is repr(transparent) so it can be used as a register output in an `asm!`
+// statement (in the `RawSyscalls` implementation).
 // TODO: derive(Debug) is currently only enabled for test builds, which is
 // necessary so it can be used in assert_eq!. We should develop a lighter-weight
 // Debug implementation and see if it is small enough to enable on non-Debug
 // builds.
 #[cfg_attr(test, derive(Debug))]
 #[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
 pub struct ReturnVariant(u32);
 
 impl From<u32> for ReturnVariant {

--- a/core/platform/src/syscalls_impl.rs
+++ b/core/platform/src/syscalls_impl.rs
@@ -1,17 +1,19 @@
 //! Implements `Syscalls` for all types that implement `RawSyscalls`.
 
-use crate::{return_variant, RawSyscalls, Syscalls, YieldType};
-
-impl<S: RawSyscalls> Syscalls for S {
+impl<S: crate::RawSyscalls> crate::Syscalls for S {
     // -------------------------------------------------------------------------
     // Yield
     // -------------------------------------------------------------------------
 
     fn yield_wait() {
-        Self::raw_yield(YieldType::Wait);
+        Self::raw_yield_wait();
     }
 
     fn yield_no_wait() -> bool {
-        Self::raw_yield(YieldType::NoWait) != return_variant::FAILURE.into()
+        let mut flag = core::mem::MaybeUninit::uninit();
+        unsafe {
+            Self::raw_yield_no_wait(flag.as_mut_ptr());
+        }
+        (unsafe { flag.assume_init() }) != 0
     }
 }

--- a/core/platform/src/syscalls_impl.rs
+++ b/core/platform/src/syscalls_impl.rs
@@ -10,10 +10,8 @@ impl<S: crate::RawSyscalls> crate::Syscalls for S {
     }
 
     fn yield_no_wait() -> bool {
-        let mut flag = core::mem::MaybeUninit::uninit();
-        unsafe {
-            Self::raw_yield_no_wait(flag.as_mut_ptr());
-        }
-        (unsafe { flag.assume_init() }) != 0
+        let mut flag = 0;
+        Self::raw_yield_no_wait(&mut flag);
+        flag != 0
     }
 }

--- a/core/runtime/src/syscalls_impl_riscv.rs
+++ b/core/runtime/src/syscalls_impl_riscv.rs
@@ -4,7 +4,7 @@ impl RawSyscalls for crate::TockSyscalls {
     // This yield implementation is currently limited to RISC-V versions without
     // floating-point registers, as it does not mark them clobbered.
     #[cfg(not(any(target_feature = "d", target_feature = "f")))]
-    unsafe fn raw_yield_no_wait(flag: *mut u8) {
+    fn raw_yield_no_wait(flag: &mut u8) {
         unsafe {
             asm!("ecall",
                  // x0 is the zero register.
@@ -66,27 +66,23 @@ impl RawSyscalls for crate::TockSyscalls {
     unsafe fn one_arg_syscall(op: u32, class: u8) -> (ReturnVariant, usize) {
         let r0_out;
         let r1;
-        unsafe {
-            asm!("ecall",
-                 inlateout("a0") op => r0_out,
-                 lateout("a1") r1,
-                 in("a4") class as usize, // Cast needed to zero high bits
-                 options(preserves_flags, nostack, nomem),
-            );
-        }
+        asm!("ecall",
+             inlateout("a0") op => r0_out,
+             lateout("a1") r1,
+             in("a4") class as usize, // Cast needed to zero high bits
+             options(preserves_flags, nostack, nomem),
+        );
         (r0_out, r1)
     }
 
     unsafe fn two_arg_syscall(op: u32, r1: usize, class: u8) -> (ReturnVariant, usize) {
         let r0_out;
-        unsafe {
-            asm!("ecall",
-                 inlateout("a0") op => r0_out,
-                 inlateout("a1") r1,
-                 in("a4") class as usize, // Cast needed to zero high bits
-                 options(preserves_flags, nostack, nomem)
-            );
-        }
+        asm!("ecall",
+             inlateout("a0") op => r0_out,
+             inlateout("a1") r1,
+             in("a4") class as usize, // Cast needed to zero high bits
+             options(preserves_flags, nostack, nomem)
+        );
         (r0_out, r1)
     }
 

--- a/core/runtime/src/syscalls_impl_riscv.rs
+++ b/core/runtime/src/syscalls_impl_riscv.rs
@@ -1,11 +1,10 @@
-use libtock_platform::{OneArgMemop, RawSyscalls, YieldType, ZeroArgMemop};
+use libtock_platform::{RawSyscalls, ReturnVariant};
 
 impl RawSyscalls for crate::TockSyscalls {
-    // This yield implementation is currently limited RISC-V versions without
+    // This yield implementation is currently limited to RISC-V versions without
     // floating-point registers, as it does not mark them clobbered.
     #[cfg(not(any(target_feature = "d", target_feature = "f")))]
-    fn raw_yield(r0_in: YieldType) -> u32 {
-        let mut r0 = r0_in as u32;
+    unsafe fn raw_yield_no_wait(flag: *mut u8) {
         unsafe {
             asm!("ecall",
                  // x0 is the zero register.
@@ -16,7 +15,38 @@ impl RawSyscalls for crate::TockSyscalls {
                  lateout("x6") _, // t1
                  lateout("x7") _, // t2
                  // x8 and x9 are s0 and s1 and are callee-saved.
-                 inlateout("x10") r0,     // a0
+                 inlateout("x10") 0 => _,    // a0
+                 inlateout("x11") flag => _, // a1
+                 lateout("x12") _,           // a2
+                 lateout("x13") _,           // a3
+                 inlateout("x14") 0 => _,    // a4
+                 lateout("x15") _,           // a5
+                 lateout("x16") _,           // a6
+                 lateout("x17") _,           // a7
+                 // x18-27 are s2-s11 and are callee-saved
+                 lateout("x28") _, // t3
+                 lateout("x29") _, // t4
+                 lateout("x30") _, // t5
+                 lateout("x31") _, // t6
+            );
+        }
+    }
+
+    // This yield implementation is currently limited to RISC-V versions without
+    // floating-point registers, as it does not mark them clobbered.
+    #[cfg(not(any(target_feature = "d", target_feature = "f")))]
+    fn raw_yield_wait() {
+        unsafe {
+            asm!("ecall",
+                 // x0 is the zero register.
+                 lateout("x1") _, // Return address
+                 // x2-x4 are stack, global, and thread pointers. sp is
+                 // callee-saved.
+                 lateout("x5") _, // t0
+                 lateout("x6") _, // t1
+                 lateout("x7") _, // t2
+                 // x8 and x9 are s0 and s1 and are callee-saved.
+                 inlateout("x10") 1 => _, // a0
                  lateout("x11") _,        // a1
                  lateout("x12") _,        // a2
                  lateout("x13") _,        // a3
@@ -31,7 +61,33 @@ impl RawSyscalls for crate::TockSyscalls {
                  lateout("x31") _, // t6
             );
         }
-        r0
+    }
+
+    unsafe fn one_arg_syscall(op: u32, class: u8) -> (ReturnVariant, usize) {
+        let r0_out;
+        let r1;
+        unsafe {
+            asm!("ecall",
+                 inlateout("a0") op => r0_out,
+                 lateout("a1") r1,
+                 in("a4") class as usize, // Cast needed to zero high bits
+                 options(preserves_flags, nostack, nomem),
+            );
+        }
+        (r0_out, r1)
+    }
+
+    unsafe fn two_arg_syscall(op: u32, r1: usize, class: u8) -> (ReturnVariant, usize) {
+        let r0_out;
+        unsafe {
+            asm!("ecall",
+                 inlateout("a0") op => r0_out,
+                 inlateout("a1") r1,
+                 in("a4") class as usize, // Cast needed to zero high bits
+                 options(preserves_flags, nostack, nomem)
+            );
+        }
+        (r0_out, r1)
     }
 
     unsafe fn four_arg_syscall(
@@ -46,36 +102,9 @@ impl RawSyscalls for crate::TockSyscalls {
              inlateout("a1") r1,
              inlateout("a2") r2,
              inlateout("a3") r3,
-             in("a4") class,
+             in("a4") class as usize, // Cast needed to zero high bits
              options(preserves_flags, nostack),
         );
         (r0, r1 as usize, r2, r3)
-    }
-
-    fn zero_arg_memop(r0_in: ZeroArgMemop) -> (u32, usize) {
-        let mut r0 = r0_in as u32;
-        let r1;
-        unsafe {
-            asm!("ecall",
-                 inlateout("a0") r0,
-                 lateout("a1") r1,
-                 in("a4") 5,
-                 options(preserves_flags, nostack, nomem),
-            );
-        }
-        (r0, r1)
-    }
-
-    fn one_arg_memop(r0_in: OneArgMemop, mut r1: usize) -> (u32, usize) {
-        let mut r0 = r0_in as u32;
-        unsafe {
-            asm!("ecall",
-                 inlateout("a0") r0,
-                 inlateout("a1") r1,
-                 in("a4") 5,
-                 options(preserves_flags, nostack, nomem)
-            );
-        }
-        (r0, r1)
     }
 }

--- a/doc/RawSyscallsDesign.md
+++ b/doc/RawSyscallsDesign.md
@@ -1,0 +1,196 @@
+`RawSyscalls` Design
+====================
+
+## High-Level Overview
+
+`libtock_platform` has two traits for Tock's system calls. `Syscalls` is the
+high-level interface that drivers should use to make system calls. `RawSyscalls`
+is a low-level interface to the system calls that is used to switch between real
+kernel system calls (provided by `libtock_runtime::TockSyscalls`) and unit
+tests' fake system call implementation (provided by
+`libtock_unittest::fake::Kernel`).
+
+Code that relies on `RawSyscalls` can be unit tested by using `fake::Kernel`,
+but the code in the `RawSyscalls` implementation cannot be unit tested. To
+minimize the amount of non-unit-testable code, `RawSyscalls` is designed to be a
+minimal wrapper around `asm!`.
+
+## Major Design Considerations
+
+**Note: This file uses the same register naming convention as the Tock 2.0
+syscalls TRD. Registers `r0`-`r4` refer to ARM registers `r0`-`r4` and RISC-V
+registers `a0`-`a4`.**
+
+1. Most system calls only clobber `r0`-`r4`, while Yield calls have a far longer
+   clobber list. It would be inefficient to share an `asm!` call between Yield
+   and another system call.
+1. Exit does not return. This initially seems to be an important distinction,
+   but it is not. `Syscalls` can use `unreachable_unchecked!` to tell the
+   compiler it doesn't exit, and it should be obvious the return values are all
+   unused.
+1. The compiler is unable to optimize away unused arguments. For example,
+   Memop's "get process RAM start address" operation only needs `r0` set, while
+   Memop's "break" operation needs both `r0` and `r1` set. If our inline
+   assembly calls "get process RAM start address" but sets both `r0` and `r1`,
+   the compiler doesn't know that `r1` will be ignored so setting that register
+   will not be optimized away. Therefore we want to set the minimum number of
+   argument registers possible.
+1. The cost of specifying unused return registers is only that of unnecessarily
+   marking a register as clobbered. Explanation: After inlining, an unused
+   register is marked as "changed by the assembly" but can immediately be
+   re-used by the compiler, which is the same as a clobbered register. System
+   calls should generally be inlined -- and even if they aren't, the unused
+   return values will probably be passed in caller-saved registers (this is true
+   for the C ABI, so probably true for the Rust ABI), which are treated as
+   clobbered regardless.
+1. Command always needs to set all four registers, because otherwise we risk
+   leaking data to capsules (which are untrusted for confidentiality). Exit,
+   Memop, and Yield do not have this concern because they are implemented by the
+   core kernel (which is trusted).
+
+## Yield Method Breakdown
+
+`yield-wait` does not take any arguments, while `yield-no-wait` takes 1.
+Therefore, to avoid setting arguments unnecessarily, `yield-wait` and
+`yield-no-wait` should be distinct functions.
+
+## Remaining Method Breakdown
+
+After taking care of `yield`, we break down the remaining system calls by the
+number of arguments they take. Here is the breakdown (Exit and Memop are listed
+twice because they have sub-operations with varying number of arguments).
+
+* **Zero:**
+* **One:** Exit, Memop
+* **Two:** Exit, Memop
+* **Three:**
+* **Four:** Command, Read-Only Allow, Read-Write Allow, Subscribe
+
+Therefore we need three more methods: `one_arg_syscall`, `two_arg_syscall`,
+`four_arg_syscall`.
+
+## `u32` versus `usize`
+
+The decision of where to use `u32` and where to use `usize` can be a bit tricky.
+The Tock syscall ABI is currently only specified for 32-bit systems, so on real
+Tock systems both types match the size of a register, but the unit test
+environment can be either 32 bit or 64 bit. `RawSyscalls` uses `usize` for
+values that can contain pointers, so that pointers are not truncated in the unit
+test environment. To keep types as consistent as possible, it uses `u32` for
+register-sized values that cannot be pointers.
+
+## Yield Methods Design
+
+Rust does not specify the representation of `bool`, only that it casts to `0`
+and `1`, so it would not be correct use a `bool` as the flag for
+`yield-no-wait`. Instead we use a `u8`.
+
+Also, passing in a `&mut` reference to the `u8` requires the compiler to
+initialize the `u8`. Instead, we take a `*mut u8` which can point at
+uninitilized memory. When `raw_yield_no_wait` returns the memory will have been
+initialized by the kernel.
+
+To avoid name collisions with the Yield methods in `Syscalls`, we prepend `raw_`
+to their names.
+
+This results in the following signatures:
+
+```rust
+unsafe raw_yield_no_wait(flag: *mut u8);
+raw_yield_wait();
+```
+
+The `asm!` statements for these methods must:
+
+1. Call syscall class `0`.
+1. `yield_no_wait`: pass `0` in `r0` as `inlateout`; `yield_wait`: pass `1` in
+   `r0` as `inlateout`.
+1. `yield_no_wait`: pass the `flag` reference in `r1` as `inlateout`.
+1. Mark all other caller-saved registers as `lateout` clobbers.
+1. NOT provide any of the following options:
+   * `pure`: Yield has side effects
+   * `nomem`: A callback can read + write globals
+   * `readonly`: A callback can write globals
+   * `preserves_flags`: A callback can change flags
+   * `noreturn`: Yield is expected to return
+   * `nostack`: A callback needs the stack
+
+## `one_arg_syscall` and `two_arg_syscall` Design
+
+None of the Exit and Memop operations that currently exist can produce memory
+unsafety, and in principle it is possible to write `one_arg_syscall` and
+`two_arg_syscall` in a way that doesn't require them to be `unsafe`. However,
+encoding the safe combinations of syscall class and operation number can only be
+soundly done using an `unsafe` trait, and doesn't save any `unsafe` uses
+relative to making `one_arg_syscall` and `two_arg_syscall` `unsafe`. Therefore
+we take the simple option and make them `unsafe`.
+
+Memop returns pointers in r1, so we need to return a `usize` for `r1` instead of
+a `u32`.
+
+This results in the following signatures:
+
+```rust
+unsafe fn one_arg_syscall(op: u32, class: u8) -> (ReturnVariant, usize);
+unsafe fn two_arg_syscall(op: u32, r1: usize, class: u8) -> (ReturnVariant, usize);
+```
+
+The `asm!` statements for these methods must:
+
+1. Call the provided system call class.
+1. Specify `r0` as an `inlateout` register.
+1. `one_arg_syscall`: specify `r1` as a `lateout` register; `two_arg_syscall`:
+   specify `r1` as a `inlateout` register.
+1. Return `(r0, r1)`
+1. Do not mark any registers as clobbered.
+1. Have the following options:
+   * `preserves_flags`
+   * `nostack`
+   * `nomem`: It is okay for the compiler to cache globals across Memop calls
+1. Does NOT have any of the following options:
+   * `pure`
+   * `readonly`: Incompatible with `nomem`
+   * `noreturn`: True for Exit but not Memop
+
+## `four_arg_syscall` Design
+
+Read-Only Allow, Read-Write Allow, and Subscribe can all cause memory unsafety,
+so we don't need to try to make a safe interface for them.
+
+**Inputs:** Driver IDs and buffer/command/subscription IDs are all 32-bit and are passed in
+`r0` and `r1`. Read-Only and Read-Write Allow pass pointer-sized data in `r2`,
+so it must be a `usize`. Subscribe's application data pointer can contain a
+pointer, so the `r3` input must be a `usize` as well.
+
+**Outputs:** `r0` always contains an arbitrary `ReturnVariant`. Subscribe can
+return pointers in `r1`, `r2`, and `r3`, so they must always be a `usize`.
+
+For Subscribe, the callback pointer should either be `0` (for the Null
+Callback) or an `unsafe extern fn(u32, u32, u32, usize)`.
+
+This gives us the following signature for `four_arg_syscall`:
+
+```rust
+unsafe fn four_arg_syscall(
+    r0: u32,
+    r1: u32,
+    r2: usize,
+    r3: usize,
+    class: u8)
+-> (ReturnVariant, usize, usize, usize);
+```
+
+The `asm!` statement in `four_arg_syscall` must:
+
+1. Call the syscall class specified by `class`
+1. Pass `r0`-`r3` in the corresponding registers as `inlateout` registers.
+1. Return `r0`-`r3` in order.
+1. Not mark any registers as clobbered.
+1. Have all of the following options:
+   * `preserves_flags`
+   * `nostack`
+1. Not have any of the following options:
+   * `pure`
+   * `nomem`: The compiler must write to globals before Allow
+   * `readonly`: Read-Write Allow can modify memory
+   * `noreturn`


### PR DESCRIPTION
There have been quite a lot of changes since I originally designed `RawSyscalls`! This change updates `RawSyscalls` to be consistent with the current TRD, plus adds some cleanups and bugfixes.

Changes:
1. Split `raw_yield` into two methods, as `yield-wait` and `yield-no-wait` now have significantly different signatures (their argument counts vary now).
1. Generalized `zero_arg_memop` and `one_arg_memop` to handle both Memop and Exit calls.
1. Moved the design documentation for `RawSyscalls` out of `raw_syscalls.rs` and into [`doc/RawSyscallsDesign.md`](https://github.com/jrvanwhy/libtock-rs/blob/raw-syscalls-update/doc/RawSyscallsDesign.md).
1. Fixed a bug in `four_arg_syscall` on RISC-V.

The bug in `four_arg_syscall` is as follows: `class` is passed in as a `u8`. It was then directly set as an `asm!` input. `asm!`'s [documentation](https://doc.rust-lang.org/beta/unstable-book/library-features/asm.html) says:

> If a value is of a smaller size than the register it is allocated in then the upper bits of that register will have an undefined value for inputs and will be ignored for outputs.

Therefore we were ending up with an undefined value in `a4`. The fix is to cast `class` to a `usize` before passing it into `asm!`.