### PR TITLE
Fix build badge to show github actions status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/tock/libtock-rs.svg?branch=master)](https://travis-ci.org/tock/libtock-rs)
+![Build Status](https://github.com/tock/libtock-rs/workflows/ci/badge.svg)
 
 # libtock-rs
 


### PR DESCRIPTION
This PR fixes the build badge to not show an errored build. It never got switched over when we stopped using Travis-CI