### PR TITLE
Add the `libtock2` crate.

### DIFF
--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -24,5 +24,5 @@ jobs:
       - name: Build and Test
         run: |
           cd "${GITHUB_WORKSPACE}"
-          LIBTOCK_PLATFORM=nrf52 cargo build -p libtock_runtime \
+          LIBTOCK_PLATFORM=nrf52 cargo build -p libtock2 \
             --target=thumbv7em-none-eabi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ exclude = [ "tock" ]
 members = [
     "codegen",
     "core",
+    "libtock2",
     "platform",
     "runtime",
     "test_runner",

--- a/libtock2/Cargo.toml
+++ b/libtock2/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+categories = ["embedded", "no-std", "os"]
+description = """Tock Rust userspace library collection. Provides all the \
+                 tools needed to create a Tock Rust process binary."""
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+name = "libtock2"
+repository = "https://www.github.com/tock/libtock-rs"
+version = "0.1.0"
+
+[dependencies]
+libtock_platform = { path = "../platform" }
+libtock_runtime = { path = "../runtime" }

--- a/libtock2/src/lib.rs
+++ b/libtock2/src/lib.rs
@@ -1,0 +1,5 @@
+#![forbid(unsafe_code)]
+#![no_std]
+
+pub use libtock_platform as platform;
+pub use libtock_runtime as runtime;


### PR DESCRIPTION
`libtock2` is the "one stop shop" for using `libtock-rs`. It is intended to be easy to use and will provide everything needed to create a `libtock-rs` process binary. However, in order to be easy to use, it will not support unit testing, as described in the [Overview](https://github.com/tock/libtock-rs/tree/master/doc/Overview.md) doc.

`make test` contained several commands that tested `libtock_runtime` specifically. I reworked those commands so they test `libtock2` as well. The new structure uses only exclusion lists to select crates, which means they will never miss newly-added crates.