### PR TITLE
Replace `RawSyscalls`' use of `*mut ()` with a `Register` alias.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /Cargo.lock
-/platform
 /target

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -5,6 +5,7 @@ mod async_traits;
 mod command_return;
 mod error_code;
 mod raw_syscalls;
+pub mod register;
 pub mod return_variant;
 mod syscalls;
 mod syscalls_impl;

--- a/platform/src/raw_syscalls.rs
+++ b/platform/src/raw_syscalls.rs
@@ -1,6 +1,8 @@
 // TODO: Implement `libtock_unittest`, which is referenced in the comment on
 // `RawSyscalls`.
 
+use crate::register::Register;
+
 /// `RawSyscalls` allows a fake Tock kernel to be injected into components for
 /// unit testing. It is implemented by `libtock_runtime::TockSyscalls` and
 /// `libtock_unittest::fake::Kernel`. **Components should not use `RawSyscalls`
@@ -19,15 +21,9 @@
 // Theoretically, RawSyscalls could consist of a single raw system call. To
 // start, something like this should work:
 //
-//   unsafe fn syscall<const CLASS: usize>([usize; 4]) -> [usize; 4];
+//   unsafe fn syscall<const CLASS: usize>([Reg; 4]) -> [Reg; 4];
 //
-// However, this will not work with Miri's -Zmiri-track-raw-pointers flag, as it
-// causes pointers passed to the kernel via the Allow system calls to be
-// untagged. In order to work with -Zmiri-track-raw-pointers, we need to pass
-// pointers for the register values. Rust's closest analogue to C's void pointer
-// is *mut () or *const (); we use *mut () because it is shorter:
-//
-//   unsafe fn syscall<const CLASS: usize>([*mut (); 4]) -> [*mut (); 4];
+// Note: Reg is an abbreviation of Register.
 //
 // Using a single system call has a major inefficiency. The single raw system
 // call would need to clobber every register that any system call can clobber.
@@ -35,8 +31,8 @@
 // inefficient for the majority of system calls. As a result, we can split yield
 // out into its own function, giving the following API:
 //
-//   unsafe fn yield([*mut (); 4]) -> [*mut (); 4];
-//   unsafe fn syscall<const CLASS: usize>([*mut (); 4]) -> [*mut (); 4];
+//   unsafe fn yield([Reg; 4]) -> [Reg; 4];
+//   unsafe fn syscall<const CLASS: usize>([Reg; 4]) -> [Reg; 4];
 //
 // There is one significant inefficiency remaining. Many system calls, such as
 // memop's "get RAM start address" operation, do not need to set all four
@@ -44,25 +40,25 @@
 // it we need to split the system calls up based on the number of arguments they
 // take:
 //
-//   unsafe fn yield0([*mut (); 0]) -> [*mut (); 4];
-//   unsafe fn yield1([*mut (); 1]) -> [*mut (); 4];
-//   unsafe fn yield2([*mut (); 2]) -> [*mut (); 4];
-//   unsafe fn yield3([*mut (); 3]) -> [*mut (); 4];
-//   unsafe fn yield4([*mut (); 4]) -> [*mut (); 4];
-//   unsafe fn syscall0<const CLASS: usize>([*mut (); 0]) -> [*mut (); 4];
-//   unsafe fn syscall1<const CLASS: usize>([*mut (); 1]) -> [*mut (); 4];
-//   unsafe fn syscall2<const CLASS: usize>([*mut (); 2]) -> [*mut (); 4];
-//   unsafe fn syscall3<const CLASS: usize>([*mut (); 3]) -> [*mut (); 4];
-//   unsafe fn syscall4<const CLASS: usize>([*mut (); 4]) -> [*mut (); 4];
+//   unsafe fn yield0([Reg; 0]) -> [Reg; 4];
+//   unsafe fn yield1([Reg; 1]) -> [Reg; 4];
+//   unsafe fn yield2([Reg; 2]) -> [Reg; 4];
+//   unsafe fn yield3([Reg; 3]) -> [Reg; 4];
+//   unsafe fn yield4([Reg; 4]) -> [Reg; 4];
+//   unsafe fn syscall0<const CLASS: usize>([Reg; 0]) -> [Reg; 4];
+//   unsafe fn syscall1<const CLASS: usize>([Reg; 1]) -> [Reg; 4];
+//   unsafe fn syscall2<const CLASS: usize>([Reg; 2]) -> [Reg; 4];
+//   unsafe fn syscall3<const CLASS: usize>([Reg; 3]) -> [Reg; 4];
+//   unsafe fn syscall4<const CLASS: usize>([Reg; 4]) -> [Reg; 4];
 //
 // However, not all of these are used! If we remove the system calls that are
 // unused, we are left with the following:
 //
-//   unsafe fn yield1([*mut (); 1]) -> [*mut (); 4];
-//   unsafe fn yield2([*mut (); 2]) -> [*mut (); 4];
-//   unsafe fn syscall1<const CLASS: usize>([*mut (); 1]) -> [*mut (); 4];
-//   unsafe fn syscall2<const CLASS: usize>([*mut (); 2]) -> [*mut (); 4];
-//   unsafe fn syscall4<const CLASS: usize>([*mut (); 4]) -> [*mut (); 4];
+//   unsafe fn yield1([Reg; 1]) -> [Reg; 4];
+//   unsafe fn yield2([Reg; 2]) -> [Reg; 4];
+//   unsafe fn syscall1<const CLASS: usize>([Reg; 1]) -> [Reg; 4];
+//   unsafe fn syscall2<const CLASS: usize>([Reg; 2]) -> [Reg; 4];
+//   unsafe fn syscall4<const CLASS: usize>([Reg; 4]) -> [Reg; 4];
 //
 // These system calls are refined further individually, which is documented on
 // a per-function basis.
@@ -86,7 +82,7 @@ pub unsafe trait RawSyscalls {
     /// # Safety
     /// yield1 may only be used for yield operations that do not return a value.
     /// It is exactly as safe as the underlying system call.
-    unsafe fn yield1(_: [*mut (); 1]);
+    unsafe fn yield1(_: [Register; 1]);
 
     // yield2 can only be used to call `yield-no-wait`. `yield-no-wait` does not
     // return any values, so to simplify the assembly we omit return arguments.
@@ -106,7 +102,7 @@ pub unsafe trait RawSyscalls {
     /// # Safety
     /// yield2 may only be used for yield operations that do not return a value.
     /// It has the same safety invariants as the underlying system call.
-    unsafe fn yield2(_: [*mut (); 2]);
+    unsafe fn yield2(_: [Register; 2]);
 
     // syscall1 is only used to invoke Memop operations. Because there are no
     // Memop commands that set r2 or r3, raw_syscall1 only needs to return r0
@@ -135,7 +131,7 @@ pub unsafe trait RawSyscalls {
     /// This directly makes a system call. It can only be used for core kernel
     /// system calls that accept 1 argument and only overwrite r0 and r1 on
     /// return. It is unsafe any time the underlying system call is unsafe.
-    unsafe fn syscall1<const CLASS: usize>(_: [*mut (); 1]) -> [*mut (); 2];
+    unsafe fn syscall1<const CLASS: usize>(_: [Register; 1]) -> [Register; 2];
 
     // syscall2 is used to invoke Exit as well as Memop operations that take an
     // argument. Memop does not currently use more than 2 registers for its
@@ -160,7 +156,7 @@ pub unsafe trait RawSyscalls {
     /// `syscall2` directly makes a system call. It can only be used for core
     /// kernel system calls that accept 2 arguments and only overwrite r0 and r1
     /// on return. It is unsafe any time the underlying system call is unsafe.
-    unsafe fn syscall2<const CLASS: usize>(_: [*mut (); 2]) -> [*mut (); 2];
+    unsafe fn syscall2<const CLASS: usize>(_: [Register; 2]) -> [Register; 2];
 
     // syscall4 should:
     //     1. Call the syscall class specified by CLASS.
@@ -183,5 +179,5 @@ pub unsafe trait RawSyscalls {
     /// `syscall4` must NOT be used to invoke yield. Otherwise, it has the same
     /// safety invariants as the underlying system call, which varies depending
     /// on the system call class.
-    unsafe fn syscall4<const CLASS: usize>(_: [*mut (); 4]) -> [*mut (); 4];
+    unsafe fn syscall4<const CLASS: usize>(_: [Register; 4]) -> [Register; 4];
 }

--- a/platform/src/register.rs
+++ b/platform/src/register.rs
@@ -1,0 +1,62 @@
+/// In order to work with Miri's `-Zmiri-track-raw-pointers` flag, we cannot
+/// pass pointers to the kernel through `usize` values (as casting to and from
+/// `usize` drops the pointer`s tag). Instead, `RawSyscalls`
+/// uses the `Register` type. `Register` is an alias for a raw pointer type that
+/// keeps that tags around. User code should not depend on the particular type
+/// of pointer that `Register` aliases, but instead use the conversion functions
+/// in this module.
+pub type Register = *mut ();
+
+// -----------------------------------------------------------------------------
+// Conversions to Register
+// -----------------------------------------------------------------------------
+
+pub fn from_u32(value: u32) -> Register {
+    value as Register
+}
+
+pub fn from_usize(value: usize) -> Register {
+    value as Register
+}
+
+pub fn from_mut_ptr<T>(value: *mut T) -> Register {
+    value as Register
+}
+
+pub fn from_ptr<T>(value: *const T) -> Register {
+    value as Register
+}
+
+// -----------------------------------------------------------------------------
+// Infallable conversions from Register
+// -----------------------------------------------------------------------------
+
+pub fn as_u32(register: Register) -> u32 {
+    register as u32
+}
+
+pub fn as_usize(register: Register) -> usize {
+    register as usize
+}
+
+pub fn as_mut_ptr<T>(register: Register) -> *mut T {
+    register as *mut T
+}
+
+pub fn as_ptr<T>(register: Register) -> *const T {
+    register as *const T
+}
+
+// -----------------------------------------------------------------------------
+// Fallable conversions from Register
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TooLargeError(());
+
+pub fn try_into_u32(register: Register) -> Result<u32, TooLargeError> {
+    use core::convert::TryInto;
+    (register as usize)
+        .try_into()
+        .map_err(|_| TooLargeError(()))
+}

--- a/platform/src/syscalls_impl.rs
+++ b/platform/src/syscalls_impl.rs
@@ -1,6 +1,6 @@
 //! Implements `Syscalls` for all types that implement `RawSyscalls`.
 
-use crate::{RawSyscalls, Syscalls, YieldNoWaitReturn};
+use crate::{register, RawSyscalls, Syscalls, YieldNoWaitReturn};
 
 mod yield_op {
     pub const NO_WAIT: u32 = 0;
@@ -19,7 +19,10 @@ impl<S: RawSyscalls> Syscalls for S {
             // Flag can be uninitialized here because the kernel promises to
             // only write to it, not read from it. MaybeUninit guarantees that
             // it is safe to write a YieldNoWaitReturn into it.
-            Self::yield2([yield_op::NO_WAIT as *mut (), flag.as_mut_ptr() as *mut ()]);
+            Self::yield2([
+                register::from_u32(yield_op::NO_WAIT),
+                register::from_mut_ptr(flag.as_mut_ptr()),
+            ]);
 
             // yield-no-wait guarantees it sets (initializes) flag before
             // returning.
@@ -32,7 +35,7 @@ impl<S: RawSyscalls> Syscalls for S {
         // requirement. The yield-wait system call cannot trigger undefined
         // behavior on its own in any other way.
         unsafe {
-            Self::yield1([yield_op::WAIT as *mut ()]);
+            Self::yield1([register::from_u32(yield_op::WAIT)]);
         }
     }
 }

--- a/runtime/src/syscalls_impl_riscv.rs
+++ b/runtime/src/syscalls_impl_riscv.rs
@@ -1,10 +1,11 @@
+use libtock_platform::register::Register;
 use libtock_platform::RawSyscalls;
 
 unsafe impl RawSyscalls for crate::TockSyscalls {
     // This yield implementation is currently limited to RISC-V versions without
     // floating-point registers, as it does not mark them clobbered.
     #[cfg(not(any(target_feature = "d", target_feature = "f")))]
-    unsafe fn yield1([r0]: [*mut (); 1]) {
+    unsafe fn yield1([r0]: [Register; 1]) {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::yield1
         unsafe {
@@ -37,7 +38,7 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
     // This yield implementation is currently limited to RISC-V versions without
     // floating-point registers, as it does not mark them clobbered.
     #[cfg(not(any(target_feature = "d", target_feature = "f")))]
-    unsafe fn yield2([r0, r1]: [*mut (); 2]) {
+    unsafe fn yield2([r0, r1]: [Register; 2]) {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::yield2
         unsafe {
@@ -67,7 +68,7 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
         }
     }
 
-    unsafe fn syscall1<const CLASS: usize>([mut r0]: [*mut (); 1]) -> [*mut (); 2] {
+    unsafe fn syscall1<const CLASS: usize>([mut r0]: [Register; 1]) -> [Register; 2] {
         let r1;
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::syscall1
@@ -82,7 +83,7 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
         [r0, r1]
     }
 
-    unsafe fn syscall2<const CLASS: usize>([mut r0, mut r1]: [*mut (); 2]) -> [*mut (); 2] {
+    unsafe fn syscall2<const CLASS: usize>([mut r0, mut r1]: [Register; 2]) -> [Register; 2] {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::syscall2
         unsafe {
@@ -97,8 +98,8 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
     }
 
     unsafe fn syscall4<const CLASS: usize>(
-        [mut r0, mut r1, mut r2, mut r3]: [*mut (); 4],
-    ) -> [*mut (); 4] {
+        [mut r0, mut r1, mut r2, mut r3]: [Register; 4],
+    ) -> [Register; 4] {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::syscall4
         unsafe {


### PR DESCRIPTION
This will make it easier to change the register type used in `RawSyscalls` to the future, and makes the conversions easier to understand.

I also removed `/platform` from `.gitignore`, as it was making `git` ignore new files in the platform crate. I didn't notice it, but I think I broke the `platform` file functionality when I moved the platform crate out of `core/`. I'm not sure if there is a need for the `platform` file anymore, though.

There is a second PR that achieves this same goal with a different implementation: #290. We need to select one to merge.