### PR TITLE
Add the `syscalls_tests` crate.

### DIFF
--- a/syscalls_tests/Cargo.toml
+++ b/syscalls_tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+edition = "2018"
+name = "syscalls_tests"
+version = "0.1.0"
+
+[dependencies]
+libtock_platform = { path = "../platform" }
+libtock_unittest = { path = "../unittest" }

--- a/syscalls_tests/src/lib.rs
+++ b/syscalls_tests/src/lib.rs
@@ -1,0 +1,23 @@
+//! This crate contains tests for `libtock_platform` functionality that use the
+//! `Syscalls` implementation.
+//!
+//! These tests are not in `libtock_platform` because adding them to
+//! `libtock_platform causes two incompatible copies of `libtock_platform` to be
+//! compiled:
+//!   1. The `libtock_platform` with `cfg(test)` enabled
+//!   2. The `libtock_platform` that `libtock_unittest` depends on, which has
+//!      `cfg(test)` disabled.
+//! Mixing types from the two `libtock_platform` instantiations in tests results
+//! in confusing error messages, so instead those tests live in this crate.
+
+// TODO: Add Allow.
+
+// TODO: Add Command.
+
+// TODO: Add Exit.
+
+// TODO: Add Memop.
+
+// TODO: Add Subscribe.
+
+// TODO: Add Yield.


### PR DESCRIPTION
Although `Syscalls` is implemented in `libtock_platform`, its unit tests cannot live in `libtock_platform`, due to a confusing "multiple copies of crate" issue that I explained in the comments. Instead, I'm putting its tests into a new crate.

This crate is currently called `syscalls_tests` because it contains tests for the `Syscalls` implementation. I'm happy to take other name suggestions -- I'm not super happy with this one, because it's a bit tricky to remember to add both 's'-es to the name. I don't want to do `platform_tests` because that would break tab completion for `platform/` and I think some `libtock_platform` tests belong in `libtock_platform`.

Like `libtock_unittest`, I am using comments so that I can implement the system calls in parallel without causing merge conflicts. I'm realizing that for each system call I need to develop the following simultaneously, because their designs are interdependent:

1. `libtock_unittest`'s fake version of the system call, including the expected syscall functionality and syscall log functionality.
1. The system call API (trait method)
1. The system call implementation
1. The unit tests for the system call implementation

After I have a working implementation of each system call, I'll break them up into reasonable-sized PRs and send them separately.