### PR TITLE
Add the `libtock_unittest` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,4 +90,5 @@ members = [
     "runtime",
     "test_runner",
     "tools/print_sizes",
+    "unittest",
 ]

--- a/unittest/Cargo.toml
+++ b/unittest/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+description = """libtock-rs unit test support. Provides a fake Tock kernel as \
+                 well as the test_component! macro."""
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+name = "libtock_unittest"
+repository = "https://www.github.com/tock/libtock-rs"
+version = "0.1.0"
+
+[dependencies]
+libtock_platform = { path = "../platform" }

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -1,0 +1,27 @@
+/// Unit tests can use `ExpectedSyscall` to alter `fake::Kernel`'s behavior for
+/// a particular system call. An example use case is error injection: unit tests
+/// can add a `ExpectedSyscall` to the fake kernel's queue to insert errors in
+/// order to test error handling code.
+#[derive(Debug)]
+pub enum ExpectedSyscall {
+    // TODO: Add Yield.
+// TODO: Add Subscribe.
+// TODO: Add Command.
+// TODO: Add Allow.
+// TODO: Add Memop.
+// TODO: Add Exit.
+}
+
+impl ExpectedSyscall {
+    // Panics with a message describing that the named system call was called
+    // instead of the expected system call. Used by fake::Kernel to report
+    // incorrect system calls.
+    #[allow(unused)] // TODO: Remove when a system call is implemented.
+    pub(crate) fn panic_wrong_call(&self, called: &str) -> ! {
+        // TODO: Implement Display for ExpectedSyscall and replace {:?} with {}
+        panic!(
+            "Expected system call {:?}, but {} was called instead.",
+            self, called
+        );
+    }
+}

--- a/unittest/src/kernel/mod.rs
+++ b/unittest/src/kernel/mod.rs
@@ -1,0 +1,137 @@
+use crate::{ExpectedSyscall, SyscallLogEntry};
+use std::cell::Cell;
+
+// TODO: Add Allow.
+// TODO: Add Command.
+// TODO: Add Exit.
+// TODO: Add Memop.
+// TODO: Add Subscribe.
+mod raw_syscalls_impl;
+mod thread_local;
+// TODO: Add Yield.
+
+/// A fake implementation of the Tock kernel. Provides
+/// `libtock_platform::Syscalls` by implementing
+/// `libtock_platform::RawSyscalls`. Allows `fake::Driver`s to be attached, and
+/// routes system calls to the correct fake driver.
+///
+/// Note that there can only be one `Kernel` instance per thread, as a
+/// thread-local variable is used to implement `libtock_platform::RawSyscalls`.
+/// As such, test code is given a `Rc<Kernel>` rather than a `Kernel` instance
+/// directly. Because `Rc` is a shared reference, Kernel extensively uses
+/// internal mutability.
+// TODO: Define the `fake::Driver` trait and add support for fake drivers in
+// Kernel.
+pub struct Kernel {
+    expected_syscalls: Cell<std::collections::VecDeque<ExpectedSyscall>>,
+    name: &'static str,
+    syscall_log: Cell<Vec<SyscallLogEntry>>,
+}
+
+impl Kernel {
+    /// Creates a `Kernel` for this thread and returns a reference to it. This
+    /// instance should be dropped at the end of the test, before this thread
+    /// creates another `Kernel`. `name` should be a string identifying the test
+    /// case, and is used to provide better diagnostics.
+    pub fn new(name: &'static str) -> std::rc::Rc<Kernel> {
+        let rc = std::rc::Rc::new(Kernel {
+            expected_syscalls: Default::default(),
+            name,
+            syscall_log: Default::default(),
+        });
+        thread_local::set_kernel(&rc);
+        rc
+    }
+
+    /// Adds an ExpectedSyscall to the expected syscall queue.
+    ///
+    /// # What is the expected syscall queue?
+    ///
+    /// In addition to routing system calls to drivers, `Kernel` supports
+    /// injecting artificial system call responses. The primary use case for
+    /// this feature is to simulate errors without having to implement error
+    /// simulation in each `fake::Driver`.
+    ///
+    /// The expected syscall queue is a FIFO queue containing anticipated
+    /// upcoming system calls. It starts empty, and as long as it is empty, the
+    /// expected syscall functionality does nothing. When the queue is nonempty
+    /// and a system call is made, the system call is compared with the next
+    /// queue entry. If the system call matches, then the action defined by the
+    /// expected syscall is taken. If the call does not match, the call panics
+    /// (to make the unit test fail).
+    pub fn add_expected_syscall(&self, expected_syscall: ExpectedSyscall) {
+        let mut queue = self.expected_syscalls.take();
+        queue.push_back(expected_syscall);
+        self.expected_syscalls.set(queue);
+    }
+
+    /// Returns the system call log and empties it.
+    pub fn take_syscall_log(&self) -> Vec<SyscallLogEntry> {
+        self.syscall_log.take()
+    }
+}
+
+impl Drop for Kernel {
+    fn drop(&mut self) {
+        thread_local::clear_kernel();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Crate implementation details below.
+// -----------------------------------------------------------------------------
+
+impl Kernel {
+    // Appends a log entry to the system call queue.
+    #[allow(unused)] // TODO: Remove when a system call is implemented.
+    fn log_syscall(&self, syscall: SyscallLogEntry) {
+        let mut log = self.syscall_log.take();
+        log.push(syscall);
+        self.syscall_log.set(log);
+    }
+
+    // Retrieves the first syscall in the expected syscalls queue, removing it
+    // from the queue. Returns None if the queue was empty.
+    #[allow(unused)] // TODO: Remove when a system call is implemented.
+    fn pop_expected_syscall(&self) -> Option<ExpectedSyscall> {
+        let mut queue = self.expected_syscalls.take();
+        let expected_syscall = queue.pop_front();
+        self.expected_syscalls.set(queue);
+        expected_syscall
+    }
+
+    // Panics, indicating that this Kernel was leaked. It is unlikely that this
+    // panic will cause the correct test case to fail, but if this Kernel is
+    // well-named the panic message should indicate where the leak occurred.
+    fn report_leaked(&self) -> ! {
+        panic!(
+            "The fake::Kernel with name '{}' was never cleaned up; \
+                perhaps a Rc<Kernel> was leaked?",
+            self.name
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Verifies the name propagates correctly into the report_leaked() error
+    // message.
+    #[test]
+    fn name_to_report_leaked() {
+        let result = std::panic::catch_unwind(|| {
+            Kernel::new("name_to_report_leaked").report_leaked();
+        });
+        let panic_arg = result.expect_err("Kernel::report_leaked did not panic");
+        let message = panic_arg
+            .downcast_ref::<String>()
+            .expect("Wrong panic payload type");
+        assert!(message.contains("name_to_report_leaked"));
+    }
+
+    // TODO: We cannot currently test the expected syscall queue or the syscall
+    // log, because ExpectedSyscall and SyscallLogEntry are currently
+    // uninhabited types. When we implement a system call, we should add tests
+    // for that functionality as well.
+}

--- a/unittest/src/kernel/raw_syscalls_impl.rs
+++ b/unittest/src/kernel/raw_syscalls_impl.rs
@@ -1,0 +1,53 @@
+mod class_id {
+    pub const SUBSCRIBE: usize = 1;
+    pub const COMMAND: usize = 2;
+    pub const RW_ALLOW: usize = 3;
+    pub const RO_ALLOW: usize = 4;
+    pub const MEMOP: usize = 5;
+    pub const EXIT: usize = 6;
+}
+
+unsafe impl libtock_platform::RawSyscalls for super::Kernel {
+    unsafe fn yield1([_r0]: [*mut (); 1]) {
+        // TODO: Add Yield.
+    }
+
+    unsafe fn yield2([_r0, _r1]: [*mut (); 2]) {
+        // TODO: Add Yield.
+    }
+
+    unsafe fn syscall1<const CLASS: usize>([_r0]: [*mut (); 1]) -> [*mut (); 2] {
+        match CLASS {
+            class_id::MEMOP => unimplemented!("TODO: Add Memop"),
+            _ => panic!("Unknown syscall1 call. Class: {}", CLASS),
+        }
+    }
+
+    unsafe fn syscall2<const CLASS: usize>([_r0, _r1]: [*mut (); 2]) -> [*mut (); 2] {
+        match CLASS {
+            class_id::MEMOP => unimplemented!("TODO: Add Memop"),
+            class_id::EXIT => unimplemented!("TODO: Add Exit"),
+            _ => panic!("Unknown syscall2 call. Class: {}", CLASS),
+        }
+    }
+
+    unsafe fn syscall4<const CLASS: usize>([_r0, _r1, _r2, _r3]: [*mut (); 4]) -> [*mut (); 4] {
+        match CLASS {
+            class_id::SUBSCRIBE => unimplemented!("TODO: Add Subscribe"),
+            class_id::COMMAND => unimplemented!("TODO: Add Command"),
+            class_id::RW_ALLOW => unimplemented!("TODO: Add Allow"),
+            class_id::RO_ALLOW => unimplemented!("TODO: Add Allow"),
+            _ => panic!("Unknown syscall4 call. Class: {}", CLASS),
+        }
+    }
+}
+
+// Miri does not always check that values are valid (see `doc/MiriTips.md` in
+// the root of this repository). This function uses a hack to verify a value is
+// valid. If the value is invalid, Miri will detect undefined behavior when it
+// executes this.
+#[allow(unused)] // TODO: Remove when a system call is implemented.
+pub(crate) fn assert_valid<T: core::fmt::Debug>(_value: T) {
+    #[cfg(miri)]
+    format!("{:?}", _value);
+}

--- a/unittest/src/kernel/thread_local.rs
+++ b/unittest/src/kernel/thread_local.rs
@@ -1,0 +1,140 @@
+// The thread_local module contains a reference to this thread's Kernel instance
+// (if one exists). It provides functionality to create and manage this
+// instance, as well as some instrumentation to help identify when tests leak a
+// Rc<Kernel>.
+
+use crate::fake::Kernel;
+use std::rc::{Rc, Weak};
+
+// Clears this thread's Kernel instance. This allows the Kernel to be
+// deallocated, and should be called by Kernel's Drop implementation.
+pub fn clear_kernel() {
+    THREAD_KERNEL.with(|thread_kernel| thread_kernel.kernel.replace(Weak::new()));
+}
+
+// Retrieves this thread's Kernel instance, if one is available.
+#[allow(unused)] // TODO: Remove when a system call is implemented.
+pub fn get_kernel() -> Option<Rc<Kernel>> {
+    let clone = THREAD_KERNEL.with(|thread_kernel| {
+        let weak = thread_kernel.kernel.replace(Weak::new());
+        let clone = weak.clone();
+        thread_kernel.kernel.replace(weak);
+        clone
+    });
+    clone.upgrade()
+}
+
+// Sets this thread's Kernel instance. If this thread already has a Kernel
+// instance, this panics with a message indicating the name of the existing
+// Kernel instance, as it was presumably leaked.
+pub fn set_kernel(kernel: &Rc<Kernel>) {
+    THREAD_KERNEL.with(|thread_kernel| {
+        let existing_weak = thread_kernel.kernel.replace(Rc::downgrade(kernel));
+        if let Some(existing_kernel) = existing_weak.upgrade() {
+            existing_kernel.report_leaked();
+        }
+    });
+}
+
+// Reference to this thread's Kernel instance, if one has been initialized. This
+// is a weak reference so that when a unit test is done with its Kernel, the
+// following cleanup can happen:
+//   1. The test drops its Rc<Kernel> instances.
+//   2. The strong count drops to 0 so the Kernel is dropped.
+//   3. Kernel's Drop implementation clears out THREAD_KERNEL, removing the weak
+//      reference.
+//   4. The backing storage holding the Kernel is deallocated.
+thread_local!(static THREAD_KERNEL: ThreadKernelRef = ThreadKernelRef::new());
+
+// Type that wraps a Weak<Kernel> pointing to this thread's Kernel. This
+// wrapper's Drop implementation verifies the Kernel has been cleaned up, in
+// order to help identify leaked Kernels. Note that ThreadKernelRef's Drop is
+// not *guaranteed* to run; see std::thread::LocalKey's documentation for more
+// details.
+struct ThreadKernelRef {
+    kernel: std::cell::Cell<Weak<Kernel>>,
+}
+
+impl ThreadKernelRef {
+    pub fn new() -> ThreadKernelRef {
+        // Note that Weak::new() does not allocate, while Default::default()
+        // does.
+        ThreadKernelRef {
+            kernel: std::cell::Cell::new(Weak::new()),
+        }
+    }
+}
+
+impl Drop for ThreadKernelRef {
+    fn drop(&mut self) {
+        if let Some(leaked_kernel) = self.kernel.replace(Weak::new()).upgrade() {
+            leaked_kernel.report_leaked();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests a sequence of clear_kernel, get_kernel, and set_kernel calls
+    // representing a fairly typical unit test (with a few extra get_kernel()
+    // invocations for extra verification).
+    #[test]
+    fn normal_test() {
+        assert!(get_kernel().is_none());
+        let rc_kernel = Kernel::new("normal_test");
+        assert!(Rc::ptr_eq(
+            &get_kernel().expect("get_kernel returned None"),
+            &rc_kernel
+        ));
+        clear_kernel();
+        assert!(get_kernel().is_none());
+    }
+
+    // Tests a sequence of calls that looks like a leak; specifically, create a
+    // second kernel before the first kernel is cleared.
+    #[test]
+    fn duplicate_kernel() {
+        assert!(get_kernel().is_none());
+        let rc_kernel_1 = Kernel::new("duplicate_kernel_1");
+        assert!(Rc::ptr_eq(
+            &get_kernel().expect("get_kernel returned None"),
+            &rc_kernel_1
+        ));
+        let result = std::panic::catch_unwind(|| {
+            Kernel::new("duplicate_kernel_2");
+        });
+        let panic_arg = result.expect_err("Setting a duplicate kernel did not panic");
+        let message = panic_arg
+            .downcast_ref::<String>()
+            .expect("Wrong panic payload type");
+        // Verify the panic message mentions the correct kernel.
+        assert!(message.contains("duplicate_kernel_1"));
+    }
+
+    // Verifies that ThreadKernelRef's Drop implementations detects a leaked
+    // Kernel at thread exit. We unfortunately cannot test this by spawning a
+    // thread and leaking a Kernel, because panicing from TLS destructors fails:
+    // https://github.com/rust-lang/rust/issues/24479
+    #[test]
+    fn thread_drop_leak() {
+        let result = std::panic::catch_unwind(|| {
+            let thread_ref = ThreadKernelRef::new();
+            // Create a kernel, loading it into THREAD_KERNEL, then use
+            // Cell::replace() to move the kernel reference into thread_ref.
+            let _rc_kernel = Kernel::new("thread_drop_leak");
+            thread_ref
+                .kernel
+                .replace(THREAD_KERNEL.with(|tk| tk.kernel.replace(Weak::new())));
+            // Drop the ThreadKernelRef, simulating a thread exit.
+            drop(thread_ref);
+        });
+        let panic_arg = result.expect_err("Leaking a thread's kernel did not panic");
+        let message = panic_arg
+            .downcast_ref::<String>()
+            .expect("Wrong panic payload type");
+        // Verify the panic message mentions the correct kernel.
+        assert!(message.contains("thread_drop_leak"));
+    }
+}

--- a/unittest/src/lib.rs
+++ b/unittest/src/lib.rs
@@ -1,0 +1,25 @@
+//! `libtock_unittest` provides testing tools needed by `libtock-rs`'s own unit
+//! tests as well as unit tests of code that uses `libtock-rs`.
+
+#![deny(unsafe_op_in_unsafe_fn)]
+
+mod expected_syscall;
+mod kernel;
+mod syscall_log;
+
+/// `fake` contains fake implementations of Tock kernel components. Fake
+/// components emulate the behavior of the real Tock kernel components, but in
+/// the unit test environment. They generally have additional testing features,
+/// such as error injection functionality.
+///
+/// These components are exposed under the `fake` module because otherwise their
+/// names would collide with the corresponding drivers (e.g. the fake Console
+/// would collide with the Console driver in unit tests). Tests should generally
+/// `use libtock_unittest::fake` and refer to the type with the `fake::` prefix
+/// (e.g. `fake::Console`).
+pub mod fake {
+    pub use crate::kernel::Kernel;
+}
+
+pub use expected_syscall::ExpectedSyscall;
+pub use syscall_log::SyscallLogEntry;

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -1,0 +1,10 @@
+/// SyscallLogEntry represents a system call made during test execution.
+#[derive(Debug, PartialEq)]
+pub enum SyscallLogEntry {
+    // TODO: Add Yield.
+// TODO: Add Subscribe.
+// TODO: Add Command.
+// TODO: Add Allow.
+// TODO: Add Memop.
+// TODO: Add Exit.
+}


### PR DESCRIPTION
`libtock_unittest` is needed in order to unit test `libtock-rs` code that makes system calls. This change contains a small fraction of the library, and intended to be followed up with several more changes that add system call implementations.

I made careful use of `// TODO` comments and `#[allow(unused)]` declarations so that I can send several system call implementations for review in parallel without causing massive merge conflicts.