### PR TITLE
Update the Rust toolchain to 2021-03-25.

### DIFF
--- a/core/platform/src/command_return_tests.rs
+++ b/core/platform/src/command_return_tests.rs
@@ -130,7 +130,7 @@ fn failure_u64() {
     assert_eq!(command_return.get_failure_2_u32(), None);
     assert_eq!(
         command_return.get_failure_u64(),
-        Some((ErrorCode::Busy, 0x00001003_00001002))
+        Some((ErrorCode::Busy, 0x0000_1003_0000_1002))
     );
     assert_eq!(command_return.get_success_u32(), None);
     assert_eq!(command_return.get_success_2_u32(), None);
@@ -240,7 +240,10 @@ fn success_u64() {
     assert_eq!(command_return.get_failure_u64(), None);
     assert_eq!(command_return.get_success_u32(), None);
     assert_eq!(command_return.get_success_2_u32(), None);
-    assert_eq!(command_return.get_success_u64(), Some(0x00001002_00001001));
+    assert_eq!(
+        command_return.get_success_u64(),
+        Some(0x0000_1002_0000_1001)
+    );
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
     assert_eq!(command_return.return_variant(), return_variant::SUCCESS_U64);
@@ -299,7 +302,7 @@ fn success_u32_u64() {
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(
         command_return.get_success_u32_u64(),
-        Some((1001, 0x00001003_00001002))
+        Some((1001, 0x0000_1003_0000_1002))
     );
     assert_eq!(
         command_return.return_variant(),

--- a/core/platform/src/lib.rs
+++ b/core/platform/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![warn(unsafe_op_in_unsafe_fn)]
 
 mod async_traits;
 mod command_return;

--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -20,6 +20,7 @@
 
 #![feature(asm)]
 #![no_std]
+#![warn(unsafe_op_in_unsafe_fn)]
 
 mod startup;
 

--- a/core/runtime/src/syscalls_impl_riscv.rs
+++ b/core/runtime/src/syscalls_impl_riscv.rs
@@ -41,14 +41,16 @@ impl RawSyscalls for crate::TockSyscalls {
         mut r3: usize,
         class: u8,
     ) -> (u32, usize, usize, usize) {
-        asm!("ecall",
-             inlateout("a0") r0,
-             inlateout("a1") r1,
-             inlateout("a2") r2,
-             inlateout("a3") r3,
-             in("a4") class,
-             options(preserves_flags, nostack),
-        );
+        unsafe {
+            asm!("ecall",
+                 inlateout("a0") r0,
+                 inlateout("a1") r1,
+                 inlateout("a2") r2,
+                 inlateout("a3") r3,
+                 in("a4") class,
+                 options(preserves_flags, nostack),
+            );
+        }
         (r0, r1 as usize, r2, r3)
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(lang_items, llvm_asm, naked_functions)]
+#![feature(asm, lang_items, llvm_asm, naked_functions)]
 #![cfg_attr(any(target_arch = "arm", target_arch = "riscv32"), no_std)]
 #![cfg_attr(feature = "alloc", feature(alloc_error_handler))]
 

--- a/layout_generic.ld
+++ b/layout_generic.ld
@@ -24,9 +24,15 @@ SECTIONS {
     /* Section for just the app crt0 header.
      * This must be first so that the app can find it.
      */
-    .crt0_header :
+    /* Runtime setup logic. The crt0_header symbol is used by the entry point
+     * assembly. We have to include start here rather than .text because
+     * otherwise elf2tab fails to recognize that the process binary's flash
+     * region should start at the beginning of .start.
+     */
+    .start :
     {
         _beginning = .; /* Start of the app in flash. */
+        crt0_header = .;
         /**
          * Populate the header expected by `crt0`:
          *
@@ -68,6 +74,8 @@ SECTIONS {
          * between the header and subsequent .data section. It's unclear why,
          * but LLD is aligning sections to a multiple of 32 bytes. */
         . = ALIGN(32);
+
+        *(.start)
     } > FLASH =0xFF
 
     /* Text section, Code! */
@@ -75,7 +83,6 @@ SECTIONS {
     {
         . = ALIGN(4);
         _text = .;
-        KEEP (*(.start))
         *(.text*)
         *(.rodata*)
         KEEP (*(.syscalls))
@@ -140,30 +147,10 @@ SECTIONS {
     {
     } > FLASH
 
-    /* ARM Exception support
-     *
-     * This contains compiler-generated support for unwinding the stack,
-     * consisting of key-value pairs of function addresses and information on
-     * how to unwind stack frames.
-     * https://wiki.linaro.org/KenWerner/Sandbox/libunwind?action=AttachFile&do=get&target=libunwind-LDS.pdf
-     *
-     * .ARM.exidx is sorted, so has to go in its own output section.
-     *
-     * __NOTE__: It's at the end because we currently don't actually serialize
-     * it to the binary in elf2tbf. If it was before the RAM sections, it would
-     * through off our calculations of the header.
-     */
-    PROVIDE_HIDDEN (__exidx_start = .);
-    .ARM.exidx :
-    {
-      /* (C++) Index entries for section unwinding */
-      *(.ARM.exidx* .gnu.linkonce.armexidx.*)
-    } > FLASH
-    PROVIDE_HIDDEN (__exidx_end = .);
-
+    /* Sections we do not need. */
     /DISCARD/ :
     {
-      *(.eh_frame)
+      *(.ARM.exidx .eh_frame)
     }
 }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 [toolchain]
 # See https://rust-lang.github.io/rustup-components-history/ for a list of
 # recently nightlies and what components are available for them.
-channel = "nightly-2020-08-20"
+channel = "nightly-2021-03-25"
 components = ["clippy", "miri", "rustfmt"]
 targets = ["thumbv7em-none-eabi",
            "riscv32imac-unknown-none-elf",

--- a/src/ble_composer.rs
+++ b/src/ble_composer.rs
@@ -15,7 +15,7 @@ pub struct BlePayload {
 }
 
 impl BlePayload {
-    pub fn add(&mut self, kind: u8, content: &[u8]) -> Result<(), ()> {
+    pub fn add(&mut self, kind: u8, content: &[u8]) -> Result<(), Overflow> {
         self.check_can_write_num_bytes(content.len() + 2)?;
 
         self.bytes[self.occupied] = (content.len() + 1) as u8;
@@ -26,7 +26,7 @@ impl BlePayload {
         Ok(())
     }
 
-    pub fn add_flag(&mut self, flag: u8) -> Result<(), ()> {
+    pub fn add_flag(&mut self, flag: u8) -> Result<(), Overflow> {
         self.check_can_write_num_bytes(3)?;
 
         self.bytes[self.occupied] = 2;
@@ -36,7 +36,7 @@ impl BlePayload {
         Ok(())
     }
 
-    pub fn add_service_payload(&mut self, uuid: [u8; 2], content: &[u8]) -> Result<(), ()> {
+    pub fn add_service_payload(&mut self, uuid: [u8; 2], content: &[u8]) -> Result<(), Overflow> {
         self.check_can_write_num_bytes(4 + content.len())?;
         self.bytes[self.occupied] = (content.len() + 3) as u8;
         self.bytes[self.occupied + 1] = gap_types::SERVICE_DATA;
@@ -49,11 +49,11 @@ impl BlePayload {
         Ok(())
     }
 
-    fn check_can_write_num_bytes(&self, number: usize) -> Result<(), ()> {
+    fn check_can_write_num_bytes(&self, number: usize) -> Result<(), Overflow> {
         if self.occupied + number <= self.bytes.len() {
             Ok(())
         } else {
-            Err(())
+            Err(Overflow)
         }
     }
 }
@@ -71,6 +71,10 @@ impl AsRef<[u8]> for BlePayload {
         &self.bytes[0..self.occupied]
     }
 }
+
+// Error type returned when the buffer is too full to perform an operation.
+#[derive(Debug)]
+pub struct Overflow;
 
 #[cfg(test)]
 mod test {

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -28,7 +28,7 @@ pub unsafe fn dump_address(address: *const usize) {
     write_as_hex(&mut buffer[12..22], *address);
     for index in 0..4 {
         let byte = *(address as *const u8).offset(index);
-        let byte_is_printable_char = byte >= 0x20 && byte < 0x80;
+        let byte_is_printable_char = (0x20..0x80).contains(&byte);
         if byte_is_printable_char {
             buffer[23 + index as usize] = byte;
         }

--- a/src/sensors/mod.rs
+++ b/src/sensors/mod.rs
@@ -46,9 +46,9 @@ macro_rules! single_value_sensor {
             }
         }
 
-        impl Into<i32> for $type_name {
-            fn into(self) -> i32 {
-                self.value
+        impl From<$type_name> for i32 {
+            fn from(sensor: $type_name) -> i32 {
+                sensor.value
             }
         }
 

--- a/test_runner/src/main.rs
+++ b/test_runner/src/main.rs
@@ -53,8 +53,8 @@ fn process_output(stdout: ChildStdout) -> Result<(), Box<dyn std::error::Error>>
 }
 
 fn test_succeeded(input: String, failed_tests: &mut Vec<String>) -> Option<bool> {
-    let success = input.find("[      OK ]").is_some();
-    let failure = input.find("[ FAILURE ]").is_some();
+    let success = input.contains("[      OK ]");
+    let failure = input.contains("[ FAILURE ]");
     let input = input.replace("[      OK ]", "");
     let input = input.replace("[ FAILURE ]", "");
     let input = input.trim();

--- a/tools/print_sizes/src/main.rs
+++ b/tools/print_sizes/src/main.rs
@@ -117,18 +117,21 @@ fn main() {
         .expect("No examples found");
     let section_width = 7;
 
-    // TODO: We do not currently print out .rodata's size. Currently, the linker
-    // script embeds .rodata in .text, so we don't see it as a separate section
-    // here. We should modify the linker script to put .rodata in its own
-    // section. Until that is done, .rodata's size will be counted as part of
-    // .text, so we'll just print .text's size for now.
     println!(
-        "{0:1$} {2:3$} {4:>7$} {5:>7$} {6:>7$}",
-        "Example", name_width, "Architecture", arch_width, ".bss", ".data", ".text", section_width
+        "{0:1$} {2:3$} {4:>8$} {5:>8$} {6:>8$} {7:>8$}",
+        "Example",
+        name_width,
+        "Architecture",
+        arch_width,
+        ".bss",
+        ".data",
+        ".text",
+        ".rodata",
+        section_width
     );
     for data in example_data {
         println!(
-            "{0:1$} {2:3$} {4:7$} {5:7$} {6:7$}",
+            "{0:1$} {2:3$} {4:8$} {5:8$} {6:8$} {7:8$}",
             data.name,
             name_width,
             data.arch,
@@ -136,6 +139,7 @@ fn main() {
             data.sizes.bss,
             data.sizes.data,
             data.sizes.text,
+            data.sizes.rodata,
             section_width
         );
     }


### PR DESCRIPTION
This includes https://github.com/rust-lang/rust/pull/82141, which is needed in order to add ARM support to `libtock_runtime`. It also allows us to use the `unsafe_op_in_unsafe_fn` lint.

I went ahead and turned on `unsafe_op_in_unsafe_fn` for the Tock 2.0 crates, as I will use that setting in upcoming PRs (in addition to warning on one pattern, it also allows you to use `unsafe {}` in `unsafe` functions).

The toolchain update caused a change in the ELF file generation, which caused elf2tab to identify the wrong flash range for the process binary. To solve this, I moved `start` out of `.text` and merged it into `.crt0_header` to form a new `.start` section. I believe the issue has to do with execute bits on the sections, but it was nontrivial to fix in elf2tab.

The remainder of the changes are a result of additional lints added in the new toolchain version.