### PR TITLE
Implement Yield in `libtock_unittest::fake::Kernel`.

### DIFF
--- a/platform/src/yield_types.rs
+++ b/platform/src/yield_types.rs
@@ -10,6 +10,6 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum YieldNoWaitReturn {
-    NoCallback = 0,
-    Callback = 1,
+    NoUpcall = 0,
+    Upcall = 1,
 }

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -2,21 +2,33 @@
 /// a particular system call. An example use case is error injection: unit tests
 /// can add a `ExpectedSyscall` to the fake kernel's queue to insert errors in
 /// order to test error handling code.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ExpectedSyscall {
-    // TODO: Add Yield.
-// TODO: Add Subscribe.
-// TODO: Add Command.
-// TODO: Add Allow.
-// TODO: Add Memop.
-// TODO: Add Exit.
+    // -------------------------------------------------------------------------
+    // Yield
+    // -------------------------------------------------------------------------
+    YieldNoWait {
+        /// If not `None`, `yield-no-wait` will set the return value to the
+        /// specified value. If `None`, `yield-no-wait` will set the return
+        /// value based on whether or not an upcall was run.
+        override_return: Option<libtock_platform::YieldNoWaitReturn>,
+    },
+
+    YieldWait {
+        /// If true, yield_wait will skip executing a upcall.
+        skip_upcall: bool,
+    },
+    // TODO: Add Subscribe.
+    // TODO: Add Command.
+    // TODO: Add Allow.
+    // TODO: Add Memop.
+    // TODO: Add Exit.
 }
 
 impl ExpectedSyscall {
     // Panics with a message describing that the named system call was called
     // instead of the expected system call. Used by fake::Kernel to report
     // incorrect system calls.
-    #[allow(unused)] // TODO: Remove when a system call is implemented.
     pub(crate) fn panic_wrong_call(&self, called: &str) -> ! {
         // TODO: Implement Display for ExpectedSyscall and replace {:?} with {}
         panic!(

--- a/unittest/src/kernel/mod.rs
+++ b/unittest/src/kernel/mod.rs
@@ -8,7 +8,10 @@ use std::cell::Cell;
 // TODO: Add Subscribe.
 mod raw_syscalls_impl;
 mod thread_local;
-// TODO: Add Yield.
+mod yield_impl;
+
+#[cfg(test)]
+mod yield_impl_tests;
 
 /// A fake implementation of the Tock kernel. Provides
 /// `libtock_platform::Syscalls` by implementing

--- a/unittest/src/kernel/yield_impl.rs
+++ b/unittest/src/kernel/yield_impl.rs
@@ -1,0 +1,41 @@
+//! Implementations of Yield system calls.
+
+use crate::kernel::thread_local::get_kernel;
+use crate::{ExpectedSyscall, SyscallLogEntry};
+
+/// # Safety
+/// It must be valid to write a `libtock_platform::YieldNoWaitReturn` into the
+/// value pointed to by `return_ptr`. When `yield_no_wait` returns, the value
+/// pointed to by `return_ptr` will be set.
+pub(super) unsafe fn yield_no_wait(return_ptr: *mut libtock_platform::YieldNoWaitReturn) {
+    let kernel = get_kernel().expect("yield-no-wait called but no fake::Kernel exists");
+    kernel.log_syscall(SyscallLogEntry::YieldNoWait);
+    let override_return = match kernel.pop_expected_syscall() {
+        None => None,
+        Some(ExpectedSyscall::YieldNoWait { override_return }) => override_return,
+        Some(expected_syscall) => expected_syscall.panic_wrong_call("yield-no-wait"),
+    };
+
+    // TODO: Add the Driver trait and implement driver support, including
+    // upcalls.
+    let upcall_ran = libtock_platform::YieldNoWaitReturn::NoUpcall;
+
+    unsafe {
+        core::ptr::write(return_ptr, override_return.unwrap_or(upcall_ran));
+    }
+}
+
+pub(super) fn yield_wait() {
+    let kernel = get_kernel().expect("yield-wait called but no fake::Kernel exists");
+    kernel.log_syscall(SyscallLogEntry::YieldWait);
+    let skip_upcall = match kernel.pop_expected_syscall() {
+        None => false,
+        Some(ExpectedSyscall::YieldWait { skip_upcall }) => skip_upcall,
+        Some(expected_syscall) => expected_syscall.panic_wrong_call("yield-wait"),
+    };
+    if skip_upcall {
+        return;
+    }
+
+    unimplemented!("TODO: Implement upcalls");
+}

--- a/unittest/src/kernel/yield_impl_tests.rs
+++ b/unittest/src/kernel/yield_impl_tests.rs
@@ -1,0 +1,178 @@
+use crate::kernel::raw_syscalls_impl::assert_valid;
+use crate::kernel::yield_impl::*;
+use crate::{fake, ExpectedSyscall, SyscallLogEntry};
+use libtock_platform::{RawSyscalls, YieldNoWaitReturn};
+use std::panic::catch_unwind;
+
+#[test]
+fn yield_no_wait_test() {
+    // Test calling yield_no_wait with no fake::Kernel present.
+    let result = catch_unwind(|| {
+        let mut return_value = core::mem::MaybeUninit::<YieldNoWaitReturn>::uninit();
+        unsafe {
+            yield_no_wait(return_value.as_mut_ptr());
+        }
+    });
+    assert!(result
+        .expect_err("failed to catch missing fake::Kernel")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("no fake::Kernel"));
+
+    let kernel = fake::Kernel::new("yield_no_wait_test");
+
+    // Test yield_no_wait with an empty upcall queue and empty expected syscall
+    // queue.
+    let mut return_value = core::mem::MaybeUninit::<YieldNoWaitReturn>::uninit();
+    unsafe {
+        yield_no_wait(return_value.as_mut_ptr());
+    }
+    let return_value = unsafe { return_value.assume_init() };
+    assert_valid(return_value);
+    assert_eq!(return_value, YieldNoWaitReturn::NoUpcall);
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldNoWait]);
+
+    // Test yield_no_wait with a return override in an expected syscall.
+    kernel.add_expected_syscall(ExpectedSyscall::YieldNoWait {
+        override_return: Some(YieldNoWaitReturn::Upcall),
+    });
+    let mut return_value = core::mem::MaybeUninit::<YieldNoWaitReturn>::uninit();
+    unsafe {
+        yield_no_wait(return_value.as_mut_ptr());
+    }
+    let return_value = unsafe { return_value.assume_init() };
+    assert_valid(return_value);
+    assert_eq!(return_value, YieldNoWaitReturn::Upcall);
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldNoWait]);
+
+    // Test yield_no_wait with a mismatched expected syscall.
+    kernel.add_expected_syscall(ExpectedSyscall::YieldWait { skip_upcall: false });
+    let result = catch_unwind(|| {
+        let mut return_value = core::mem::MaybeUninit::<YieldNoWaitReturn>::uninit();
+        unsafe {
+            yield_no_wait(return_value.as_mut_ptr());
+        }
+    });
+    assert!(result
+        .expect_err("failed to catch mismatched expected syscall")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("yield-no-wait was called instead"));
+}
+
+#[test]
+fn yield_wait_test() {
+    // Test calling yield_wait with no fake::Kernel present.
+    assert!(catch_unwind(yield_wait)
+        .expect_err("failed to catch missing fake::Kernel")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("no fake::Kernel"));
+
+    let kernel = fake::Kernel::new("yield_wait_test");
+
+    // Test yield_wait with a mismatched expected syscall.
+    kernel.add_expected_syscall(ExpectedSyscall::YieldNoWait {
+        override_return: None,
+    });
+    assert!(catch_unwind(yield_wait)
+        .expect_err("failed to catch mismatched expected syscall")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("yield-wait was called instead"));
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldWait]);
+
+    // Test yield_wait with a skipped upcall in an expected syscall.
+    kernel.add_expected_syscall(ExpectedSyscall::YieldWait { skip_upcall: true });
+    yield_wait();
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldWait]);
+}
+
+// TODO: Move the yield1 and yield2 tests into a raw_syscalls_impl test module,
+// once all system calls have been implemented.
+
+#[test]
+fn yield1() {
+    let kernel = fake::Kernel::new("yield1");
+
+    #[cfg(target_pointer_width = "64")]
+    {
+        let result =
+            catch_unwind(|| unsafe { fake::Kernel::yield1([(u32::MAX as usize + 1).into()]) });
+        assert!(result
+            .expect_err("failed to catch too large yield ID")
+            .downcast_ref::<String>()
+            .expect("wrong panic payload type")
+            .contains("too-large Yield ID"));
+    }
+
+    // Call yield-no-wait through yield1, which is not valid.
+    let result = catch_unwind(|| unsafe { fake::Kernel::yield1([0u32.into()]) });
+    assert!(result
+        .expect_err("failed to catch yield-no-wait without arg")
+        .downcast_ref::<&'static str>()
+        .expect("wrong panic payload type")
+        .contains("yield-no-wait called without an argument"));
+
+    // Test a successful invocation of yield-wait.
+    kernel.add_expected_syscall(ExpectedSyscall::YieldWait { skip_upcall: true });
+    unsafe {
+        fake::Kernel::yield1([1u32.into()]);
+    }
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldWait]);
+
+    // Call yield1 with a yield ID that is unknown but which fits in a u32.
+    let result = catch_unwind(|| unsafe { fake::Kernel::yield1([2u32.into()]) });
+    assert!(result
+        .expect_err("failed to catch incorrect yield ID -- new ID added?")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("unknown yield ID"));
+}
+
+// Tests RawSyscalls::yield2's handling of bad yield IDs.
+#[test]
+fn yield2() {
+    let kernel = fake::Kernel::new("yield2");
+
+    #[cfg(target_pointer_width = "64")]
+    {
+        let result = catch_unwind(|| unsafe {
+            fake::Kernel::yield2([(u32::MAX as usize + 1).into(), 0u32.into()])
+        });
+        assert!(result
+            .expect_err("failed to catch too large yield ID")
+            .downcast_ref::<String>()
+            .expect("wrong panic payload type")
+            .contains("too-large Yield ID"));
+    }
+
+    // Test a successful invocation of yield-no-wait.
+    kernel.add_expected_syscall(ExpectedSyscall::YieldNoWait {
+        override_return: Some(YieldNoWaitReturn::Upcall),
+    });
+    let mut return_value = core::mem::MaybeUninit::<YieldNoWaitReturn>::uninit();
+    unsafe {
+        fake::Kernel::yield2([0u32.into(), return_value.as_mut_ptr().into()]);
+    }
+    let return_value = unsafe { return_value.assume_init() };
+    assert_valid(return_value);
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldNoWait]);
+    assert_eq!(return_value, YieldNoWaitReturn::Upcall);
+
+    // Call yield-wait through yield2, which should be rejected.
+    let result = catch_unwind(|| unsafe { fake::Kernel::yield2([1u32.into(), 0u32.into()]) });
+    assert!(result
+        .expect_err("failed to catch yield-wait with arg")
+        .downcast_ref::<&'static str>()
+        .expect("wrong panic payload type")
+        .contains("yield-wait called with an argument"));
+
+    // Call yield2 with a yield ID that is unknown but which fits in a u32.
+    let result = catch_unwind(|| unsafe { fake::Kernel::yield2([2u32.into(), 0u32.into()]) });
+    assert!(result
+        .expect_err("failed to catch incorrect yield ID -- new ID added?")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("unknown yield ID"));
+}

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -1,10 +1,15 @@
 /// SyscallLogEntry represents a system call made during test execution.
 #[derive(Debug, PartialEq)]
 pub enum SyscallLogEntry {
-    // TODO: Add Yield.
-// TODO: Add Subscribe.
-// TODO: Add Command.
-// TODO: Add Allow.
-// TODO: Add Memop.
-// TODO: Add Exit.
+    // -------------------------------------------------------------------------
+    // Yield
+    // -------------------------------------------------------------------------
+    YieldNoWait,
+
+    YieldWait,
+    // TODO: Add Subscribe.
+    // TODO: Add Command.
+    // TODO: Add Allow.
+    // TODO: Add Memop.
+    // TODO: Add Exit.
 }


### PR DESCRIPTION
This Yield implementation will be used by the unit tests of the `libtock_platform::Syscalls` yield calls. This implementation is currently partial, as the `fake::Driver` trait and upcall queue have not been designed yet.

I also changed `libtock_platform::YieldNoWaitReturn` to use the new upcall terminology rather than callback.