### PR TITLE
Improve `libtock_runtime`'s error handling if it can't find an assembly toolchain.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
       # relocation.
       - name: Build and Test
         run: |
-          sudo apt-get install binutils-riscv64-unknown-elf
+          sudo apt-get install binutils-arm-none-eabi \
+            binutils-riscv64-unknown-elf
           cd "${GITHUB_WORKSPACE}"
           echo "[target.'cfg(all())']" >> .cargo/config
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config

--- a/runtime/extern_asm.rs
+++ b/runtime/extern_asm.rs
@@ -2,6 +2,9 @@
 //! point) and linking it into the process binary. Requires out_dir to be added
 //! to rustc's link search path.
 
+/// Compiles the external assembly and tells cargo/rustc to link the resulting
+/// library into the crate. Panics if it is unable to find a working assembly
+/// toolchain or if the assembly fails to compile.
 pub(crate) fn build_and_link(out_dir: &str) {
     use std::env::var;
     let arch = var("CARGO_CFG_TARGET_ARCH").expect("Unable to read CARGO_CFG_TARGET_ARCH");
@@ -49,6 +52,8 @@ pub(crate) fn build_and_link(out_dir: &str) {
             return;
         }
     }
+
+    panic!("Unable to find a toolchain for architecture {}", arch);
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Previously, if `libtock_runtime`'s build script was unable to find a toolchain to build its external assembly with, its build would succeed then the process binary would fail to link. This change makes `libtock_runtime`'s build script panic with a useful error message instead.