### PR TITLE
Implement Command in `libtock_unittest::fake::Kernel`.

### DIFF
--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -2,14 +2,29 @@
 /// a particular system call. An example use case is error injection: unit tests
 /// can add a `ExpectedSyscall` to the fake kernel's queue to insert errors in
 /// order to test error handling code.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ExpectedSyscall {
     // TODO: Add Yield.
-// TODO: Add Subscribe.
-// TODO: Add Command.
-// TODO: Add Allow.
-// TODO: Add Memop.
-// TODO: Add Exit.
+    // TODO: Add Subscribe.
+
+    // -------------------------------------------------------------------------
+    // Command
+    // -------------------------------------------------------------------------
+    Command {
+        // Matched values: the command must give the specified driver_id,
+        // command_id, argument0, and argument1 values.
+        driver_id: u32,
+        command_id: u32,
+        argument0: u32,
+        argument1: u32,
+
+        // If not None, the output of the driver will be replaced with the given
+        // return value.
+        override_return: Option<libtock_platform::CommandReturn>,
+    },
+    // TODO: Add Allow.
+    // TODO: Add Memop.
+    // TODO: Add Exit.
 }
 
 impl ExpectedSyscall {

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -36,7 +36,6 @@ pub enum ExpectedSyscall {
         // return value.
         override_return: Option<libtock_platform::CommandReturn>,
     },
-
     // TODO: Add Allow.
     // TODO: Add Memop.
     // TODO: Add Exit.

--- a/unittest/src/kernel/command_impl.rs
+++ b/unittest/src/kernel/command_impl.rs
@@ -1,0 +1,69 @@
+//! `fake::Kernel`'s implementation of the Command system call.
+
+use crate::kernel::thread_local::get_kernel;
+use crate::{command_return, ExpectedSyscall, SyscallLogEntry};
+use libtock_platform::{ErrorCode, Register};
+use std::convert::TryInto;
+
+pub(super) fn command(
+    driver_id: Register,
+    command_id: Register,
+    argument0: Register,
+    argument1: Register,
+) -> [Register; 4] {
+    let driver_id = driver_id.try_into().expect("Too large driver ID");
+    let command_id = command_id.try_into().expect("Too large command ID");
+    let argument0 = argument0.try_into().expect("Too large argument 0");
+    let argument1 = argument1.try_into().expect("Too large argument 1");
+    let kernel = get_kernel().expect("Command called but no fake::Kernel exists");
+    kernel.log_syscall(SyscallLogEntry::Command {
+        driver_id,
+        command_id,
+        argument0,
+        argument1,
+    });
+    // Check for an expected syscall entry. Sets override_return to None if the
+    // expected syscall queue is empty or if it expected this syscall but did
+    // not specify a return override. Panics if a different syscall was expected
+    // (either a non-Command syscall, or a Command call with different
+    // arguments).
+    #[allow(unreachable_patterns)] // TODO: Remove when 2nd syscall done.
+    let override_return = match kernel.pop_expected_syscall() {
+        None => None,
+        Some(ExpectedSyscall::Command {
+            driver_id: expected_driver_id,
+            command_id: expected_command_id,
+            argument0: expected_argument0,
+            argument1: expected_argument1,
+            override_return,
+        }) => {
+            assert_eq!(
+                driver_id, expected_driver_id,
+                "expected different driver_id"
+            );
+            assert_eq!(
+                command_id, expected_command_id,
+                "expected different command_id"
+            );
+            assert_eq!(
+                argument0, expected_argument0,
+                "expected different argument0"
+            );
+            assert_eq!(
+                argument1, expected_argument1,
+                "expected different argument1"
+            );
+            override_return
+        }
+        Some(expected_syscall) => expected_syscall.panic_wrong_call("Command"),
+    };
+
+    // TODO: Add the Driver trait and implement driver support.
+    let driver_return = command_return::failure(ErrorCode::NoSupport);
+
+    // Convert the override return value (or the driver return value if no
+    // override is present) into the representative register values.
+    let (return_variant, r1, r2, r3) = override_return.unwrap_or(driver_return).raw_values();
+    let r0: u32 = return_variant.into();
+    [r0.into(), r1.into(), r2.into(), r3.into()]
+}

--- a/unittest/src/kernel/command_impl_tests.rs
+++ b/unittest/src/kernel/command_impl_tests.rs
@@ -1,6 +1,6 @@
 use super::command_impl::*;
 use crate::{command_return, fake, ExpectedSyscall, SyscallLogEntry};
-use libtock_platform::{return_variant, RawSyscalls, ReturnVariant};
+use libtock_platform::{return_variant, syscall_class, RawSyscalls, ReturnVariant};
 use std::convert::TryInto;
 use std::panic::catch_unwind;
 
@@ -10,7 +10,7 @@ use std::panic::catch_unwind;
 // Tests command with expected syscalls that don't match this command call.
 #[test]
 fn expected_wrong_command() {
-    let kernel = fake::Kernel::new("expected_wrong_command");
+    let kernel = fake::Kernel::new();
     let expected_syscall = ExpectedSyscall::Command {
         driver_id: 1,
         command_id: 1,
@@ -68,7 +68,7 @@ fn no_kernel() {
 
 #[test]
 fn override_return() {
-    let kernel = fake::Kernel::new("override_return");
+    let kernel = fake::Kernel::new();
     kernel.add_expected_syscall(ExpectedSyscall::Command {
         driver_id: 1,
         command_id: 2,
@@ -94,9 +94,14 @@ fn override_return() {
 // completed, to avoid git conflicts.
 #[test]
 fn syscall4() {
-    let kernel = fake::Kernel::new("syscall4");
+    let kernel = fake::Kernel::new();
     unsafe {
-        fake::Kernel::syscall4::<2>([1u32.into(), 2u32.into(), 3u32.into(), 4u32.into()]);
+        fake::Kernel::syscall4::<{ syscall_class::COMMAND }>([
+            1u32.into(),
+            2u32.into(),
+            3u32.into(),
+            4u32.into(),
+        ]);
     }
     assert_eq!(
         kernel.take_syscall_log(),
@@ -112,7 +117,7 @@ fn syscall4() {
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn too_large_argument0() {
-    let _kernel = fake::Kernel::new("too_large_argument0");
+    let _kernel = fake::Kernel::new();
     let result = catch_unwind(|| {
         command(
             1u32.into(),
@@ -131,7 +136,7 @@ fn too_large_argument0() {
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn too_large_argument1() {
-    let _kernel = fake::Kernel::new("too_large_argument1");
+    let _kernel = fake::Kernel::new();
     let result = catch_unwind(|| {
         command(
             1u32.into(),
@@ -150,7 +155,7 @@ fn too_large_argument1() {
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn too_large_command_id() {
-    let _kernel = fake::Kernel::new("too_large_command_id");
+    let _kernel = fake::Kernel::new();
     let result = catch_unwind(|| {
         command(
             1u32.into(),
@@ -169,7 +174,7 @@ fn too_large_command_id() {
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn too_large_driver_id() {
-    let _kernel = fake::Kernel::new("too_large_driver_id");
+    let _kernel = fake::Kernel::new();
     let result = catch_unwind(|| {
         command(
             (u32::MAX as usize + 1).into(),

--- a/unittest/src/kernel/command_impl_tests.rs
+++ b/unittest/src/kernel/command_impl_tests.rs
@@ -1,0 +1,188 @@
+use super::command_impl::*;
+use crate::{command_return, fake, ExpectedSyscall, SyscallLogEntry};
+use libtock_platform::{return_variant, RawSyscalls, ReturnVariant};
+use std::convert::TryInto;
+use std::panic::catch_unwind;
+
+// TODO: When another system call is implemented, add a test for the case
+// where a different system call class is expected.
+
+// Tests command with expected syscalls that don't match this command call.
+#[test]
+fn expected_wrong_command() {
+    let kernel = fake::Kernel::new("expected_wrong_command");
+    let expected_syscall = ExpectedSyscall::Command {
+        driver_id: 1,
+        command_id: 1,
+        argument0: 1,
+        argument1: 1,
+        override_return: None,
+    };
+
+    kernel.add_expected_syscall(expected_syscall);
+    assert!(
+        catch_unwind(|| command(2u32.into(), 1u32.into(), 1u32.into(), 1u32.into()))
+            .expect_err("failed to catch wrong driver_id")
+            .downcast_ref::<String>()
+            .expect("wrong panic payload type")
+            .contains("expected different driver_id")
+    );
+
+    kernel.add_expected_syscall(expected_syscall);
+    assert!(
+        catch_unwind(|| command(1u32.into(), 2u32.into(), 1u32.into(), 1u32.into()))
+            .expect_err("failed to catch wrong command_id")
+            .downcast_ref::<String>()
+            .expect("wrong panic payload type")
+            .contains("expected different command_id")
+    );
+
+    kernel.add_expected_syscall(expected_syscall);
+    assert!(
+        catch_unwind(|| command(1u32.into(), 1u32.into(), 2u32.into(), 1u32.into()))
+            .expect_err("failed to catch wrong argument0")
+            .downcast_ref::<String>()
+            .expect("wrong panic payload type")
+            .contains("expected different argument0")
+    );
+
+    kernel.add_expected_syscall(expected_syscall);
+    assert!(
+        catch_unwind(|| command(1u32.into(), 1u32.into(), 1u32.into(), 2u32.into()))
+            .expect_err("failed to catch wrong argument1")
+            .downcast_ref::<String>()
+            .expect("wrong panic payload type")
+            .contains("expected different argument1")
+    );
+}
+
+#[test]
+fn no_kernel() {
+    let result = catch_unwind(|| command(1u32.into(), 1u32.into(), 0u32.into(), 0u32.into()));
+    assert!(result
+        .expect_err("failed to catch missing kernel")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("no fake::Kernel exists"));
+}
+
+#[test]
+fn override_return() {
+    let kernel = fake::Kernel::new("override_return");
+    kernel.add_expected_syscall(ExpectedSyscall::Command {
+        driver_id: 1,
+        command_id: 2,
+        argument0: 3,
+        argument1: 4,
+        override_return: Some(command_return::success_3_u32(1, 2, 3)),
+    });
+    let [r0, r1, r2, r3] = command(1u32.into(), 2u32.into(), 3u32.into(), 4u32.into());
+    let r0: u32 = r0.try_into().expect("too large r0");
+    let r1: u32 = r1.try_into().expect("too large r1");
+    let r2: u32 = r2.try_into().expect("too large r2");
+    let r3: u32 = r3.try_into().expect("too large r3");
+    let return_variant: ReturnVariant = r0.into();
+    assert_eq!(return_variant, return_variant::SUCCESS_3_U32);
+    assert_eq!(r1, 1);
+    assert_eq!(r2, 2);
+    assert_eq!(r3, 3);
+}
+
+// Test that fake::Kernel's implementation of RawSyscalls correctly forwards
+// a command to `command`.
+// TODO: Migrate into raw_syscalls_impl.rs when the other system calls are
+// completed, to avoid git conflicts.
+#[test]
+fn syscall4() {
+    let kernel = fake::Kernel::new("syscall4");
+    unsafe {
+        fake::Kernel::syscall4::<2>([1u32.into(), 2u32.into(), 3u32.into(), 4u32.into()]);
+    }
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::Command {
+            driver_id: 1,
+            command_id: 2,
+            argument0: 3,
+            argument1: 4,
+        }]
+    );
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_argument0() {
+    let _kernel = fake::Kernel::new("too_large_argument0");
+    let result = catch_unwind(|| {
+        command(
+            1u32.into(),
+            1u32.into(),
+            (u32::MAX as usize + 1).into(),
+            0u32.into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large argument0")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large argument 0"));
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_argument1() {
+    let _kernel = fake::Kernel::new("too_large_argument1");
+    let result = catch_unwind(|| {
+        command(
+            1u32.into(),
+            1u32.into(),
+            0u32.into(),
+            (u32::MAX as usize + 1).into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large argument1")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large argument 1"));
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_command_id() {
+    let _kernel = fake::Kernel::new("too_large_command_id");
+    let result = catch_unwind(|| {
+        command(
+            1u32.into(),
+            (u32::MAX as usize + 1).into(),
+            0u32.into(),
+            0u32.into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large command ID")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large command ID"));
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_driver_id() {
+    let _kernel = fake::Kernel::new("too_large_driver_id");
+    let result = catch_unwind(|| {
+        command(
+            (u32::MAX as usize + 1).into(),
+            1u32.into(),
+            0u32.into(),
+            0u32.into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large driver ID")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large driver ID"));
+}
+
+// TODO: When driver support is added, add a test that tests driver support.

--- a/unittest/src/kernel/mod.rs
+++ b/unittest/src/kernel/mod.rs
@@ -131,33 +131,34 @@ mod tests {
     #[test]
     fn expected_syscall_queue() {
         use libtock_platform::YieldNoWaitReturn::Upcall;
+        use std::matches;
         use ExpectedSyscall::{YieldNoWait, YieldWait};
         let kernel = Kernel::new();
-        assert_eq!(kernel.pop_expected_syscall(), None);
+        assert!(matches!(kernel.pop_expected_syscall(), None));
         kernel.add_expected_syscall(YieldNoWait {
             override_return: None,
         });
         kernel.add_expected_syscall(YieldNoWait {
             override_return: Some(Upcall),
         });
-        assert_eq!(
+        assert!(matches!(
             kernel.pop_expected_syscall(),
             Some(YieldNoWait {
                 override_return: None
             })
-        );
+        ));
         kernel.add_expected_syscall(YieldWait { skip_upcall: false });
-        assert_eq!(
+        assert!(matches!(
             kernel.pop_expected_syscall(),
             Some(YieldNoWait {
                 override_return: Some(Upcall)
             })
-        );
-        assert_eq!(
+        ));
+        assert!(matches!(
             kernel.pop_expected_syscall(),
             Some(YieldWait { skip_upcall: false })
-        );
-        assert_eq!(kernel.pop_expected_syscall(), None);
+        ));
+        assert!(matches!(kernel.pop_expected_syscall(), None));
     }
 
     #[test]

--- a/unittest/src/kernel/mod.rs
+++ b/unittest/src/kernel/mod.rs
@@ -2,7 +2,12 @@ use crate::{ExpectedSyscall, SyscallLogEntry};
 use std::cell::Cell;
 
 // TODO: Add Allow.
-// TODO: Add Command.
+
+mod command_impl;
+
+#[cfg(test)]
+mod command_impl_tests;
+
 // TODO: Add Exit.
 // TODO: Add Memop.
 // TODO: Add Subscribe.

--- a/unittest/src/kernel/raw_syscalls_impl.rs
+++ b/unittest/src/kernel/raw_syscalls_impl.rs
@@ -35,12 +35,11 @@ unsafe impl RawSyscalls for super::Kernel {
         }
     }
 
-    unsafe fn syscall4<const CLASS: usize>(
-        [Register(_r0), Register(_r1), Register(_r2), Register(_r3)]: [Register; 4],
-    ) -> [Register; 4] {
+    unsafe fn syscall4<const CLASS: usize>([r0, r1, r2, r3]: [Register; 4]) -> [Register; 4] {
+        assert_valid((r0, r1, r2, r3));
         match CLASS {
             class_id::SUBSCRIBE => unimplemented!("TODO: Add Subscribe"),
-            class_id::COMMAND => unimplemented!("TODO: Add Command"),
+            class_id::COMMAND => super::command_impl::command(r0, r1, r2, r3),
             class_id::RW_ALLOW => unimplemented!("TODO: Add Allow"),
             class_id::RO_ALLOW => unimplemented!("TODO: Add Allow"),
             _ => panic!("Unknown syscall4 call. Class: {}", CLASS),

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -19,7 +19,6 @@ pub enum SyscallLogEntry {
         argument0: u32,
         argument1: u32,
     },
-
     // TODO: Add Allow.
     // TODO: Add Memop.
     // TODO: Add Exit.

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -2,9 +2,18 @@
 #[derive(Debug, PartialEq)]
 pub enum SyscallLogEntry {
     // TODO: Add Yield.
-// TODO: Add Subscribe.
-// TODO: Add Command.
-// TODO: Add Allow.
-// TODO: Add Memop.
-// TODO: Add Exit.
+    // TODO: Add Subscribe.
+
+    // -------------------------------------------------------------------------
+    // Command
+    // -------------------------------------------------------------------------
+    Command {
+        driver_id: u32,
+        command_id: u32,
+        argument0: u32,
+        argument1: u32,
+    },
+    // TODO: Add Allow.
+    // TODO: Add Memop.
+    // TODO: Add Exit.
 }


### PR DESCRIPTION
This Command implementation will be used by the unit tests for `libtock_platform::Syscalls::command()`. This implementation includes support for expected system calls, but not fake drivers. I will add fake driver support in the future.