### PR TITLE
Move the class ID and yield op constants into a new `constants` module in `libtock_platform`.

### DIFF
--- a/platform/src/constants.rs
+++ b/platform/src/constants.rs
@@ -1,0 +1,15 @@
+//! Defines constants shared between multiple `libtock-rs` crates.
+
+pub mod syscall_class {
+    pub const SUBSCRIBE: usize = 1;
+    pub const COMMAND: usize = 2;
+    pub const RW_ALLOW: usize = 3;
+    pub const RO_ALLOW: usize = 4;
+    pub const MEMOP: usize = 5;
+    pub const EXIT: usize = 6;
+}
+
+pub mod yield_op {
+    pub const NO_WAIT: u32 = 0;
+    pub const WAIT: u32 = 1;
+}

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod async_traits;
 mod command_return;
+mod constants;
 mod error_code;
 mod raw_syscalls;
 mod register;
@@ -13,6 +14,7 @@ mod yield_types;
 
 pub use async_traits::{CallbackContext, FreeCallback, Locator, MethodCallback};
 pub use command_return::CommandReturn;
+pub use constants::{syscall_class, yield_op};
 pub use error_code::ErrorCode;
 pub use raw_syscalls::RawSyscalls;
 pub use register::Register;

--- a/platform/src/syscalls_impl.rs
+++ b/platform/src/syscalls_impl.rs
@@ -1,11 +1,6 @@
 //! Implements `Syscalls` for all types that implement `RawSyscalls`.
 
-use crate::{RawSyscalls, Syscalls, YieldNoWaitReturn};
-
-mod yield_op {
-    pub const NO_WAIT: u32 = 0;
-    pub const WAIT: u32 = 1;
-}
+use crate::{yield_op, RawSyscalls, Syscalls, YieldNoWaitReturn};
 
 impl<S: RawSyscalls> Syscalls for S {
     // -------------------------------------------------------------------------

--- a/runtime/asm/start_prototype.rs
+++ b/runtime/asm/start_prototype.rs
@@ -22,12 +22,6 @@ struct RtHeader {
     bss_start: *mut u8,
 }
 
-mod class_id {
-    pub const COMMAND: usize = 2;
-    pub const MEMOP: usize = 5;
-    pub const EXIT: usize = 6;
-}
-
 #[link_section = ".start"]
 #[no_mangle]
 extern "C" fn start_prototype(
@@ -37,7 +31,7 @@ extern "C" fn start_prototype(
     _app_break: usize,
 ) -> ! {
     use crate::TockSyscalls;
-    use libtock_platform::RawSyscalls;
+    use libtock_platform::{RawSyscalls, syscall_class};
 
     let pc: usize;
     unsafe {
@@ -50,20 +44,20 @@ extern "C" fn start_prototype(
         // Binary is in an incorrect location: report an error via
         // LowLevelDebug then exit.
         unsafe {
-            TockSyscalls::syscall4::<class_id::COMMAND>([
+            TockSyscalls::syscall4::<syscall_class::COMMAND>([
                 8 as *mut (),
                 1 as *mut (),
                 2 as *mut (),
                 0 as *mut (),
             ]);
-            TockSyscalls::syscall2::<class_id::EXIT>([0 as *mut (), 0 as *mut ()]);
+            TockSyscalls::syscall2::<syscall_class::EXIT>([0 as *mut (), 0 as *mut ()]);
         }
     }
 
     // Set the app break.
     // TODO: Replace with Syscalls::memop_brk() when that is implemented.
     unsafe {
-        TockSyscalls::syscall2::<class_id::MEMOP>([0 as *mut (), rt_header.initial_break]);
+        TockSyscalls::syscall2::<syscall_class::MEMOP>([0 as *mut (), rt_header.initial_break]);
     }
 
     // Set the stack pointer.

--- a/unittest/src/kernel/raw_syscalls_impl.rs
+++ b/unittest/src/kernel/raw_syscalls_impl.rs
@@ -1,13 +1,4 @@
-use libtock_platform::{RawSyscalls, Register};
-
-mod class_id {
-    pub const SUBSCRIBE: usize = 1;
-    pub const COMMAND: usize = 2;
-    pub const RW_ALLOW: usize = 3;
-    pub const RO_ALLOW: usize = 4;
-    pub const MEMOP: usize = 5;
-    pub const EXIT: usize = 6;
-}
+use libtock_platform::{syscall_class, RawSyscalls, Register};
 
 unsafe impl RawSyscalls for super::Kernel {
     unsafe fn yield1([Register(_r0)]: [Register; 1]) {
@@ -20,7 +11,7 @@ unsafe impl RawSyscalls for super::Kernel {
 
     unsafe fn syscall1<const CLASS: usize>([Register(_r0)]: [Register; 1]) -> [Register; 2] {
         match CLASS {
-            class_id::MEMOP => unimplemented!("TODO: Add Memop"),
+            syscall_class::MEMOP => unimplemented!("TODO: Add Memop"),
             _ => panic!("Unknown syscall1 call. Class: {}", CLASS),
         }
     }
@@ -29,8 +20,8 @@ unsafe impl RawSyscalls for super::Kernel {
         [Register(_r0), Register(_r1)]: [Register; 2],
     ) -> [Register; 2] {
         match CLASS {
-            class_id::MEMOP => unimplemented!("TODO: Add Memop"),
-            class_id::EXIT => unimplemented!("TODO: Add Exit"),
+            syscall_class::MEMOP => unimplemented!("TODO: Add Memop"),
+            syscall_class::EXIT => unimplemented!("TODO: Add Exit"),
             _ => panic!("Unknown syscall2 call. Class: {}", CLASS),
         }
     }
@@ -39,10 +30,10 @@ unsafe impl RawSyscalls for super::Kernel {
         [Register(_r0), Register(_r1), Register(_r2), Register(_r3)]: [Register; 4],
     ) -> [Register; 4] {
         match CLASS {
-            class_id::SUBSCRIBE => unimplemented!("TODO: Add Subscribe"),
-            class_id::COMMAND => unimplemented!("TODO: Add Command"),
-            class_id::RW_ALLOW => unimplemented!("TODO: Add Allow"),
-            class_id::RO_ALLOW => unimplemented!("TODO: Add Allow"),
+            syscall_class::SUBSCRIBE => unimplemented!("TODO: Add Subscribe"),
+            syscall_class::COMMAND => unimplemented!("TODO: Add Command"),
+            syscall_class::RW_ALLOW => unimplemented!("TODO: Add Allow"),
+            syscall_class::RO_ALLOW => unimplemented!("TODO: Add Allow"),
             _ => panic!("Unknown syscall4 call. Class: {}", CLASS),
         }
     }


### PR DESCRIPTION
I realized I was developing redundant definitions of system call class IDs and yield operations. `libtock_platform` needs them to implement `Syscalls`, `libtock_unittest` implements them to implement `RawSyscalls`, and `libtock_unittest`'s internal unit tests needs them to invoke `RawSyscalls`.

To try to avoid this duplication, I decided to add the constants to `libtock_platform`, so they would be available to all `libtock-rs` crates.

I will manually de-conflict this PR with my other outstanding PRs before I merge them.