### PR TITLE
Add ARM support to `libtock_runtime`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ EXCLUDE_RUNTIME := --exclude libtock_runtime
 
 .PHONY: test
 test: examples test-qemu-hifive
+	# TODO: Remove the libtock_runtime build when we have a code example for the
+	# 2.0 crates.
+	LIBTOCK_PLATFORM=nrf52 cargo build --release --target=thumbv7em-none-eabi -p libtock_runtime
 	LIBTOCK_PLATFORM=nrf52 PLATFORM=nrf52 cargo fmt --all -- --check
 	PLATFORM=nrf52 cargo clippy --all-targets --exclude libtock_runtime --workspace
 	LIBTOCK_PLATFORM=hifive1 cargo clippy --target=riscv32imac-unknown-none-elf -p libtock_runtime

--- a/runtime/asm/asm_arm.S
+++ b/runtime/asm/asm_arm.S
@@ -1,0 +1,88 @@
+/* rt_header is defined by the general linker script (libtock_layout.ld). It has
+ * the following layout:
+ *
+ *     Field                       | Offset
+ *     ------------------------------------
+ *     Address of the start symbol |      0
+ *     Initial process break       |      4
+ *     Top of the stack            |      8
+ *     Size of .data               |     12
+ *     Start of .data in flash     |     16
+ *     Start of .data in ram       |     20
+ *     Size of .bss                |     24
+ *     Start of .bss in ram        |     28
+ */
+
+/* start is the entry point -- the first code executed by the kernel. The kernel
+ * passes arguments through 4 registers:
+ *
+ *     r0  Pointer to beginning of the process binary's code. The linker script
+ *         locates rt_header at this address.
+ *
+ *     r1  Address of the beginning of the process's usable memory region.
+ *     r2  Size of the process' allocated memory region (including grant region)
+ *     r3  Process break provided by the kernel.
+ *
+ * We currently only use the value in r0. It is copied into r5 early on because
+ * r0 is needed to invoke system calls.
+ */
+.section .start, "ax"
+.global start
+.thumb_func
+start:
+	/* First, verify the process binary was loaded at the correct address. The
+	 * check is performed by comparing the program counter at the start to the
+	 * address of `start`, which is stored in rt_header. */
+	mov r4, pc        /* r4 = address of .start + 4 (Thumb bit unset) */
+	mov r5, r0        /* Save rt_header; we use r0 for syscalls */
+	ldr r0, [r5, #0]  /* r0 = rt_header.start */
+	add r0, #3        /* r0 = rt_header.start + 4 - 1 (for Thumb bit) */
+	cmp r0, r4
+	beq .Lset_brk     /* Skip error handling if pc correct */
+	/* If the beq on the previous line did not jump, then the binary is not at
+	 * the correct location. Report the error via LowLevelDebug then exit. */
+	mov r0, #8  /* LowLevelDebug driver number */
+	mov r1, #1  /* Command: print alert code */
+	mov r2, #2  /* Alert code 2 (incorrect location */
+	svc 2       /* Execute `command` */
+	mov r0, #0  /* Operation: exit-terminate */
+	svc 6       /* Execute `exit` */
+
+.Lset_brk:
+	/* memop(): set brk to rt_header's initial break value */
+	mov r0, #0        /* operation: set break */
+	ldr r1, [r5, #4]  /* rt_header`s initial process break */
+	svc 5             /* call `memop` */
+
+	/* Set the stack pointer */
+	ldr r0, [r5, #8]  /* r0 = rt_header._stack_top */
+	mov sp, r0
+
+	/* Copy .data into place */
+	ldr r0, [r5, #12]          /* remaining = rt_header.data_size */
+	cbz r0, .Lzero_bss         /* Jump to zero_bss if remaining == 0 */
+	ldr r1, [r5, #16]          /* src = rt_header.data_flash_start */
+	ldr r2, [r5, #20]          /* dest = rt_header.data_ram_start */
+.Ldata_loop_body:
+	ldr r3, [r1]               /* r3 = *src */
+	str r3, [r2]               /* *(dest) = r3 */
+	sub r0, #4                 /* remaining -= 4 */
+	add r1, #4                 /* src += 4 */
+	add r2, #4                 /* dest += 4 */
+	cmp r0, #0
+	bne .Ldata_loop_body       /* Iterate again if remaining != 0 */
+
+.Lzero_bss:
+	ldr r0, [r5, #24]          /* remaining = rt_header.bss_size */
+	cbz r0, .Lcall_rust_start  /* Jump to call_rust_start if remaining == 0 */
+	ldr r1, [r5, #28]          /* dest = rt_header.bss_start */
+	mov r2, #0                 /* r2 = 0 */
+.Lbss_loop_body:
+	strb r2, [r1]              /* *(dest) = r2 = 0 */
+	sub r0, #1                 /* remaining -= 1 */
+	add r1, #1                 /* dest += 1 */
+	cmp r0, #0
+	bne .Lbss_loop_body        /* Iterate again if remaining != 0 */
+
+.Lcall_rust_start:
+	bl rust_start

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -27,5 +27,7 @@ mod startup;
 /// TockSyscalls implements `libtock_platform::Syscalls`.
 pub struct TockSyscalls;
 
+#[cfg(target_arch = "arm")]
+mod syscalls_impl_arm;
 #[cfg(target_arch = "riscv32")]
 mod syscalls_impl_riscv;

--- a/runtime/src/syscalls_impl_arm.rs
+++ b/runtime/src/syscalls_impl_arm.rs
@@ -1,0 +1,92 @@
+use libtock_platform::RawSyscalls;
+
+unsafe impl RawSyscalls for crate::TockSyscalls {
+    unsafe fn yield1([r0]: [*mut (); 1]) {
+        // Safety: This matches the invariants required by the documentation on
+        // RawSyscalls::yield1
+        unsafe {
+            asm!("svc 0",
+                 inlateout("r0") r0 => _, // a1
+                 lateout("r1") _,         // a2
+                 lateout("r2") _,         // a3
+                 lateout("r3") _,         // a4
+                 // r4-r8 are callee-saved.
+                 // r9 is platform-specific. We don't use it in libtock_runtime,
+                 // so it is either unused or used as a callee-saved register.
+                 // r10 and r11 are callee-saved.
+                 lateout("r12") _, // ip
+                 // r13 is the stack pointer and must be restored by the callee.
+                 lateout("r14") _, // lr
+                 // r15 is the program counter.
+            );
+        }
+    }
+
+    unsafe fn yield2([r0, r1]: [*mut (); 2]) {
+        // Safety: This matches the invariants required by the documentation on
+        // RawSyscalls::yield2
+        unsafe {
+            asm!("svc 0",
+                 inlateout("r0") r0 => _, // a1
+                 inlateout("r1") r1 => _, // a2
+                 lateout("r2") _,         // a3
+                 lateout("r3") _,         // a4
+                 // r4-r8 are callee-saved.
+                 // r9 is platform-specific. We don't use it in libtock_runtime,
+                 // so it is either unused or used as a callee-saved register.
+                 // r10 and r11 are callee-saved.
+                 lateout("r12") _, // ip
+                 // r13 is the stack pointer and must be restored by the callee.
+                 lateout("r14") _, // lr
+                 // r15 is the program counter.
+            );
+        }
+    }
+
+    unsafe fn syscall1<const CLASS: usize>([mut r0]: [*mut (); 1]) -> [*mut (); 2] {
+        let r1;
+        // Safety: This matches the invariants required by the documentation on
+        // RawSyscalls::syscall1
+        unsafe {
+            asm!("svc {}",
+                 const CLASS,
+                 inlateout("r0") r0,
+                 lateout("r1") r1,
+                 options(preserves_flags, nostack, nomem),
+            );
+        }
+        [r0, r1]
+    }
+
+    unsafe fn syscall2<const CLASS: usize>([mut r0, mut r1]: [*mut (); 2]) -> [*mut (); 2] {
+        // Safety: This matches the invariants required by the documentation on
+        // RawSyscalls::syscall2
+        unsafe {
+            asm!("svc {}",
+                 const CLASS,
+                 inlateout("r0") r0,
+                 inlateout("r1") r1,
+                 options(preserves_flags, nostack, nomem)
+            );
+        }
+        [r0, r1]
+    }
+
+    unsafe fn syscall4<const CLASS: usize>(
+        [mut r0, mut r1, mut r2, mut r3]: [*mut (); 4],
+    ) -> [*mut (); 4] {
+        // Safety: This matches the invariants required by the documentation on
+        // RawSyscalls::syscall4
+        unsafe {
+            asm!("svc {}",
+                 const CLASS,
+                 inlateout("r0") r0,
+                 inlateout("r1") r1,
+                 inlateout("r2") r2,
+                 inlateout("r3") r3,
+                 options(preserves_flags, nostack),
+            );
+        }
+        [r0, r1, r2, r3]
+    }
+}


### PR DESCRIPTION
This support includes:
1. ARM entry point assembly.
2. Changes to `start_prototype` so it works with the new `RawSyscalls` and on ARM.
3. A new toolchain specification in `extern_asm.rs`. I renamed "target" to "prefix" because on ARM the tool prefix doesn't match the target triple.
4. An ARM implementation of `RawSyscalls` on `TockSyscalls`.