### PR TITLE
Vendor `ufmt` into `libtock-rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,5 +90,6 @@ members = [
     "runtime",
     "test_runner",
     "tools/print_sizes",
+    "ufmt",
     "unittest",
 ]

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ libtock-rs is licensed under either of
 
 at your option.
 
-Submodules have their own licenses.
+Submodules, as well as the code in the `ufmt` directory, have their own licenses.
 
 ### Contribution
 

--- a/ufmt/Cargo.toml
+++ b/ufmt/Cargo.toml
@@ -25,10 +25,3 @@ std = ["ufmt-write/std"]
 [[test]]
 name = "vs-std-write"
 required-features = ["std"]
-
-[workspace]
-members = [
-  "macros",
-  "utils",
-  "write",
-]

--- a/ufmt/Cargo.toml
+++ b/ufmt/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+categories = ["embedded", "no-std"]
+description = "A (6-40x) smaller, (2-9x) faster and panic-free alternative to `core::fmt`"
+documentation = "https://docs.rs/ufmt"
+edition = "2018"
+keywords = ["Debug", "Display", "Write", "format"]
+license = "MIT OR Apache-2.0"
+name = "ufmt"
+readme = "README.md"
+repository = "https://github.com/japaric/ufmt"
+version = "0.1.0"
+
+[dependencies]
+proc-macro-hack = "0.5.11"
+ufmt-macros = { path = "macros", version = "0.1.0" }
+ufmt-write = { path = "write", version = "0.1.0" }
+
+# NOTE do NOT add an `alloc` feature before the alloc crate can be used in
+# no-std BINARIES
+[features]
+# NOTE do NOT turn `std` into a default feature; this is a no-std first crate
+std = ["ufmt-write/std"]
+
+[[test]]
+name = "vs-std-write"
+required-features = ["std"]
+
+[workspace]
+members = [
+  "macros",
+  "utils",
+  "write",
+]

--- a/ufmt/LICENSE-APACHE
+++ b/ufmt/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ufmt/LICENSE-MIT
+++ b/ufmt/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2019 Jorge Aparicio
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/ufmt/README.md
+++ b/ufmt/README.md
@@ -3,7 +3,7 @@
 **This is a fork of the [ufmt](https://github.com/japaric/ufmt) crate.** We are
 currently evaluating whether `libtock-rs` should use `ufmt` for its debug
 formatting functionality. Because `ufmt` has unfixed bugs (and appears to be
-unmaintained), we have forked it here are making bugfixes.
+unmaintained), we have forked it here and are making bugfixes.
 
 This fork is temporary and will be removed when one of the following happens:
 

--- a/ufmt/README.md
+++ b/ufmt/README.md
@@ -1,3 +1,34 @@
+# Tock fork of `ufmt`
+
+**This is a fork of the [ufmt](https://github.com/japaric/ufmt) crate.** We are
+currently evaluating whether `libtock-rs` should use `ufmt` for its debug
+formatting functionality. Because `ufmt` has unfixed bugs (and appears to be
+unmaintained), we have forked it here are making bugfixes.
+
+This fork is temporary and will be removed when one of the following happens:
+
+1. We decide that `ufmt` is the right solution for `libtock-rs`. If this
+   happens, we will work to restore the maintenance of `ufmt`.
+2. We decide that `ufmt` is not the right solution for `libtock-rs`, at which
+   point we will replace it with an alternative.
+
+We did the following to create this fork:
+
+1. `wget 'https://github.com/japaric/ufmt/archive/fe817a3cd5d1a3f4edaf8828193519069f2901ec.zip'`
+1. `unzip fe817a3cd5d1a3f4edaf8828193519069f2901ec.zip`
+1. `mv ufmt-fe817a3cd5d1a3f4edaf8828193519069f2901ec ufmt`
+1. Changed the wording of the License section of `libtock-rs`' `README.md` to
+   mention that `ufmt` has its own license.
+1. cd `ufmt`
+1. Removed CI infrastructure and tools that aren't used now that this is in a
+   subdirectory of `libtock-rs`:
+   `rm -r cg.png ci .github .gitignore nopanic .travis.yml`
+1. Committed, creating commit
+   [5163051a2d7fefbe4c9b1c6ba62b79fa07c324e7](https://github.com/tock/libtock-rs/commit/5163051a2d7fefbe4c9b1c6ba62b79fa07c324e7).
+
+Further changes beyond the commit mentioned above are in separate commits so
+their diffs are readable.
+
 # `μfmt`
 
 > A (6-40x) smaller, (2-9x) faster and panic-free alternative to `core::fmt`

--- a/ufmt/README.md
+++ b/ufmt/README.md
@@ -1,0 +1,116 @@
+# `μfmt`
+
+> A (6-40x) smaller, (2-9x) faster and panic-free alternative to `core::fmt`
+
+![Call graph of formatting structs](cg.png)
+
+Call graph of a program that formats some structs (generated using
+[`cargo-call-stack`]). Source code can be found at the bottom of this file. The
+program was compiled with `-C opt-level=z`.
+
+[`cargo-call-stack`]: https://crates.io/crates/cargo-call-stack
+
+## [API docs](https://docs.rs/ufmt)
+
+## Design goals
+
+From highest priority to lowest priority
+
+- Optimized for binary size and speed (rather than for compilation time)
+
+- No dynamic dispatch in generated code
+
+- No panicking branches in generated code, when optimized
+
+- No recursion where possible
+
+## Features
+
+- `Debug` and `Display`-like traits
+
+- `core::write!`-like macro
+
+- A generic `Formatter<'_, impl uWrite>` instead of a single `core::Formatter`;
+  the `uWrite` trait has an associated error type so each writer can choose its
+  error type. For example, the implementation for `std::String` uses
+  `Infallible` as its error type.
+
+- `core::fmt::Formatter::debug_struct`-like API
+
+- `#[derive(uDebug)]`
+
+- Pretty formatting (`{:#?}`) for `uDebug`
+
+# Minimum Supported Rust Version (MSRV)
+
+This crate is guaranteed to compile on stable Rust 1.34 and up. It *might*
+compile on older versions but that may change in any new patch release.
+
+## License
+
+All source code (including code snippets) is licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  [https://www.apache.org/licenses/LICENSE-2.0][L1])
+
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  [https://opensource.org/licenses/MIT][L2])
+
+[L1]: https://www.apache.org/licenses/LICENSE-2.0
+[L2]: https://opensource.org/licenses/MIT
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+licensed as above, without any additional terms or conditions.
+
+## Appendix
+
+### Formatting structs (snippet)
+
+Full source code in [nopanic/examples/struct.rs](nopanic/examples/struct.rs).
+
+``` rust
+// ..
+
+#[derive(Clone, Copy, uDebug)]
+struct Pair {
+    x: i32,
+    y: i32,
+}
+
+static X: AtomicI32 = AtomicI32::new(0);
+static Y: AtomicI32 = AtomicI32::new(0);
+
+#[exception]
+fn PendSV() {
+    let x = X.load(Ordering::Relaxed);
+    let y = Y.load(Ordering::Relaxed);
+
+    uwrite!(&mut W, "{:?}", Braces {}).unwrap();
+    uwrite!(&mut W, "{:#?}", Braces {}).unwrap();
+
+    uwrite!(&mut W, "{:?}", Parens()).unwrap();
+    uwrite!(&mut W, "{:#?}", Parens()).unwrap();
+
+    uwrite!(&mut W, "{:?}", I32(x)).unwrap();
+    uwrite!(&mut W, "{:#?}", I32(x)).unwrap();
+
+    uwrite!(&mut W, "{:?}", Tuple(x, y)).unwrap();
+    uwrite!(&mut W, "{:#?}", Tuple(x, y)).unwrap();
+
+    let pair = Pair { x, y };
+    uwrite!(&mut W, "{:?}", pair).unwrap();
+    uwrite!(&mut W, "{:#?}", pair).unwrap();
+
+    let first = pair;
+    let second = pair;
+    uwrite!(&mut W, "{:?}", Nested { first, second }).unwrap();
+    uwrite!(&mut W, "{:#?}", Nested { first, second }).unwrap();
+}
+
+// ..
+```

--- a/ufmt/macros/Cargo.toml
+++ b/ufmt/macros/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+categories = ["embedded", "no-std"]
+description = "`μfmt` macros"
+edition = "2018"
+keywords = ["Debug", "Display", "Write", "format"]
+license = "MIT OR Apache-2.0"
+name = "ufmt-macros"
+repository = "https://github.com/japaric/ufmt"
+version = "0.1.1"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro-hack = "0.5.11"
+proc-macro2 = "1"
+quote = "1"
+
+[dependencies.syn]
+features = ["full"]
+version = "1"

--- a/ufmt/macros/src/lib.rs
+++ b/ufmt/macros/src/lib.rs
@@ -1,5 +1,8 @@
 //! `μfmt` macros
 
+// Added when we vendored ufmt into libtock-rs to avoid needing to immediately
+// make many changes.
+#![allow(clippy::all)]
 #![deny(warnings)]
 
 extern crate proc_macro;

--- a/ufmt/macros/src/lib.rs
+++ b/ufmt/macros/src/lib.rs
@@ -1,0 +1,493 @@
+//! `μfmt` macros
+
+#![deny(warnings)]
+
+extern crate proc_macro;
+
+use core::mem;
+use proc_macro::TokenStream;
+use std::borrow::Cow;
+
+use proc_macro2::{Literal, Span};
+use proc_macro_hack::proc_macro_hack;
+use quote::quote;
+use syn::{
+    parse::{self, Parse, ParseStream},
+    parse_macro_input, parse_quote,
+    punctuated::Punctuated,
+    spanned::Spanned,
+    Data, DeriveInput, Expr, Fields, GenericParam, Ident, LitStr, Token,
+};
+
+/// Automatically derive the `uDebug` trait for a `struct` or `enum`
+///
+/// Supported items
+///
+/// - all kind of `struct`-s
+/// - all kind of `enum`-s
+///
+/// `union`-s are not supported
+#[proc_macro_derive(uDebug)]
+pub fn debug(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let mut generics = input.generics;
+
+    for param in &mut generics.params {
+        if let GenericParam::Type(type_param) = param {
+            type_param.bounds.push(parse_quote!(ufmt::uDebug));
+        }
+    }
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let ident = &input.ident;
+    let ts = match input.data {
+        Data::Struct(data) => {
+            let ident_s = ident.to_string();
+
+            let body = match data.fields {
+                Fields::Named(fields) => {
+                    let fields = fields
+                        .named
+                        .iter()
+                        .map(|field| {
+                            let ident = field.ident.as_ref().expect("UNREACHABLE");
+                            let name = ident.to_string();
+
+                            quote!(field(#name, &self.#ident)?)
+                        })
+                        .collect::<Vec<_>>();
+
+                    quote!(f.debug_struct(#ident_s)?#(.#fields)*.finish())
+                }
+
+                Fields::Unnamed(fields) => {
+                    let fields = (0..fields.unnamed.len())
+                        .map(|i| {
+                            let i = Literal::u64_unsuffixed(i as u64);
+
+                            quote!(field(&self.#i)?)
+                        })
+                        .collect::<Vec<_>>();
+
+                    quote!(f.debug_tuple(#ident_s)?#(.#fields)*.finish())
+                }
+
+                Fields::Unit => quote!(f.write_str(#ident_s)),
+            };
+
+            quote!(
+                impl #impl_generics ufmt::uDebug for #ident #ty_generics #where_clause {
+                    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
+                    where
+                        W: ufmt::uWrite + ?Sized,
+                    {
+                        #body
+                    }
+                }
+
+            )
+        }
+
+        Data::Enum(data) => {
+            let arms = data
+                .variants
+                .iter()
+                .map(|var| {
+                    let variant = &var.ident;
+                    let variant_s = variant.to_string();
+
+                    match &var.fields {
+                        Fields::Named(fields) => {
+                            let mut pats = Vec::with_capacity(fields.named.len());
+                            let mut methods = Vec::with_capacity(fields.named.len());
+                            for field in &fields.named {
+                                let ident = field.ident.as_ref().unwrap();
+                                let ident_s = ident.to_string();
+
+                                pats.push(quote!(#ident));
+                                methods.push(quote!(field(#ident_s, #ident)?));
+                            }
+
+                            quote!(
+                                #ident::#variant { #(#pats),* } => {
+                                    f.debug_struct(#variant_s)?#(.#methods)*.finish()
+                                }
+                            )
+                        }
+
+                        Fields::Unnamed(fields) => {
+                            let pats = &(0..fields.unnamed.len())
+                                .map(|i| Ident::new(&format!("_{}", i), Span::call_site()))
+                                .collect::<Vec<_>>();
+
+                            quote!(
+                                #ident::#variant(#(#pats),*) => {
+                                    f.debug_tuple(#variant_s)?#(.field(#pats)?)*.finish()
+                                }
+                            )
+                        }
+
+                        Fields::Unit => quote!(
+                            #ident::#variant => {
+                                f.write_str(#variant_s)
+                            }
+                        ),
+                    }
+                })
+                .collect::<Vec<_>>();
+
+            quote!(
+                impl #impl_generics ufmt::uDebug for #ident #ty_generics #where_clause {
+                    fn fmt<W>(&self, f: &mut ufmt::Formatter<'_, W>) -> core::result::Result<(), W::Error>
+                        where
+                        W: ufmt::uWrite + ?Sized,
+                    {
+                        match self {
+                            #(#arms),*
+                        }
+                    }
+                }
+            )
+        }
+
+        Data::Union(..) => {
+            return parse::Error::new(Span::call_site(), "this trait cannot be derived for unions")
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    ts.into()
+}
+
+#[proc_macro_hack]
+pub fn uwrite(input: TokenStream) -> TokenStream {
+    write(input, false)
+}
+
+#[proc_macro_hack]
+pub fn uwriteln(input: TokenStream) -> TokenStream {
+    write(input, true)
+}
+
+fn write(input: TokenStream, newline: bool) -> TokenStream {
+    let input = parse_macro_input!(input as Input);
+
+    let formatter = &input.formatter;
+    let literal = input.literal;
+
+    let mut format = literal.value();
+    if newline {
+        format.push('\n');
+    }
+    let pieces = match parse(&format, literal.span()) {
+        Err(e) => return e.to_compile_error().into(),
+        Ok(pieces) => pieces,
+    };
+
+    let required_args = pieces.iter().filter(|piece| !piece.is_str()).count();
+    let supplied_args = input.args.len();
+    if supplied_args < required_args {
+        return parse::Error::new(
+            literal.span(),
+            &format!(
+                "format string requires {} arguments but {} {} supplied",
+                required_args,
+                supplied_args,
+                if supplied_args == 1 { "was" } else { "were" }
+            ),
+        )
+        .to_compile_error()
+        .into();
+    } else if supplied_args > required_args {
+        return parse::Error::new(
+            input.args[required_args].span(),
+            &format!("argument never used"),
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let mut args = vec![];
+    let mut pats = vec![];
+    let mut exprs = vec![];
+    let mut i = 0;
+    for piece in pieces {
+        if let Piece::Str(s) = piece {
+            exprs.push(quote!(f.write_str(#s)?;))
+        } else {
+            let pat = mk_ident(i);
+            let arg = &input.args[i];
+            i += 1;
+
+            args.push(quote!(&(#arg)));
+            pats.push(quote!(#pat));
+
+            match piece {
+                Piece::Display => {
+                    exprs.push(quote!(ufmt::uDisplay::fmt(#pat, f)?;));
+                }
+
+                Piece::Debug { pretty } => {
+                    exprs.push(if pretty {
+                        quote!(f.pretty(|f| ufmt::uDebug::fmt(#pat, f))?;)
+                    } else {
+                        quote!(ufmt::uDebug::fmt(#pat, f)?;)
+                    });
+                }
+
+                _ => unreachable!(),
+            }
+        }
+    }
+
+    quote!(match (#(#args),*) {
+        (#(#pats),*) => {
+            use ufmt::UnstableDoAsFormatter as _;
+
+            (#formatter).do_as_formatter(|f| {
+                #(#exprs)*
+                Ok(())
+            })
+        }
+    })
+    .into()
+}
+
+struct Input {
+    formatter: Expr,
+    _comma: Token![,],
+    literal: LitStr,
+    _comma2: Option<Token![,]>,
+    args: Punctuated<Expr, Token![,]>,
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream) -> parse::Result<Self> {
+        let formatter = input.parse()?;
+        let _comma = input.parse()?;
+        let literal = input.parse()?;
+
+        if input.is_empty() {
+            Ok(Input {
+                formatter,
+                _comma,
+                literal,
+                _comma2: None,
+                args: Punctuated::new(),
+            })
+        } else {
+            Ok(Input {
+                formatter,
+                _comma,
+                literal,
+                _comma2: input.parse()?,
+                args: Punctuated::parse_terminated(input)?,
+            })
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Piece<'a> {
+    Debug { pretty: bool },
+    Display,
+    Str(Cow<'a, str>),
+}
+
+impl Piece<'_> {
+    fn is_str(&self) -> bool {
+        match self {
+            Piece::Str(_) => true,
+            _ => false,
+        }
+    }
+}
+
+fn mk_ident(i: usize) -> Ident {
+    Ident::new(&format!("__{}", i), Span::call_site())
+}
+
+// `}}` -> `}`
+fn unescape<'l>(mut literal: &'l str, span: Span) -> parse::Result<Cow<'l, str>> {
+    if literal.contains('}') {
+        let mut buf = String::new();
+
+        while literal.contains('}') {
+            const ERR: &str = "format string contains an unmatched right brace";
+            let mut parts = literal.splitn(2, '}');
+
+            match (parts.next(), parts.next()) {
+                (Some(left), Some(right)) => {
+                    const ESCAPED_BRACE: &str = "}";
+
+                    if right.starts_with(ESCAPED_BRACE) {
+                        buf.push_str(left);
+                        buf.push('}');
+
+                        literal = &right[ESCAPED_BRACE.len()..];
+                    } else {
+                        return Err(parse::Error::new(span, ERR));
+                    }
+                }
+
+                _ => unreachable!(),
+            }
+        }
+
+        buf.push_str(literal);
+
+        Ok(buf.into())
+    } else {
+        Ok(Cow::Borrowed(literal))
+    }
+}
+
+fn parse<'l>(mut literal: &'l str, span: Span) -> parse::Result<Vec<Piece<'l>>> {
+    let mut pieces = vec![];
+
+    let mut buf = String::new();
+    loop {
+        let mut parts = literal.splitn(2, '{');
+        match (parts.next(), parts.next()) {
+            // empty string literal
+            (None, None) => break,
+
+            // end of the string literal
+            (Some(s), None) => {
+                if buf.is_empty() {
+                    if !s.is_empty() {
+                        pieces.push(Piece::Str(unescape(s, span)?));
+                    }
+                } else {
+                    buf.push_str(&unescape(s, span)?);
+
+                    pieces.push(Piece::Str(Cow::Owned(buf)));
+                }
+
+                break;
+            }
+
+            (head, Some(tail)) => {
+                const DEBUG: &str = ":?}";
+                const DEBUG_PRETTY: &str = ":#?}";
+                const DISPLAY: &str = "}";
+                const ESCAPED_BRACE: &str = "{";
+
+                let head = head.unwrap_or("");
+                if tail.starts_with(DEBUG)
+                    || tail.starts_with(DEBUG_PRETTY)
+                    || tail.starts_with(DISPLAY)
+                {
+                    if buf.is_empty() {
+                        if !head.is_empty() {
+                            pieces.push(Piece::Str(unescape(head, span)?));
+                        }
+                    } else {
+                        buf.push_str(&unescape(head, span)?);
+
+                        pieces.push(Piece::Str(Cow::Owned(mem::replace(
+                            &mut buf,
+                            String::new(),
+                        ))));
+                    }
+
+                    if tail.starts_with(DEBUG) {
+                        pieces.push(Piece::Debug { pretty: false });
+
+                        literal = &tail[DEBUG.len()..];
+                    } else if tail.starts_with(DEBUG_PRETTY) {
+                        pieces.push(Piece::Debug { pretty: true });
+
+                        literal = &tail[DEBUG_PRETTY.len()..];
+                    } else {
+                        pieces.push(Piece::Display);
+
+                        literal = &tail[DISPLAY.len()..];
+                    }
+                } else if tail.starts_with(ESCAPED_BRACE) {
+                    buf.push_str(&unescape(head, span)?);
+                    buf.push('{');
+
+                    literal = &tail[ESCAPED_BRACE.len()..];
+                } else {
+                    return Err(parse::Error::new(
+                        span,
+                        "invalid format string: expected `{{`, `{}`, `{:?}` or `{:#?}`",
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(pieces)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use proc_macro2::Span;
+
+    use crate::Piece;
+
+    #[test]
+    fn pieces() {
+        let span = Span::call_site();
+
+        // string interpolation
+        assert_eq!(
+            super::parse("The answer is {}", span).ok(),
+            Some(vec![
+                Piece::Str(Cow::Borrowed("The answer is ")),
+                Piece::Display
+            ]),
+        );
+
+        assert_eq!(
+            super::parse("{:?}", span).ok(),
+            Some(vec![Piece::Debug { pretty: false }]),
+        );
+
+        assert_eq!(
+            super::parse("{:#?}", span).ok(),
+            Some(vec![Piece::Debug { pretty: true }]),
+        );
+
+        // escaped braces
+        assert_eq!(
+            super::parse("{{}} is not an argument", span).ok(),
+            Some(vec![Piece::Str(Cow::Borrowed("{} is not an argument"))]),
+        );
+
+        // left brace & junk
+        assert!(super::parse("{", span).is_err());
+        assert!(super::parse(" {", span).is_err());
+        assert!(super::parse("{ ", span).is_err());
+        assert!(super::parse("{ {", span).is_err());
+        assert!(super::parse("{:x}", span).is_err());
+    }
+
+    #[test]
+    fn unescape() {
+        let span = Span::call_site();
+
+        // no right brace
+        assert_eq!(super::unescape("", span).ok(), Some(Cow::Borrowed("")));
+        assert_eq!(
+            super::unescape("Hello", span).ok(),
+            Some(Cow::Borrowed("Hello"))
+        );
+
+        // unmatched right brace
+        assert!(super::unescape(" }", span).is_err());
+        assert!(super::unescape("} ", span).is_err());
+        assert!(super::unescape("}", span).is_err());
+
+        // escaped right brace
+        assert_eq!(super::unescape("}}", span).ok(), Some(Cow::Borrowed("}")));
+        assert_eq!(super::unescape("}} ", span).ok(), Some(Cow::Borrowed("} ")));
+    }
+}

--- a/ufmt/src/helpers.rs
+++ b/ufmt/src/helpers.rs
@@ -1,0 +1,412 @@
+use crate::{uDebug, uWrite, Formatter};
+
+impl<'w, W> Formatter<'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    /// Creates a `DebugList` builder designed to assist with creation of `uDebug` implementations
+    /// for list-like structures.
+    pub fn debug_list(&mut self) -> Result<DebugList<'_, 'w, W>, W::Error> {
+        self.write_str("[")?;
+
+        if self.pretty {
+            self.indentation += 1;
+        }
+
+        Ok(DebugList {
+            first: true,
+            formatter: self,
+        })
+    }
+
+    /// Creates a `DebugMap` builder designed to assist with creation of `uDebug` implementations
+    /// for map-like structures.
+    pub fn debug_map(&mut self) -> Result<DebugMap<'_, 'w, W>, W::Error> {
+        self.write_str("{")?;
+
+        if self.pretty {
+            self.indentation += 1;
+        }
+
+        Ok(DebugMap {
+            first: true,
+            formatter: self,
+        })
+    }
+
+    /// Creates a `DebugSet` builder designed to assist with creation of `uDebug` implementations
+    /// for set-like structures.
+    pub fn debug_set(&mut self) -> Result<DebugSet<'_, 'w, W>, W::Error> {
+        self.write_str("{")?;
+
+        if self.pretty {
+            self.indentation += 1;
+        }
+
+        Ok(DebugSet {
+            first: true,
+            formatter: self,
+        })
+    }
+
+    /// Creates a `DebugStruct` builder designed to assist with creation of `uDebug` implementations
+    /// for structs.
+    pub fn debug_struct(&mut self, name: &str) -> Result<DebugStruct<'_, 'w, W>, W::Error> {
+        self.write_str(name)?;
+
+        if self.pretty {
+            self.indentation += 1;
+        }
+
+        Ok(DebugStruct {
+            first: true,
+            formatter: self,
+        })
+    }
+
+    /// Creates a `DebugTuple` builder designed to assist with creation of `uDebug` implementations
+    /// for tuple structs.
+    pub fn debug_tuple(&mut self, name: &str) -> Result<DebugTuple<'_, 'w, W>, W::Error> {
+        self.write_str(name)?;
+
+        if self.pretty {
+            self.indentation += 1;
+        }
+
+        Ok(DebugTuple {
+            fields: 0,
+            first: true,
+            formatter: self,
+            unnamed: name.is_empty(),
+        })
+    }
+}
+
+/// A struct to help with [`uDebug`] implementations.
+///
+/// This is useful when you wish to output a formatted list of items as a part of your
+/// [`uDebug::fmt`] implementation.
+///
+/// This can be constructed by the [`Formatter::debug_list`] method.
+pub struct DebugList<'f, 'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    first: bool,
+    formatter: &'f mut Formatter<'w, W>,
+}
+
+impl<W> DebugList<'_, '_, W>
+where
+    W: uWrite + ?Sized,
+{
+    /// Adds a new entry to the list output.
+    pub fn entry(&mut self, entry: &impl uDebug) -> Result<&mut Self, W::Error> {
+        if self.first {
+            self.first = false;
+
+            if self.formatter.pretty {
+                self.formatter.write_str("\n")?;
+            }
+        } else if !self.formatter.pretty {
+            self.formatter.write_str(", ")?;
+        }
+
+        if self.formatter.pretty {
+            self.formatter.indent()?;
+        }
+
+        entry.fmt(self.formatter)?;
+
+        if self.formatter.pretty {
+            self.formatter.write_str(",\n")?;
+        }
+
+        Ok(self)
+    }
+
+    /// Adds the contents of an iterator of entries to the list output.
+    pub fn entries(
+        &mut self,
+        entries: impl IntoIterator<Item = impl uDebug>,
+    ) -> Result<&mut Self, W::Error> {
+        for entry in entries {
+            self.entry(&entry)?;
+        }
+
+        Ok(self)
+    }
+
+    /// Finishes output
+    pub fn finish(&mut self) -> Result<(), W::Error> {
+        if self.formatter.pretty {
+            self.formatter.indentation -= 1;
+            self.formatter.indent()?;
+        }
+
+        self.formatter.write_str("]")
+    }
+}
+
+/// A struct to help with [`uDebug`] implementations.
+///
+/// This is useful when you wish to output a formatted map as a part of your [`uDebug::fmt`]
+/// implementation.
+///
+/// This can be constructed by the [`Formatter::debug_map`] method.
+pub struct DebugMap<'f, 'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    first: bool,
+    formatter: &'f mut Formatter<'w, W>,
+}
+
+impl<W> DebugMap<'_, '_, W>
+where
+    W: uWrite + ?Sized,
+{
+    /// Adds a new entry to the map output.
+    pub fn entry(&mut self, key: &impl uDebug, value: &impl uDebug) -> Result<&mut Self, W::Error> {
+        if self.first {
+            self.first = false;
+
+            if self.formatter.pretty {
+                self.formatter.write_str("\n")?;
+            }
+        } else if !self.formatter.pretty {
+            self.formatter.write_str(", ")?;
+        }
+
+        if self.formatter.pretty {
+            self.formatter.indent()?;
+        }
+
+        key.fmt(self.formatter)?;
+        self.formatter.write_str(": ")?;
+        value.fmt(self.formatter)?;
+
+        if self.formatter.pretty {
+            self.formatter.write_str(",\n")?;
+        }
+
+        Ok(self)
+    }
+
+    /// Adds the contents of an iterator of entries to the map output.
+    pub fn entries(
+        &mut self,
+        entries: impl IntoIterator<Item = (impl uDebug, impl uDebug)>,
+    ) -> Result<&mut Self, W::Error> {
+        for (k, v) in entries.into_iter() {
+            self.entry(&k, &v)?;
+        }
+
+        Ok(self)
+    }
+
+    /// Finishes output
+    pub fn finish(&mut self) -> Result<(), W::Error> {
+        self.formatter.write_str("}")
+    }
+}
+
+/// A struct to help with [`uDebug`] implementations.
+///
+/// This is useful when you wish to output a formatted set of items as a part of your
+/// [`uDebug::fmt`] implementation.
+///
+/// This can be constructed by the [`Formatter::debug_set`] method.
+pub struct DebugSet<'f, 'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    first: bool,
+    formatter: &'f mut Formatter<'w, W>,
+}
+
+impl<W> DebugSet<'_, '_, W>
+where
+    W: uWrite + ?Sized,
+{
+    /// Adds a new entry to the set output.
+    pub fn entry(&mut self, entry: &impl uDebug) -> Result<&mut Self, W::Error> {
+        if self.first {
+            self.first = false;
+
+            if self.formatter.pretty {
+                self.formatter.write_str("\n")?;
+            }
+        } else if !self.formatter.pretty {
+            self.formatter.write_str(", ")?;
+        }
+
+        if self.formatter.pretty {
+            self.formatter.indent()?;
+        }
+
+        entry.fmt(self.formatter)?;
+
+        if self.formatter.pretty {
+            self.formatter.write_str(",\n")?;
+        }
+
+        Ok(self)
+    }
+
+    /// Adds the contents of an iterator of entries to the set output.
+    pub fn entries(
+        &mut self,
+        entries: impl IntoIterator<Item = impl uDebug>,
+    ) -> Result<&mut Self, W::Error> {
+        for entry in entries {
+            self.entry(&entry)?;
+        }
+
+        Ok(self)
+    }
+
+    /// Finishes output
+    pub fn finish(&mut self) -> Result<(), W::Error> {
+        self.formatter.write_str("}")
+    }
+}
+
+/// A struct to help with [`uDebug`] implementations.
+///
+/// This is useful when you wish to output a formatted struct as a part of your [`uDebug::fmt`]
+/// implementation.
+///
+/// This can be constructed by the [`Formatter::debug_struct`] method.
+pub struct DebugStruct<'f, 'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    first: bool,
+    formatter: &'f mut Formatter<'w, W>,
+}
+
+impl<W> DebugStruct<'_, '_, W>
+where
+    W: uWrite + ?Sized,
+{
+    /// Adds a new field to the generated struct output.
+    pub fn field(&mut self, name: &str, value: &impl uDebug) -> Result<&mut Self, W::Error> {
+        if self.first {
+            self.first = false;
+
+            self.formatter.write_str(" {")?;
+
+            if self.formatter.pretty {
+                self.formatter.write_str("\n")?;
+            } else {
+                self.formatter.write_str(" ")?;
+            }
+        } else if !self.formatter.pretty {
+            self.formatter.write_str(", ")?;
+        }
+
+        if self.formatter.pretty {
+            self.formatter.indent()?;
+        }
+
+        self.formatter.write_str(name)?;
+        self.formatter.write_str(": ")?;
+        value.fmt(self.formatter)?;
+
+        if self.formatter.pretty {
+            self.formatter.write_str(",\n")?;
+        }
+
+        Ok(self)
+    }
+
+    /// Finishes output
+    pub fn finish(&mut self) -> Result<(), W::Error> {
+        if self.formatter.pretty {
+            self.formatter.indentation -= 1;
+        }
+
+        if !self.first {
+            if self.formatter.pretty {
+                self.formatter.indent()?;
+            } else {
+                self.formatter.write_str(" ")?;
+            }
+
+            self.formatter.write_str("}")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A struct to help with [`uDebug`] implementations.
+///
+/// This is useful when you wish to output a formatted tuple as a part of your [`uDebug::fmt`]
+/// implementation.
+///
+/// This can be constructed by the [`Formatter::debug_tuple`] method.
+pub struct DebugTuple<'f, 'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    fields: u8,
+    first: bool,
+    formatter: &'f mut Formatter<'w, W>,
+    unnamed: bool,
+}
+
+impl<W> DebugTuple<'_, '_, W>
+where
+    W: uWrite + ?Sized,
+{
+    /// Adds a new field to the generated tuple struct output.
+    pub fn field(&mut self, value: &impl uDebug) -> Result<&mut Self, W::Error> {
+        self.fields += 1;
+
+        if self.first {
+            self.first = false;
+
+            self.formatter.write_str("(")?;
+
+            if self.formatter.pretty {
+                self.formatter.write_str("\n")?;
+            }
+        } else if !self.formatter.pretty {
+            self.formatter.write_str(", ")?;
+        }
+
+        if self.formatter.pretty {
+            self.formatter.indent()?;
+        }
+
+        value.fmt(self.formatter)?;
+
+        if self.formatter.pretty {
+            self.formatter.write_str(",\n")?;
+        }
+
+        Ok(self)
+    }
+
+    /// Finishes output
+    pub fn finish(&mut self) -> Result<(), W::Error> {
+        if self.formatter.pretty {
+            self.formatter.indentation -= 1;
+        }
+
+        if !self.first {
+            if self.formatter.pretty {
+                self.formatter.indent()?;
+            } else if self.unnamed && self.fields == 1 {
+                // this is a one-element tuple so we need a trailing comma
+                self.formatter.write_str(",")?;
+            }
+
+            self.formatter.write_str(")")?;
+        }
+
+        Ok(())
+    }
+}

--- a/ufmt/src/impls.rs
+++ b/ufmt/src/impls.rs
@@ -1,0 +1,9 @@
+mod array;
+mod core;
+mod ixx;
+mod nz;
+mod ptr;
+#[cfg(feature = "std")]
+mod std;
+mod tuple;
+mod uxx;

--- a/ufmt/src/impls/array.rs
+++ b/ufmt/src/impls/array.rs
@@ -1,0 +1,24 @@
+use crate::{uDebug, uWrite, Formatter};
+
+macro_rules! array {
+    ($($N:expr),+) => {
+        $(
+            impl<T> uDebug for [T; $N]
+            where
+                T: uDebug,
+            {
+                fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+                    where
+                    W: uWrite + ?Sized,
+                {
+                    <[T] as uDebug>::fmt(self, f)
+                }
+            }
+        )+
+    }
+}
+
+array!(
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+    26, 27, 28, 29, 30, 31, 32
+);

--- a/ufmt/src/impls/core.rs
+++ b/ufmt/src/impls/core.rs
@@ -1,0 +1,186 @@
+use crate::{uDebug, uDisplay, uWrite, Formatter};
+
+impl uDebug for bool {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        if *self {
+            f.write_str("true")
+        } else {
+            f.write_str("false")
+        }
+    }
+}
+
+impl uDisplay for bool {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <bool as uDebug>::fmt(self, f)
+    }
+}
+
+// FIXME this (`escape_debug`) contains a panicking branch
+// impl uDebug for char {
+//     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+//     where
+//         W: uWrite + ?Sized,
+//     {
+//         f.write_str("'")?;
+//         for c in self.escape_debug() {
+//             f.write_char(c)?
+//         }
+//         f.write_str("'")
+//     }
+// }
+
+impl uDisplay for char {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.write_char(*self)
+    }
+}
+
+impl<T> uDebug for [T]
+where
+    T: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.debug_list()?.entries(self)?.finish()
+    }
+}
+
+// FIXME this (`escape_debug`) contains a panicking branch
+// impl uDebug for str {
+//     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+//     where
+//         W: uWrite + ?Sized,
+//     {
+//         f.write_str("\"")?;
+
+//         let mut from = 0;
+//         for (i, c) in self.char_indices() {
+//             let esc = c.escape_debug();
+
+//             // If char needs escaping, flush backlog so far and write, else skip
+//             if esc.len() != 1 {
+//                 f.write_str(
+//                     self.get(from..i)
+//                         .unwrap_or_else(|| unsafe { assume_unreachable!() }),
+//                 )?;
+//                 for c in esc {
+//                     f.write_char(c)?;
+//                 }
+//                 from = i + c.len_utf8();
+//             }
+//         }
+
+//         f.write_str(
+//             self.get(from..)
+//                 .unwrap_or_else(|| unsafe { assume_unreachable!() }),
+//         )?;
+//         f.write_str("\"")
+//     }
+// }
+
+impl uDisplay for str {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.write_str(self)
+    }
+}
+
+impl<T> uDebug for &'_ T
+where
+    T: uDebug + ?Sized,
+{
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <T as uDebug>::fmt(self, f)
+    }
+}
+
+impl<T> uDisplay for &'_ T
+where
+    T: uDisplay + ?Sized,
+{
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <T as uDisplay>::fmt(self, f)
+    }
+}
+
+impl<T> uDebug for &'_ mut T
+where
+    T: uDebug + ?Sized,
+{
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <T as uDebug>::fmt(self, f)
+    }
+}
+
+impl<T> uDisplay for &'_ mut T
+where
+    T: uDisplay + ?Sized,
+{
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <T as uDisplay>::fmt(self, f)
+    }
+}
+
+impl<T> uDebug for Option<T>
+where
+    T: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        match self {
+            None => f.write_str("None"),
+            Some(x) => f.debug_tuple("Some")?.field(x)?.finish(),
+        }
+    }
+}
+
+impl<T, E> uDebug for Result<T, E>
+where
+    T: uDebug,
+    E: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        match self {
+            Err(e) => f.debug_tuple("Err")?.field(e)?.finish(),
+            Ok(x) => f.debug_tuple("Ok")?.field(x)?.finish(),
+        }
+    }
+}

--- a/ufmt/src/impls/ixx.rs
+++ b/ufmt/src/impls/ixx.rs
@@ -1,0 +1,220 @@
+use core::str;
+
+use crate::{uDebug, uDisplay, uWrite, Formatter};
+
+macro_rules! ixx {
+    ($uxx:ty, $n:expr, $buf:expr) => {{
+        let n = $n;
+        let negative = n.is_negative();
+        let mut n = if negative {
+            match n.checked_abs() {
+                Some(n) => n as $uxx,
+                None => <$uxx>::max_value() / 2 + 1,
+            }
+        } else {
+            n as $uxx
+        };
+        let mut i = $buf.len() - 1;
+        loop {
+            *$buf
+                .get_mut(i)
+                .unwrap_or_else(|| unsafe { assume_unreachable!() }) = (n % 10) as u8 + b'0';
+            n = n / 10;
+
+            if n == 0 {
+                break;
+            } else {
+                i -= 1;
+            }
+        }
+
+        if negative {
+            i -= 1;
+            *$buf
+                .get_mut(i)
+                .unwrap_or_else(|| unsafe { assume_unreachable!() }) = b'-';
+        }
+
+        unsafe { str::from_utf8_unchecked($buf.get(i..).unwrap_or_else(|| assume_unreachable!())) }
+    }};
+}
+
+fn isize(n: isize, buf: &mut [u8]) -> &str {
+    ixx!(usize, n, buf)
+}
+
+impl uDebug for i8 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 4] = unsafe { crate::uninitialized() };
+
+        f.write_str(isize(isize::from(*self), &mut buf))
+    }
+}
+
+impl uDisplay for i8 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i8 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for i16 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 6] = unsafe { crate::uninitialized() };
+
+        f.write_str(isize(isize::from(*self), &mut buf))
+    }
+}
+
+impl uDisplay for i16 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i16 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for i32 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 11] = unsafe { crate::uninitialized() };
+
+        f.write_str(isize(*self as isize, &mut buf))
+    }
+}
+
+impl uDisplay for i32 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i32 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for i64 {
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+
+        let s = ixx!(u64, *self, buf);
+        f.write_str(s)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+
+        f.write_str(isize(*self as isize, &mut buf))
+    }
+}
+
+impl uDisplay for i64 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i64 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for i128 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 40] = unsafe { crate::uninitialized() };
+
+        let s = ixx!(u128, *self, buf);
+        f.write_str(s)
+    }
+}
+
+impl uDisplay for i128 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i128 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for isize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i16 as uDebug>::fmt(&(*self as i16), f)
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i32 as uDebug>::fmt(&(*self as i32), f)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i64 as uDebug>::fmt(&(*self as i64), f)
+    }
+}
+
+impl uDisplay for isize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i16 as uDisplay>::fmt(&(*self as i16), f)
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i32 as uDisplay>::fmt(&(*self as i32), f)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <i64 as uDisplay>::fmt(&(*self as i64), f)
+    }
+}

--- a/ufmt/src/impls/nz.rs
+++ b/ufmt/src/impls/nz.rs
@@ -1,0 +1,45 @@
+use core::num::{
+    NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU16, NonZeroU32,
+    NonZeroU64, NonZeroU8, NonZeroUsize,
+};
+
+use crate::{uDebug, uDisplay, uWrite, Formatter};
+
+macro_rules! nz {
+    ($($NZ:ident : $inner:ident,)*) => {
+        $(
+            impl uDebug for $NZ {
+                #[inline(always)]
+                fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+                where
+                    W: uWrite + ?Sized,
+                {
+                    <$inner as uDebug>::fmt(&self.get(), f)
+                }
+            }
+
+            impl uDisplay for $NZ {
+                #[inline(always)]
+                fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+                where
+                    W: uWrite + ?Sized,
+                {
+                    <$inner as uDisplay>::fmt(&self.get(), f)
+                }
+            }
+        )*
+    }
+}
+
+nz!(
+    NonZeroI16: i16,
+    NonZeroI32: i32,
+    NonZeroI64: i64,
+    NonZeroI8: i8,
+    NonZeroIsize: isize,
+    NonZeroU16: u16,
+    NonZeroU32: u32,
+    NonZeroU64: u64,
+    NonZeroU8: u8,
+    NonZeroUsize: usize,
+);

--- a/ufmt/src/impls/ptr.rs
+++ b/ufmt/src/impls/ptr.rs
@@ -1,0 +1,79 @@
+use core::str;
+
+use crate::{uDebug, uWrite, Formatter};
+
+macro_rules! hex {
+    ($self:expr, $f:expr, $N:expr) => {{
+        let mut buf: [u8; $N] = unsafe { crate::uninitialized() };
+
+        let i = hex(*$self as usize, &mut buf);
+
+        unsafe {
+            $f.write_str(str::from_utf8_unchecked(
+                buf.get(i..).unwrap_or_else(|| assume_unreachable!()),
+            ))
+        }
+    }};
+}
+
+fn hex(mut n: usize, buf: &mut [u8]) -> usize {
+    let mut i = buf.len() - 1;
+
+    loop {
+        let d = (n % 16) as u8;
+        *buf.get_mut(i)
+            .unwrap_or_else(|| unsafe { assume_unreachable!() }) =
+            if d < 10 { d + b'0' } else { (d - 10) + b'a' };
+        n = n / 16;
+
+        i -= 1;
+        if n == 0 {
+            break;
+        }
+    }
+
+    *buf.get_mut(i)
+        .unwrap_or_else(|| unsafe { assume_unreachable!() }) = b'x';
+    i -= 1;
+
+    *buf.get_mut(i)
+        .unwrap_or_else(|| unsafe { assume_unreachable!() }) = b'0';
+
+    i
+}
+
+impl<T> uDebug for *const T {
+    #[cfg(target_pointer_width = "16")]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        hex!(self, f, 6)
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        hex!(self, f, 10)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        hex!(self, f, 18)
+    }
+}
+
+impl<T> uDebug for *mut T {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        (*self as *const T).fmt(f)
+    }
+}

--- a/ufmt/src/impls/std.rs
+++ b/ufmt/src/impls/std.rs
@@ -1,0 +1,108 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use crate::{uDebug, uDisplay, uWrite, Formatter};
+
+impl<T> uDebug for Box<T>
+where
+    T: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <T as uDebug>::fmt(self, f)
+    }
+}
+
+impl<T> uDisplay for Box<T>
+where
+    T: uDisplay,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <T as uDisplay>::fmt(self, f)
+    }
+}
+
+impl<K, V> uDebug for BTreeMap<K, V>
+where
+    K: uDebug,
+    V: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.debug_map()?.entries(self)?.finish()
+    }
+}
+
+impl<T> uDebug for BTreeSet<T>
+where
+    T: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.debug_set()?.entries(self)?.finish()
+    }
+}
+
+impl<K, V> uDebug for HashMap<K, V>
+where
+    K: uDebug,
+    V: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.debug_map()?.entries(self)?.finish()
+    }
+}
+
+impl<T> uDebug for HashSet<T>
+where
+    T: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.debug_set()?.entries(self)?.finish()
+    }
+}
+
+// TODO
+// impl uDebug for String {
+//     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+//     where
+//         W: uWrite + ?Sized,
+//     {
+//         <str as uDebug>::fmt(self, f)
+//     }
+// }
+
+impl uDisplay for String {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <str as uDisplay>::fmt(self, f)
+    }
+}
+
+impl<T> uDebug for Vec<T>
+where
+    T: uDebug,
+{
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <[T] as uDebug>::fmt(self, f)
+    }
+}

--- a/ufmt/src/impls/tuple.rs
+++ b/ufmt/src/impls/tuple.rs
@@ -1,0 +1,40 @@
+use crate::{uDebug, uWrite, Formatter};
+
+macro_rules! tuple {
+    ($($T:ident),*; $($i:tt),*) => {
+        impl<$($T,)*> uDebug for ($($T,)*)
+        where
+            $($T: uDebug,)*
+        {
+            fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+            where
+                W: uWrite + ?Sized,
+            {
+                f.debug_tuple("")?$(.field(&self.$i)?)*.finish()
+            }
+        }
+
+    }
+}
+
+impl uDebug for () {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.write_str("()")
+    }
+}
+
+tuple!(A; 0);
+tuple!(A, B; 0, 1);
+tuple!(A, B, C; 0, 1, 2);
+tuple!(A, B, C, D; 0, 1, 2, 3);
+tuple!(A, B, C, D, E; 0, 1, 2, 3, 4);
+tuple!(A, B, C, D, E, F; 0, 1, 2, 3, 4, 5);
+tuple!(A, B, C, D, E, F, G; 0, 1, 2, 3, 4, 5, 6);
+tuple!(A, B, C, D, E, F, G, H; 0, 1, 2, 3, 4, 5, 6, 7);
+tuple!(A, B, C, D, E, F, G, H, I; 0, 1, 2, 3, 4, 5, 6, 7, 8);
+tuple!(A, B, C, D, E, F, G, H, I, J; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+tuple!(A, B, C, D, E, F, G, H, I, J, K; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+tuple!(A, B, C, D, E, F, G, H, I, J, K, L; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);

--- a/ufmt/src/impls/uxx.rs
+++ b/ufmt/src/impls/uxx.rs
@@ -1,0 +1,204 @@
+use core::str;
+
+use crate::{uDebug, uDisplay, uWrite, Formatter};
+
+macro_rules! uxx {
+    ($n:expr, $buf:expr) => {{
+        let mut n = $n;
+        let mut i = $buf.len() - 1;
+        loop {
+            *$buf
+                .get_mut(i)
+                .unwrap_or_else(|| unsafe { assume_unreachable!() }) = (n % 10) as u8 + b'0';
+            n = n / 10;
+
+            if n == 0 {
+                break;
+            } else {
+                i -= 1;
+            }
+        }
+
+        unsafe { str::from_utf8_unchecked($buf.get(i..).unwrap_or_else(|| assume_unreachable!())) }
+    }};
+}
+
+fn usize(n: usize, buf: &mut [u8]) -> &str {
+    uxx!(n, buf)
+}
+
+impl uDebug for u8 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 3] = unsafe { crate::uninitialized() };
+
+        f.write_str(usize(usize::from(*self), &mut buf))
+    }
+}
+
+impl uDisplay for u8 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u8 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for u16 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 5] = unsafe { crate::uninitialized() };
+
+        f.write_str(usize(usize::from(*self), &mut buf))
+    }
+}
+
+impl uDisplay for u16 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u16 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for u32 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 10] = unsafe { crate::uninitialized() };
+
+        f.write_str(usize(*self as usize, &mut buf))
+    }
+}
+
+impl uDisplay for u32 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u32 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for u64 {
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "16"))]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+
+        let s = uxx!(*self, buf);
+        f.write_str(s)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+
+        f.write_str(usize(*self as usize, &mut buf))
+    }
+}
+
+impl uDisplay for u64 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u64 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for u128 {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        let mut buf: [u8; 39] = unsafe { crate::uninitialized() };
+
+        let s = uxx!(*self, buf);
+        f.write_str(s)
+    }
+}
+
+impl uDisplay for u128 {
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u128 as uDebug>::fmt(self, f)
+    }
+}
+
+impl uDebug for usize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u16 as uDebug>::fmt(&(*self as u16), f)
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u32 as uDebug>::fmt(&(*self as u32), f)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u64 as uDebug>::fmt(&(*self as u64), f)
+    }
+}
+
+impl uDisplay for usize {
+    #[cfg(target_pointer_width = "16")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u16 as uDisplay>::fmt(&(*self as u16), f)
+    }
+
+    #[cfg(target_pointer_width = "32")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u32 as uDisplay>::fmt(&(*self as u32), f)
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[inline(always)]
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <u64 as uDisplay>::fmt(&(*self as u64), f)
+    }
+}

--- a/ufmt/src/lib.rs
+++ b/ufmt/src/lib.rs
@@ -190,6 +190,9 @@
 //! This crate is guaranteed to compile on stable Rust 1.34 and up. It *might* compile on older
 //! versions but that may change in any new patch release.
 
+// Added when we vendored ufmt into libtock-rs to avoid needing to immediately
+// make many changes.
+#![allow(clippy::all)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 #![deny(rust_2018_compatibility)]

--- a/ufmt/src/lib.rs
+++ b/ufmt/src/lib.rs
@@ -1,0 +1,364 @@
+//! `μfmt`, a (6-40x) smaller, (2-9x) faster and panic-free alternative to `core::fmt`
+//!
+//! # Design goals
+//!
+//! From highest priority to lowest priority
+//!
+//! - Optimized for binary size and speed (rather than for compilation time)
+//! - No dynamic dispatch in generated code
+//! - No panicking branches in generated code, when optimized
+//! - No recursion where possible
+//!
+//! # Features
+//!
+//! - [`Debug`] and [`Display`]-like traits
+//! - [`core::write!`][uwrite]-like macro
+//! - A generic [`Formatter<'_, impl uWrite>`][formatter] instead of a single `core::Formatter`; the
+//!   [`uWrite`] trait has an associated error type so each writer can choose its error type. For
+//!   example, the implementation for `std::String` uses [`Infallible`] as its error type.
+//! - [`core::fmt::Formatter::debug_struct`][debug_struct]-like API
+//! - [`#[derive(uDebug)]`][derive]
+//! - Pretty formatting (`{:#?}`) for `uDebug`
+//!
+//! [`Debug`]: trait.uDebug.html
+//! [`Display`]: trait.uDisplay.html
+//! [uwrite]: index.html#reexports
+//! [formatter]: struct.Formatter.html
+//! [`uWrite`]: trait.uWrite.html
+//! [`Infallible`]: https://doc.rust-lang.org/core/convert/enum.Infallible.html
+//! [debug_struct]: file:///home/japaric/rust/ufmt/target/doc/ufmt/struct.Formatter.html#method.debug_list
+//! [derive]: derive/index.html
+//!
+//! # Non-features
+//!
+//! These are out of scope
+//!
+//! - Padding, alignment and other formatting options
+//! - Formatting floating point numbers
+//!
+//! # Examples
+//!
+//! - `uwrite!` / `uwriteln!`
+//!
+//! ```
+//! use ufmt::{derive::uDebug, uwrite};
+//!
+//! #[derive(uDebug)]
+//! struct Pair { x: u32, y: u32 }
+//!
+//! let mut s = String::new();
+//! let pair = Pair { x: 1, y: 2 };
+//! uwrite!(s, "{:?}", pair).unwrap();
+//! assert_eq!(s, "Pair { x: 1, y: 2 }");
+//! ```
+//!
+//! - implementing `uWrite`
+//!
+//! When implementing the `uWrite` trait you should prefer the `ufmt_write::uWrite` crate over the
+//! `ufmt::uWrite` crate for better forward compatibility.
+//!
+//! ```
+//! use core::convert::Infallible;
+//!
+//! use ufmt_write::uWrite;
+//!
+//! struct MyWriter;
+//!
+//! impl uWrite for MyWriter {
+//!     type Error = Infallible;
+//!
+//!     fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+//!         // ..
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! - writing a `macro_rules!` macro that uses `uwrite!` (or `uwriteln!`).
+//!
+//! Both `ufmt` macros are implemented using [`proc-macro-hack`]; care is needed to avoid running
+//! into the compiler bug [#43081](https://github.com/rust-lang/rust/issues/43081). See also
+//! [dtolnay/proc-macro-hack#46][pmh-46].
+//!
+//! [`proc-macro-hack`]: https://github.com/dtolnay/proc-macro-hack
+//! [pmh-46]: https://github.com/dtolnay/proc-macro-hack/issues/46
+//!
+//! ```
+//! // like `std::format!` it returns a `std::String` but uses `uwrite!` instead of `write!`
+//! macro_rules! uformat {
+//!     // IMPORTANT use `tt` fragments instead of `expr` fragments (i.e. `$($exprs:expr),*`)
+//!     ($($tt:tt)*) => {{
+//!         let mut s = String::new();
+//!         match ufmt::uwrite!(&mut s, $($tt)*) {
+//!             Ok(_) => Ok(s),
+//!             Err(e) => Err(e),
+//!         }
+//!     }}
+//! }
+//! ```
+//!
+//! # Benchmarks
+//!
+//! The benchmarks ran on a ARM Cortex-M3 chip (`thumbv7m-none-eabi`).
+//!
+//! The benchmarks were compiled with `nightly-2019-05-01`, `-C opt-level=3`, `lto = true`,
+//! `codegen-units = 1`.
+//!
+//! In all benchmarks `x = i32::MIN` and `y = i32::MIN` plus some obfuscation was applied to
+//! prevent const-propagation of the `*write!` arguments.
+//!
+//! The unit of time is one core clock cycle: 125 ns (8 MHz)
+//!
+//! The `.text` and `.rodata` columns indicate the delta (in bytes) when commenting out the
+//! `*write!` statement.
+//!
+//! |Code                                      |Time|%        |`.text`|%        |`.rodata`|%       |
+//! |------------------------------------------|----|---------|-------|---------|---------|--------|
+//! |`write!("Hello, world!")`                 |154 |~        |1906   |~        |248      |~       |
+//! |`uwrite!("Hello, world!")`                |20  |**13.0%**|34     |**1.8%** |16       |**6.5%**|
+//! |`write!(w, "{}", 0i32)`                   |256 |~        |1958   |~        |232      |~       |
+//! |`uwrite!(w, "{}", 0i32)`                  |37  |**14.5%**|288    |**14.7%**|0        |**0%**  |
+//! |`write!(w, "{}", x)`                      |381 |~        |
+//! |`uwrite!(w, "{}", x)`                     |295 |77.4%    |
+//! |`write!(w, "{:?}", Pair { x: 0, y: 0 })`  |996 |~        |4704   |~        |312      |~       |
+//! |`uwrite!(w, "{:?}", Pair { x: 0, y: 0 })` |254 |**25.5%**|752    |**16.0%**|24       |**7.7%**|
+//! |`write!(w, "{:?}", Pair { x, y })`        |1264|~        |
+//! |`uwrite!(w, "{:?}", Pair { x, y })`       |776 |61.4%    |
+//! |`write!(w, "{:#?}", Pair { x: 0, y: 0 })` |2853|~        |4710   |~        |348      |~       |
+//! |`uwrite!(w, "{:#?}", Pair { x: 0, y: 0 })`|301 |**10.6%**|754    |**16.0%**|24       |**6.9%**|
+//! |`write!(w, "{:#?}", Pair { x, y })`       |3693|~        |
+//! |`uwrite!(w, "{:#?}", Pair { x, y })`      |823 |**22.3%**|
+//!
+//!
+//! Benchmark program:
+//!
+//! ``` ignore
+//! static X: AtomicI32 = AtomicI32::new(i32::MIN); // or `0`
+//! static Y: AtomicI32 = AtomicI32::new(i32::MIN); // or `0`
+//!
+//! #[exception]
+//! fn PendSV() {
+//!    // read DWT.CYCCNT here
+//!
+//!    let x = X.load(Ordering::Relaxed);
+//!    let y = Y.load(Ordering::Relaxed);
+//!
+//!    let p = Pair { x, y };
+//!
+//!    uwrite!(&mut W, "{:#?}", p).ok();
+//!
+//!    // write!(&mut W, "{:#?}", p).ok();
+//!
+//!    asm::bkpt(); // read DWT.CYCCNT here
+//! }
+//! ```
+//!
+//! Writer used in the benchmarks:
+//!
+//! ```
+//! use core::{convert::Infallible, fmt, ptr};
+//!
+//! use ufmt::uWrite;
+//!
+//! struct W;
+//!
+//! impl uWrite for W {
+//!     type Error = Infallible;
+//!
+//!     fn write_str(&mut self, s: &str) -> Result<(), Infallible> {
+//!         s.as_bytes()
+//!             .iter()
+//!             .for_each(|b| unsafe { drop(ptr::read_volatile(b)) });
+//!
+//!         Ok(())
+//!     }
+//! }
+//!
+//! impl fmt::Write for W {
+//!     fn write_str(&mut self, s: &str) -> fmt::Result {
+//!         s.as_bytes()
+//!             .iter()
+//!             .for_each(|b| unsafe { drop(ptr::read_volatile(b)) });
+//!
+//!         Ok(())
+//!     }
+//! }
+//! ```
+//!
+//! # Minimum Supported Rust Version (MSRV)
+//!
+//! This crate is guaranteed to compile on stable Rust 1.34 and up. It *might* compile on older
+//! versions but that may change in any new patch release.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
+#![deny(rust_2018_compatibility)]
+#![deny(rust_2018_idioms)]
+#![deny(warnings)]
+
+// this lets us use `uwrite!` in the test suite
+#[allow(unused_extern_crates)]
+#[cfg(test)]
+extern crate self as ufmt;
+
+use core::str;
+
+use proc_macro_hack::proc_macro_hack;
+pub use ufmt_write::uWrite;
+
+/// Write formatted data into a buffer
+///
+/// This macro accepts a format string, a list of arguments, and a 'writer'. Arguments will be
+/// formatted according to the specified format string and the result will be passed to the writer.
+/// The writer must have type `[&mut] impl uWrite` or `[&mut] ufmt::Formatter<'_, impl uWrite>`. The
+/// macro returns the associated `Error` type of the `uWrite`-r.
+///
+/// The syntax is similar to [`core::write!`] but only a handful of argument types are accepted:
+///
+/// [`core::write!`]: https://doc.rust-lang.org/core/macro.write.html
+///
+/// - `{}` - `uDisplay`
+/// - `{:?}` - `uDebug`
+/// - `{:#?}` - "pretty" `uDebug`
+///
+/// Named parameters and "specified" positional parameters (`{0}`) are not supported.
+///
+/// `{{` and `}}` can be used to escape braces.
+#[proc_macro_hack]
+pub use ufmt_macros::uwrite;
+
+/// Write formatted data into a buffer, with a newline appended
+///
+/// See [`uwrite!`](macro.uwrite.html) for more details
+#[proc_macro_hack]
+pub use ufmt_macros::uwriteln;
+
+pub use crate::helpers::{DebugList, DebugMap, DebugStruct, DebugTuple};
+
+#[macro_use]
+mod macros;
+
+mod helpers;
+mod impls;
+/// Derive macros
+pub mod derive {
+    pub use ufmt_macros::uDebug;
+}
+
+#[allow(deprecated)]
+unsafe fn uninitialized<T>() -> T {
+    core::mem::uninitialized()
+}
+
+/// Just like `core::fmt::Debug`
+#[allow(non_camel_case_types)]
+pub trait uDebug {
+    /// Formats the value using the given formatter
+    fn fmt<W>(&self, _: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized;
+}
+
+/// Just like `core::fmt::Display`
+#[allow(non_camel_case_types)]
+pub trait uDisplay {
+    /// Formats the value using the given formatter
+    fn fmt<W>(&self, _: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized;
+}
+
+/// Configuration for formatting
+#[allow(non_camel_case_types)]
+pub struct Formatter<'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    indentation: u8,
+    pretty: bool,
+    writer: &'w mut W,
+}
+
+impl<'w, W> Formatter<'w, W>
+where
+    W: uWrite + ?Sized,
+{
+    /// Creates a formatter from the given writer
+    pub fn new(writer: &'w mut W) -> Self {
+        Self {
+            indentation: 0,
+            pretty: false,
+            writer,
+        }
+    }
+
+    /// Execute the closure with pretty-printing enabled
+    pub fn pretty(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<(), W::Error>,
+    ) -> Result<(), W::Error> {
+        let pretty = self.pretty;
+        self.pretty = true;
+        f(self)?;
+        self.pretty = pretty;
+        Ok(())
+    }
+
+    /// Writes a character to the underlying buffer contained within this formatter.
+    pub fn write_char(&mut self, c: char) -> Result<(), W::Error> {
+        self.writer.write_char(c)
+    }
+
+    /// Writes a string slice to the underlying buffer contained within this formatter.
+    pub fn write_str(&mut self, s: &str) -> Result<(), W::Error> {
+        self.writer.write_str(s)
+    }
+
+    /// Write whitespace according to the current `self.indentation`
+    fn indent(&mut self) -> Result<(), W::Error> {
+        for _ in 0..self.indentation {
+            self.write_str("    ")?;
+        }
+
+        Ok(())
+    }
+}
+
+// Implementation detail of the `uwrite*!` macros
+#[doc(hidden)]
+pub trait UnstableDoAsFormatter {
+    type Writer: uWrite + ?Sized;
+
+    fn do_as_formatter(
+        &mut self,
+        f: impl FnOnce(&mut Formatter<'_, Self::Writer>) -> Result<(), <Self::Writer as uWrite>::Error>,
+    ) -> Result<(), <Self::Writer as uWrite>::Error>;
+}
+
+impl<W> UnstableDoAsFormatter for W
+where
+    W: uWrite + ?Sized,
+{
+    type Writer = W;
+
+    fn do_as_formatter(
+        &mut self,
+        f: impl FnOnce(&mut Formatter<'_, W>) -> Result<(), W::Error>,
+    ) -> Result<(), W::Error> {
+        f(&mut Formatter::new(self))
+    }
+}
+
+impl<W> UnstableDoAsFormatter for Formatter<'_, W>
+where
+    W: uWrite + ?Sized,
+{
+    type Writer = W;
+
+    fn do_as_formatter(
+        &mut self,
+        f: impl FnOnce(&mut Formatter<'_, W>) -> Result<(), W::Error>,
+    ) -> Result<(), W::Error> {
+        f(self)
+    }
+}

--- a/ufmt/src/macros.rs
+++ b/ufmt/src/macros.rs
@@ -1,0 +1,9 @@
+macro_rules! assume_unreachable {
+    () => {
+        if cfg!(debug_assertions) {
+            unreachable!()
+        } else {
+            core::hint::unreachable_unchecked()
+        }
+    };
+}

--- a/ufmt/tests/vs-std-write.rs
+++ b/ufmt/tests/vs-std-write.rs
@@ -1,0 +1,339 @@
+use core::convert::Infallible;
+use std::collections::{BTreeMap, BTreeSet};
+
+use ufmt::{derive::uDebug, uDebug, uWrite, uwrite, uwriteln, Formatter};
+
+macro_rules! uformat {
+    ($($tt:tt)*) => {{
+        let mut s = String::new();
+        #[allow(unreachable_code)]
+        match ufmt::uwrite!(&mut s, $($tt)*) {
+            Ok(_) => Ok(s),
+            Err(e) => Err(e),
+        }
+    }};
+}
+
+macro_rules! cmp {
+    ($($tt:tt)*) => {
+        assert_eq!(
+            uformat!($($tt)*),
+            Ok(format!($($tt)*)),
+        )
+    }
+}
+
+#[test]
+fn core() {
+    cmp!("{:?}", None::<i32>);
+    cmp!("{:#?}", None::<i32>);
+
+    cmp!("{:?}", Some(0));
+    cmp!("{:#?}", Some(0));
+
+    cmp!("{:?}", Ok::<_, ()>(1));
+    cmp!("{:#?}", Ok::<_, ()>(1));
+
+    cmp!("{:?}", Err::<(), _>(2));
+    cmp!("{:#?}", Err::<(), _>(2));
+}
+
+#[test]
+fn recursion() {
+    #[derive(uDebug, Debug)]
+    struct Node {
+        value: i32,
+        next: Option<Box<Node>>,
+    }
+
+    fn x() -> Node {
+        let tail = Node {
+            value: 0,
+            next: None,
+        };
+        Node {
+            value: 1,
+            next: Some(Box::new(tail)),
+        }
+    }
+
+    cmp!("{:?}", x());
+    cmp!("{:#?}", x());
+}
+
+#[test]
+fn uxx() {
+    cmp!("{}", 0u8);
+    cmp!("{}", 10u8);
+    cmp!("{}", 100u8);
+
+    // extreme values
+    cmp!("{}", u8::max_value());
+    cmp!("{}", u16::max_value());
+    cmp!("{}", u32::max_value());
+    cmp!("{}", u64::max_value());
+    cmp!("{}", u128::max_value());
+    cmp!("{}", usize::max_value());
+}
+
+#[test]
+fn ixx() {
+    // sanity check
+    cmp!("{}", 0i8);
+    cmp!("{}", 10i8);
+    cmp!("{}", 100i8);
+
+    // extreme values
+    cmp!("{}", i8::min_value());
+    cmp!("{}", i8::max_value());
+    cmp!("{}", i16::min_value());
+    cmp!("{}", i16::max_value());
+    cmp!("{}", i32::min_value());
+    cmp!("{}", i32::max_value());
+    cmp!("{}", i64::min_value());
+    cmp!("{}", i64::max_value());
+    cmp!("{}", i128::min_value());
+    cmp!("{}", i128::max_value());
+    cmp!("{}", isize::min_value());
+    cmp!("{}", isize::max_value());
+}
+
+#[test]
+fn fmt() {
+    cmp!("Hello, world!");
+    cmp!("The answer is {}", 42);
+}
+
+#[test]
+fn map() {
+    fn x() -> BTreeMap<i32, i32> {
+        let mut m = BTreeMap::new();
+        m.insert(1, 2);
+        m.insert(3, 4);
+        m
+    }
+
+    cmp!("{:?}", BTreeMap::<(), ()>::new());
+    cmp!("{:?}", x());
+
+    cmp!("{:#?}", BTreeMap::<(), ()>::new());
+    cmp!("{:#?}", x());
+}
+
+#[test]
+fn set() {
+    fn x() -> BTreeSet<i32> {
+        let mut m = BTreeSet::new();
+        m.insert(1);
+        m.insert(3);
+        m
+    }
+
+    cmp!("{:?}", BTreeSet::<()>::new());
+    cmp!("{:?}", x());
+
+    cmp!("{:#?}", BTreeSet::<()>::new());
+    cmp!("{:#?}", x());
+}
+
+#[test]
+fn struct_() {
+    #[derive(Debug, uDebug)]
+    struct Braces {}
+
+    #[derive(Debug, uDebug)]
+    struct Parens();
+
+    #[derive(Debug, Default, uDebug)]
+    struct I32(i32);
+
+    #[derive(Debug, Default, uDebug)]
+    struct Tuple(i32, i32);
+
+    #[derive(Debug, Default, uDebug)]
+    struct Pair {
+        x: i32,
+        y: i32,
+    }
+
+    #[derive(Debug, Default, uDebug)]
+    struct Nested {
+        first: Pair,
+        second: Pair,
+    }
+
+    cmp!("{:?}", Braces {});
+    cmp!("{:?}", Parens());
+    cmp!("{:?}", I32::default());
+    cmp!("{:?}", Tuple::default());
+    cmp!("{:?}", Pair::default());
+    cmp!("{:?}", Nested::default());
+
+    cmp!("{:#?}", Braces {});
+    cmp!("{:#?}", Parens());
+    cmp!("{:#?}", I32::default());
+    cmp!("{:#?}", Tuple::default());
+    cmp!("{:#?}", Pair::default());
+    cmp!("{:#?}", Nested::default());
+}
+
+#[test]
+fn enum_() {
+    #[derive(Debug, uDebug)]
+    enum X {
+        A,
+        B(u8, u16),
+        C { x: u8, y: u16 },
+    }
+
+    cmp!("{:?}", X::A);
+    cmp!("{:?}", X::B(0, 1));
+    cmp!("{:?}", X::C { x: 0, y: 1 });
+
+    cmp!("{:#?}", X::A);
+    cmp!("{:#?}", X::B(0, 1));
+    cmp!("{:#?}", X::C { x: 0, y: 1 });
+}
+
+#[test]
+fn ptr() {
+    cmp!("{:?}", 1 as *const u8);
+    cmp!("{:?}", 0xf as *const u8);
+    cmp!("{:?}", 0xff as *const u8);
+    cmp!("{:?}", 0xfff as *const u8);
+    cmp!("{:?}", 0xffff as *const u8);
+    cmp!("{:?}", 0xfffff as *const u8);
+    cmp!("{:?}", 0xffffff as *const u8);
+    cmp!("{:?}", 0xfffffff as *const u8);
+    cmp!("{:?}", 0xffffffff as *const u8);
+
+    #[cfg(target_pointer_width = "64")]
+    cmp!("{:?}", 0xfffffffff as *const u8);
+}
+
+#[test]
+fn tuples() {
+    cmp!("{:?}", ());
+    cmp!("{:?}", (1,));
+    cmp!("{:?}", (1, 2));
+    cmp!("{:?}", (1, 2, 3));
+    cmp!("{:?}", (1, 2, 3, 4));
+    cmp!("{:?}", (1, 2, 3, 4, 5));
+    cmp!("{:?}", (1, 2, 3, 4, 5, 6));
+    cmp!("{:?}", (1, 2, 3, 4, 5, 6, 7));
+    cmp!("{:?}", (1, 2, 3, 4, 5, 6, 7, 8));
+    cmp!("{:?}", (1, 2, 3, 4, 5, 6, 7, 8, 9));
+    cmp!("{:?}", (1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+    cmp!("{:?}", (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+    cmp!("{:?}", (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12));
+
+    cmp!("{:#?}", ());
+    cmp!("{:#?}", (1,));
+    cmp!("{:#?}", (1, 2));
+}
+
+#[test]
+fn slice() {
+    cmp!("{:?}", [0; 0]);
+    cmp!("{:?}", [0]);
+    cmp!("{:?}", [0, 1]);
+
+    cmp!("{:#?}", [0; 0]);
+    cmp!("{:#?}", [0]);
+    cmp!("{:#?}", [0, 1]);
+}
+
+#[test]
+fn uwriteln() {
+    let mut s = String::new();
+    uwriteln!(&mut s, "Hello").unwrap();
+    uwriteln!(&mut s, "World",).unwrap();
+    assert_eq!(s, "Hello\nWorld\n");
+}
+
+#[test]
+fn formatter_uwrite() {
+    #[derive(uDebug)]
+    struct X;
+
+    struct Y;
+
+    impl uDebug for Y {
+        fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+        where
+            W: uWrite + ?Sized,
+        {
+            uwrite!(f, "{:?}", X)
+        }
+    }
+
+    assert_eq!(uformat!("{:?}", Y).unwrap(), "X")
+}
+
+#[test]
+fn generic() {
+    #[derive(uDebug, Debug)]
+    struct X<T>(T);
+
+    cmp!("{:?}", X(0));
+
+    #[derive(uDebug, Debug)]
+    enum Y<T> {
+        Z(T),
+    }
+
+    cmp!("{:?}", Y::Z(0));
+}
+
+// compile-pass test
+#[allow(dead_code)]
+fn static_lifetime(x: &'static mut u32) {
+    fn foo(x: &'static mut u32) -> *mut u32 {
+        x as *mut u32
+    }
+
+    uwrite!(&mut String::new(), "{:?}", foo(x)).ok();
+}
+
+// test dynamically sized writer
+#[test]
+fn dst() {
+    #[allow(rust_2018_idioms)] // false positive?
+    struct Cursor<B>
+    where
+        B: ?Sized,
+    {
+        pos: usize,
+        buffer: B,
+    }
+
+    impl<B> Cursor<B> {
+        fn new(buffer: B) -> Self {
+            Cursor { pos: 0, buffer }
+        }
+    }
+
+    impl uWrite for Cursor<[u8]> {
+        type Error = Infallible;
+
+        fn write_str(&mut self, s: &str) -> Result<(), Infallible> {
+            let bytes = s.as_bytes();
+            let len = bytes.len();
+            let start = self.pos;
+            if let Some(buffer) = self.buffer.get_mut(start..start + len) {
+                buffer.copy_from_slice(bytes);
+                self.pos += len;
+            }
+
+            Ok(())
+        }
+    }
+
+    let mut cursor = Cursor::new([0; 256]);
+    let cursor: &mut Cursor<[u8]> = &mut cursor;
+
+    uwrite!(cursor, "The answer is {}", 42).ok();
+
+    let msg = b"The answer is 42";
+    assert_eq!(&cursor.buffer[..msg.len()], msg);
+}

--- a/ufmt/utils/Cargo.toml
+++ b/ufmt/utils/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+categories = ["embedded", "no-std"]
+description = "`μfmt` utilities"
+documentation = "https://docs.rs/ufmt-utils"
+edition = "2018"
+keywords = ["Debug", "Display", "Write", "format"]
+license = "MIT OR Apache-2.0"
+name = "ufmt-utils"
+repository = "https://github.com/japaric/ufmt"
+version = "0.1.1"
+
+[dependencies]
+heapless = "0.5.0"
+ufmt-write = { version = "0.1.0", path = "../write" }
+
+[dev-dependencies]
+ufmt = { version = "0.1.0", path = ".." }

--- a/ufmt/utils/src/lib.rs
+++ b/ufmt/utils/src/lib.rs
@@ -1,0 +1,171 @@
+//! `μfmt` utilities
+//!
+//! # Minimum Supported Rust Version (MSRV)
+//!
+//! This crate is guaranteed to compile on stable Rust 1.36 and up. It *might* compile on older
+//! versions but that may change in any new patch release.
+
+#![deny(missing_docs)]
+#![deny(rust_2018_compatibility)]
+#![deny(rust_2018_idioms)]
+#![deny(warnings)]
+#![no_std]
+
+use core::{convert::Infallible, str, fmt};
+
+pub use heapless::consts;
+use heapless::{ArrayLength, String};
+use ufmt_write::uWrite;
+
+
+macro_rules! assume_unreachable {
+    () => {
+        if cfg!(debug_assertions) {
+            panic!()
+        } else {
+            core::hint::unreachable_unchecked()
+        }
+    };
+}
+
+/// A write adapter that ignores all errors
+pub struct Ignore<W>
+where
+    W: uWrite,
+{
+    writer: W,
+}
+
+impl<W> Ignore<W>
+where
+    W: uWrite,
+{
+    /// Creates a new `Ignore` adapter
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    /// Destroys the adapter and returns the underlying writer
+    pub fn free(self) -> W {
+        self.writer
+    }
+}
+
+impl<W> uWrite for Ignore<W>
+where
+    W: uWrite,
+{
+    type Error = Infallible;
+
+    fn write_str(&mut self, s: &str) -> Result<(), Infallible> {
+        let _ = self.writer.write_str(s);
+        Ok(())
+    }
+}
+
+/// A write adapter that buffers writes and automatically flushes on newlines
+pub struct LineBuffered<W, N>
+where
+    N: ArrayLength<u8>,
+    W: uWrite,
+{
+    buffer: String<N>,
+    writer: W,
+}
+
+impl<W, N> LineBuffered<W, N>
+where
+    N: ArrayLength<u8>,
+    W: uWrite,
+{
+    /// Creates a new `LineBuffered` adapter
+    pub fn new(writer: W) -> Self {
+        Self {
+            buffer: String::new(),
+            writer,
+        }
+    }
+
+    /// Flushes the contents of the buffer
+    pub fn flush(&mut self) -> Result<(), W::Error> {
+        let ret = self.writer.write_str(&self.buffer);
+        self.buffer.clear();
+        ret
+    }
+
+    /// Destroys the adapter and returns the underlying writer
+    pub fn free(self) -> W {
+        self.writer
+    }
+
+    fn push_str(&mut self, s: &str) -> Result<(), W::Error> {
+        let len = s.as_bytes().len();
+        if self.buffer.len() + len > self.buffer.capacity() {
+            self.flush()?;
+        }
+
+        if len > self.buffer.capacity() {
+            self.writer.write_str(s)?;
+        } else {
+            self.buffer
+                .push_str(s)
+                .unwrap_or_else(|_| unsafe { assume_unreachable!() })
+        }
+
+        Ok(())
+    }
+}
+
+impl<W, N> uWrite for LineBuffered<W, N>
+where
+    N: ArrayLength<u8>,
+    W: uWrite,
+{
+    type Error = W::Error;
+
+    fn write_str(&mut self, mut s: &str) -> Result<(), W::Error> {
+        while let Some(pos) = s.as_bytes().iter().position(|b| *b == b'\n') {
+            let line = s
+                .get(..pos + 1)
+                .unwrap_or_else(|| unsafe { assume_unreachable!() });
+
+            self.push_str(line)?;
+            self.flush()?;
+
+            s = s
+                .get(pos + 1..)
+                .unwrap_or_else(|| unsafe { assume_unreachable!() });
+        }
+
+        self.push_str(s)
+    }
+}
+
+
+/// An adapter struct allowing to use `ufmt` on types which implement `core::fmt::Write`
+///
+/// For example:
+///
+/// ```
+/// use ufmt::uwrite;
+/// use ufmt_write::uWrite;
+/// use ufmt_utils::WriteAdapter;
+///
+/// let fancy_number: u8 = 42;
+///
+/// let mut s = String::new();
+/// uwrite!(WriteAdapter(&mut s), "{:?}", fancy_number);
+/// ```
+pub struct WriteAdapter<W>(pub W) where W: fmt::Write;
+
+impl<W> uWrite for WriteAdapter<W> where W: fmt::Write {
+    type Error = fmt::Error;
+
+    fn write_char(&mut self, c: char) -> Result<(), Self::Error> {
+        self.0.write_char(c)
+    }
+
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error> {
+        self.0.write_str(s)
+    }
+}

--- a/ufmt/write/Cargo.toml
+++ b/ufmt/write/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["Jorge Aparicio <jorge@japaric.io>"]
+categories = ["embedded", "no-std"]
+description = "`μfmt`'s `uWrite` trait"
+edition = "2018"
+keywords = ["Debug", "Display", "Write", "format"]
+license = "MIT OR Apache-2.0"
+name = "ufmt-write"
+repository = "https://github.com/japaric/ufmt"
+version = "0.1.0"
+
+# NOTE do NOT add an `alloc` feature before the alloc crate can be used in
+# no-std BINARIES
+[features]
+# NOTE do NOT turn `std` into a default feature; this is a no-std first crate
+std = []

--- a/ufmt/write/src/lib.rs
+++ b/ufmt/write/src/lib.rs
@@ -1,0 +1,48 @@
+//! `μfmt`'s `uWrite` trait
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
+#![deny(rust_2018_compatibility)]
+#![deny(rust_2018_idioms)]
+#![deny(warnings)]
+
+#[cfg(feature = "std")]
+use core::convert::Infallible;
+
+#[allow(deprecated)]
+unsafe fn uninitialized<T>() -> T {
+    core::mem::uninitialized()
+}
+
+/// A collection of methods that are required / used to format a message into a stream.
+#[allow(non_camel_case_types)]
+pub trait uWrite {
+    /// The error associated to this writer
+    type Error;
+
+    /// Writes a string slice into this writer, returning whether the write succeeded.
+    ///
+    /// This method can only succeed if the entire string slice was successfully written, and this
+    /// method will not return until all data has been written or an error occurs.
+    fn write_str(&mut self, s: &str) -> Result<(), Self::Error>;
+
+    /// Writes a [`char`] into this writer, returning whether the write succeeded.
+    ///
+    /// A single [`char`] may be encoded as more than one byte. This method can only succeed if the
+    /// entire byte sequence was successfully written, and this method will not return until all
+    /// data has been written or an error occurs.
+    fn write_char(&mut self, c: char) -> Result<(), Self::Error> {
+        let mut buf: [u8; 4] = unsafe { uninitialized() };
+        self.write_str(c.encode_utf8(&mut buf))
+    }
+}
+
+#[cfg(feature = "std")]
+impl uWrite for String {
+    type Error = Infallible;
+
+    fn write_str(&mut self, s: &str) -> Result<(), Infallible> {
+        self.push_str(s);
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is the first step in implementing the [debug printing plan](https://github.com/tock/libtock-rs/issues/84#issuecomment-810690991) we discussed during a core WG call last month. This brings in the `ufmt` crate (minus testing code that we won't use). This is a temporary fork of `ufmt`: we will eventually either decide to abandon `ufmt` or to restore the maintenance of `ufmt`.

# Review Guide

1. Review the first section of [`ufmt/README.md`](https://github.com/jrvanwhy/libtock-rs/tree/vendor-ufmt/ufmt), which describes how the first commit was created.
1. Review the [diff of`README.md`](https://github.com/jrvanwhy/libtock-rs/commit/5163051a2d7fefbe4c9b1c6ba62b79fa07c324e7#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5), which is part of the first commit.
1. Review the rest of the commits (currently there is only 1 other commit), which should be manageable in size.

I changed the License section of our README to indicate that `ufmt` has different licensing. The licenses themselves are the same as `libtock-rs`, but the contribution history and copyright are different, and I feel that difference is worth pointing out.