### PR TITLE
Add a test that verifies `ErrorCode` includes every possible value.

### DIFF
--- a/platform/src/error_code_tests.rs
+++ b/platform/src/error_code_tests.rs
@@ -1,0 +1,9 @@
+// Verifies that `ErrorCode` represents every valid value in the range
+// [1, 1023].
+#[cfg(miri)]
+#[test]
+fn error_code_range() {
+    for value in 1..=1023u16 {
+        unsafe { *(&value as *const u16 as *const crate::ErrorCode) };
+    }
+}

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -22,3 +22,6 @@ pub use yield_types::YieldNoWaitReturn;
 
 #[cfg(test)]
 mod command_return_tests;
+
+#[cfg(test)]
+mod error_code_tests;


### PR DESCRIPTION
The syscalls TRD says an `ErrorCode` can have any value in [1, 1023]. This test uses Miri to confirm that the `ErrorCode` enum is not missing any of these values.

I verified this test works by changing the `1023` to `1024`, which gave the following error:

```
error: Undefined Behavior: type validation failed: encountered 0x0400 at .<enum-tag>, but expected a valid enum tag
 --> platform/src/error_code_tests.rs:7:18
  |
7 |         unsafe { *(&value as *const u16 as *const crate::ErrorCode) };
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type validation failed: encountered 0x0400 at .<enum-tag>, but expected a valid enum tag
  |
  = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
  = help: see https://doc.rust-lang.org/nightly/reference/behavior-considered-undefined.html for further information
```