### PR TITLE
Update the status of the Platform Design Story document.

### DIFF
--- a/doc/PlatformDesignStory.md
+++ b/doc/PlatformDesignStory.md
@@ -1,8 +1,10 @@
 `libtock_platform` Design Story
 ===============================
 
-Note: At the time of this writing, `libtock_platform` is still a work in
-progress that exists largely in @jrvanwhy's head.
+Note: `libtock_platform` is part of the libtock 2.0 rewrite. It is partially
+implemented in this repository. A working version exists in @jrvanwhy's
+repository in the [wip](https://github.com/jrvanwhy/libtock-rs/tree/wip) branch.
+It is being refined and merged upstream in pieces.
 
 `libtock_platform` is a crate that will contain core abstractions that will be
 used by `libtock_core`'s drivers. For example, it will contain abstractions for


### PR DESCRIPTION
[Rendered](https://www.github.com/jrvanwhy/libtock-rs/tree/platform-update/doc/PlatformDesignStory.md)

The rewritten `libtock-rs` no longer exists only in my head, it is working. I am updating the note at the top of the document because I am sharing it with others and need it to be accurate.

I am implementing more tests to make sure the core abstractions (such as `RawSyscalls`) are all sound, and then I will break it into smaller pieces for review. I will write more docs and tests as I send each piece for review.