### PR TITLE
Update `CommandReturn` in preparation for the Command implementation.

### DIFF
--- a/platform/src/command_return_tests.rs
+++ b/platform/src/command_return_tests.rs
@@ -5,7 +5,7 @@ fn failure() {
     let command_return = unsafe {
         CommandReturn::new(
             return_variant::FAILURE,
-            ErrorCode::Reserve as usize,
+            ErrorCode::Reserve as u32,
             1002,
             1003,
         )
@@ -29,6 +29,10 @@ fn failure() {
     assert_eq!(command_return.get_success_u64(), None);
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::FAILURE, 5, 1002, 1003)
+    );
     assert_eq!(command_return.return_variant(), return_variant::FAILURE);
 }
 
@@ -37,7 +41,7 @@ fn failure_u32() {
     let command_return = unsafe {
         CommandReturn::new(
             return_variant::FAILURE_U32,
-            ErrorCode::Off as usize,
+            ErrorCode::Off as u32,
             1002,
             1003,
         )
@@ -64,6 +68,10 @@ fn failure_u32() {
     assert_eq!(command_return.get_success_u64(), None);
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::FAILURE_U32, 4, 1002, 1003)
+    );
     assert_eq!(command_return.return_variant(), return_variant::FAILURE_U32);
 }
 
@@ -72,7 +80,7 @@ fn failure_2_u32() {
     let command_return = unsafe {
         CommandReturn::new(
             return_variant::FAILURE_2_U32,
-            ErrorCode::Already as usize,
+            ErrorCode::Already as u32,
             1002,
             1003,
         )
@@ -100,6 +108,10 @@ fn failure_2_u32() {
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
     assert_eq!(
+        command_return.raw_values(),
+        (return_variant::FAILURE_2_U32, 3, 1002, 1003)
+    );
+    assert_eq!(
         command_return.return_variant(),
         return_variant::FAILURE_2_U32
     );
@@ -110,7 +122,7 @@ fn failure_u64() {
     let command_return = unsafe {
         CommandReturn::new(
             return_variant::FAILURE_U64,
-            ErrorCode::Busy as usize,
+            ErrorCode::Busy as u32,
             0x1002,
             0x1003,
         )
@@ -137,6 +149,10 @@ fn failure_u64() {
     assert_eq!(command_return.get_success_u64(), None);
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::FAILURE_U64, 2, 0x1002, 0x1003)
+    );
     assert_eq!(command_return.return_variant(), return_variant::FAILURE_U64);
 }
 
@@ -162,6 +178,10 @@ fn success() {
     assert_eq!(command_return.get_success_u64(), None);
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::SUCCESS, 1001, 1002, 1003)
+    );
     assert_eq!(command_return.return_variant(), return_variant::SUCCESS);
 }
 
@@ -188,6 +208,10 @@ fn success_u32() {
     assert_eq!(command_return.get_success_u64(), None);
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::SUCCESS_U32, 1001, 1002, 1003)
+    );
     assert_eq!(command_return.return_variant(), return_variant::SUCCESS_U32);
 }
 
@@ -214,6 +238,10 @@ fn success_2_u32() {
     assert_eq!(command_return.get_success_u64(), None);
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::SUCCESS_2_U32, 1001, 1002, 1003)
+    );
     assert_eq!(
         command_return.return_variant(),
         return_variant::SUCCESS_2_U32
@@ -246,6 +274,10 @@ fn success_u64() {
     );
     assert_eq!(command_return.get_success_3_u32(), None);
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::SUCCESS_U64, 0x1001, 0x1002, 1003)
+    );
     assert_eq!(command_return.return_variant(), return_variant::SUCCESS_U64);
 }
 
@@ -272,6 +304,10 @@ fn success_3_u32() {
     assert_eq!(command_return.get_success_u64(), None);
     assert_eq!(command_return.get_success_3_u32(), Some((1001, 1002, 1003)));
     assert_eq!(command_return.get_success_u32_u64(), None);
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::SUCCESS_3_U32, 1001, 1002, 1003)
+    );
     assert_eq!(
         command_return.return_variant(),
         return_variant::SUCCESS_3_U32
@@ -303,6 +339,10 @@ fn success_u32_u64() {
     assert_eq!(
         command_return.get_success_u32_u64(),
         Some((1001, 0x0000_1003_0000_1002))
+    );
+    assert_eq!(
+        command_return.raw_values(),
+        (return_variant::SUCCESS_U32_U64, 1001, 0x1002, 0x1003)
     );
     assert_eq!(
         command_return.return_variant(),

--- a/platform/src/error_code.rs
+++ b/platform/src/error_code.rs
@@ -1,10 +1,6 @@
 /// An error code returned by the kernel.
-// TODO: derive(Debug) is currently only enabled for test builds, which is
-// necessary so it can be used in assert_eq!. We should develop a lighter-weight
-// Debug implementation and see if it is small enough to enable on non-Debug
-// builds.
-#[cfg_attr(test, derive(Debug))]
-#[derive(Clone, Copy, PartialEq, Eq)]
+// TODO: Add a ufmt debug implementation for process binaries to use.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u16)]  // To facilitate use with transmute() in CommandReturn
 #[rustfmt::skip]
 pub enum ErrorCode {

--- a/platform/src/return_variant.rs
+++ b/platform/src/return_variant.rs
@@ -1,11 +1,7 @@
 /// `ReturnVariant` describes what value type the kernel has returned.
 // ReturnVariant is not an enum so that it can be converted from a u32 for free.
-// TODO: derive(Debug) is currently only enabled for test builds, which is
-// necessary so it can be used in assert_eq!. We should develop a lighter-weight
-// Debug implementation and see if it is small enough to enable on non-Debug
-// builds.
-#[cfg_attr(test, derive(Debug))]
-#[derive(Clone, Copy, PartialEq, Eq)]
+// TODO: Add a ufmt debug implementation for use by process binaries.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReturnVariant(u32);
 
 impl From<u32> for ReturnVariant {

--- a/unittest/src/command_return.rs
+++ b/unittest/src/command_return.rs
@@ -1,0 +1,164 @@
+//! Safe constructors for `libtock_platform::CommandReturn` variants.
+
+use libtock_platform::{return_variant, CommandReturn, ErrorCode};
+
+pub fn failure(error_code: ErrorCode) -> CommandReturn {
+    // Safety: return_variant is a failure, so r1 must be a valid ErrorCode,
+    // which is enforced by error_code's type.
+    unsafe { CommandReturn::new(return_variant::FAILURE, error_code as u32, 0, 0) }
+}
+
+pub fn failure_u32(error_code: ErrorCode, value: u32) -> CommandReturn {
+    // Safety: return_variant is a failure, so r1 must be a valid ErrorCode,
+    // which is enforced by error_code's type.
+    unsafe { CommandReturn::new(return_variant::FAILURE_U32, error_code as u32, value, 0) }
+}
+
+pub fn failure_2_u32(error_code: ErrorCode, value0: u32, value1: u32) -> CommandReturn {
+    unsafe {
+        // Safety: return_variant is a failure, so r1 must be a valid ErrorCode,
+        // which is enforced by error_code's type.
+        CommandReturn::new(
+            return_variant::FAILURE_2_U32,
+            error_code as u32,
+            value0,
+            value1,
+        )
+    }
+}
+
+pub fn failure_u64(error_code: ErrorCode, value: u64) -> CommandReturn {
+    unsafe {
+        // Safety: return_variant is a failure, so r1 must be a valid ErrorCode,
+        // which is enforced by error_code's type.
+        CommandReturn::new(
+            return_variant::FAILURE_U64,
+            error_code as u32,
+            value as u32,
+            (value >> 32) as u32,
+        )
+    }
+}
+
+pub fn success() -> CommandReturn {
+    // Safety: return_variant is a success so there are no other invariants to
+    // maintain.
+    unsafe { CommandReturn::new(return_variant::SUCCESS, 0, 0, 0) }
+}
+
+pub fn success_u32(value: u32) -> CommandReturn {
+    // Safety: return_variant is a success so there are no other invariants to
+    // maintain.
+    unsafe { CommandReturn::new(return_variant::SUCCESS_U32, value, 0, 0) }
+}
+
+pub fn success_2_u32(value0: u32, value1: u32) -> CommandReturn {
+    // Safety: return_variant is a success so there are no other invariants to
+    // maintain.
+    unsafe { CommandReturn::new(return_variant::SUCCESS_2_U32, value0, value1, 0) }
+}
+
+pub fn success_u64(value: u64) -> CommandReturn {
+    unsafe {
+        // Safety: return_variant is a success so there are no other invariants
+        // to maintain.
+        CommandReturn::new(
+            return_variant::SUCCESS_U64,
+            value as u32,
+            (value >> 32) as u32,
+            0,
+        )
+    }
+}
+
+pub fn success_3_u32(value0: u32, value1: u32, value2: u32) -> CommandReturn {
+    // Safety: return_variant is a success so there are no other invariants to
+    // maintain.
+    unsafe { CommandReturn::new(return_variant::SUCCESS_3_U32, value0, value1, value2) }
+}
+
+pub fn success_u32_u64(value0: u32, value1: u64) -> CommandReturn {
+    unsafe {
+        // Safety: return_variant is a success so there are no other invariants
+        // to maintain.
+        CommandReturn::new(
+            return_variant::SUCCESS_U32_U64,
+            value0,
+            value1 as u32,
+            (value1 >> 32) as u32,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failure_test() {
+        assert_eq!(
+            failure(ErrorCode::Fail).get_failure(),
+            Some(ErrorCode::Fail)
+        );
+    }
+
+    #[test]
+    fn failure_u32_test() {
+        assert_eq!(
+            failure_u32(ErrorCode::Busy, 42).get_failure_u32(),
+            Some((ErrorCode::Busy, 42))
+        );
+    }
+
+    #[test]
+    fn failure_2_u32_test() {
+        assert_eq!(
+            failure_2_u32(ErrorCode::Off, 31, 27).get_failure_2_u32(),
+            Some((ErrorCode::Off, 31, 27))
+        );
+    }
+
+    #[test]
+    fn failure_u64_test() {
+        assert_eq!(
+            failure_u64(ErrorCode::Size, 0x1111_2222_3333_4444).get_failure_u64(),
+            Some((ErrorCode::Size, 0x1111_2222_3333_4444))
+        );
+    }
+
+    #[test]
+    fn success_test() {
+        assert!(success().is_success());
+    }
+
+    #[test]
+    fn success_u32_test() {
+        assert_eq!(success_u32(1618).get_success_u32(), Some(1618));
+    }
+
+    #[test]
+    fn success_2_u32_test() {
+        assert_eq!(success_2_u32(1, 2).get_success_2_u32(), Some((1, 2)));
+    }
+
+    #[test]
+    fn success_u64_test() {
+        assert_eq!(
+            success_u64(0x1111_2222_3333_4444).get_success_u64(),
+            Some(0x1111_2222_3333_4444)
+        );
+    }
+
+    #[test]
+    fn success_3_u32_test() {
+        assert_eq!(success_3_u32(3, 5, 8).get_success_3_u32(), Some((3, 5, 8)));
+    }
+
+    #[test]
+    fn success_u32_u64_test() {
+        assert_eq!(
+            success_u32_u64(13, 0x1111_2222_3333_4444).get_success_u32_u64(),
+            Some((13, 0x1111_2222_3333_4444))
+        );
+    }
+}

--- a/unittest/src/lib.rs
+++ b/unittest/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(unsafe_op_in_unsafe_fn)]
 
+pub mod command_return;
 mod expected_syscall;
 mod kernel;
 mod syscall_log;


### PR DESCRIPTION
This makes the following change to `CommandReturn`, which are needed by my implementation of the Command system call and its tests:

1. Implements `Debug`. This is not a replacement for `ufmt`-based debugging, but rather to support unit tests (e.g. `assert_eq!`).
2. Changes the register values from `usize` to `u32`, as `RawSyscalls` no longer returns its registers as `usize`s. I discovered that code that interacts with `CommandReturn` is cleaner if we store `u32`s in `CommandReturn` rather than `Register`s.
3. `new` is now `pub` rather than `pub(crate)`, as `libtock_unittest` needs to create `CommandReturn` values.
4. I added `CommandReturn::raw_values`, which will be used by `libtock_unittest` to transform `CommandReturn`s from fake drivers and expected syscalls into register values for `RawSyscalls`.
5. I added safe `CommandReturn` constructors to `libtock_unittest`. `libtock_platform` intentionally does not expose safe constructors, as a process binary should only create a `CommandReturn` by calling the Command system call. However, `libtock_unittest` and unit tests based on it need to create `CommandReturn` values as well, so I added safe constructors.

The combination of 1 and 5 required me to add `Debug` to `ErrorCode` and `ReturnVariant`, so I did that as well.