### PR TITLE
Remove uses of `core::mem::uninitialized` from `ufmt`.

### DIFF
--- a/ufmt/src/impls/ixx.rs
+++ b/ufmt/src/impls/ixx.rs
@@ -48,7 +48,7 @@ impl uDebug for i8 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 4] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 4] = [0; 4];
 
         f.write_str(isize(isize::from(*self), &mut buf))
     }
@@ -69,7 +69,7 @@ impl uDebug for i16 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 6] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 6] = [0; 6];
 
         f.write_str(isize(isize::from(*self), &mut buf))
     }
@@ -90,7 +90,7 @@ impl uDebug for i32 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 11] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 11] = [0; 11];
 
         f.write_str(isize(*self as isize, &mut buf))
     }
@@ -112,7 +112,7 @@ impl uDebug for i64 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 20] = [0; 20];
 
         let s = ixx!(u64, *self, buf);
         f.write_str(s)
@@ -123,7 +123,7 @@ impl uDebug for i64 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 20] = [0; 20];
 
         f.write_str(isize(*self as isize, &mut buf))
     }
@@ -144,7 +144,7 @@ impl uDebug for i128 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 40] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 40] = [0; 40];
 
         let s = ixx!(u128, *self, buf);
         f.write_str(s)

--- a/ufmt/src/impls/ptr.rs
+++ b/ufmt/src/impls/ptr.rs
@@ -4,7 +4,7 @@ use crate::{uDebug, uWrite, Formatter};
 
 macro_rules! hex {
     ($self:expr, $f:expr, $N:expr) => {{
-        let mut buf: [u8; $N] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; $N] = [0; $N];
 
         let i = hex(*$self as usize, &mut buf);
 

--- a/ufmt/src/impls/uxx.rs
+++ b/ufmt/src/impls/uxx.rs
@@ -32,7 +32,7 @@ impl uDebug for u8 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 3] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 3] = [0; 3];
 
         f.write_str(usize(usize::from(*self), &mut buf))
     }
@@ -53,7 +53,7 @@ impl uDebug for u16 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 5] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 5] = [0; 5];
 
         f.write_str(usize(usize::from(*self), &mut buf))
     }
@@ -74,7 +74,7 @@ impl uDebug for u32 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 10] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 10] = [0; 10];
 
         f.write_str(usize(*self as usize, &mut buf))
     }
@@ -96,7 +96,7 @@ impl uDebug for u64 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 20] = [0; 20];
 
         let s = uxx!(*self, buf);
         f.write_str(s)
@@ -107,7 +107,7 @@ impl uDebug for u64 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 20] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 20] = [0; 20];
 
         f.write_str(usize(*self as usize, &mut buf))
     }
@@ -128,7 +128,7 @@ impl uDebug for u128 {
     where
         W: uWrite + ?Sized,
     {
-        let mut buf: [u8; 39] = unsafe { crate::uninitialized() };
+        let mut buf: [u8; 39] = [0; 39];
 
         let s = uxx!(*self, buf);
         f.write_str(s)

--- a/ufmt/src/lib.rs
+++ b/ufmt/src/lib.rs
@@ -248,11 +248,6 @@ pub mod derive {
     pub use ufmt_macros::uDebug;
 }
 
-#[allow(deprecated)]
-unsafe fn uninitialized<T>() -> T {
-    core::mem::uninitialized()
-}
-
 /// Just like `core::fmt::Debug`
 #[allow(non_camel_case_types)]
 pub trait uDebug {

--- a/ufmt/write/src/lib.rs
+++ b/ufmt/write/src/lib.rs
@@ -9,11 +9,6 @@
 #[cfg(feature = "std")]
 use core::convert::Infallible;
 
-#[allow(deprecated)]
-unsafe fn uninitialized<T>() -> T {
-    core::mem::uninitialized()
-}
-
 /// A collection of methods that are required / used to format a message into a stream.
 #[allow(non_camel_case_types)]
 pub trait uWrite {
@@ -32,7 +27,7 @@ pub trait uWrite {
     /// entire byte sequence was successfully written, and this method will not return until all
     /// data has been written or an error occurs.
     fn write_char(&mut self, c: char) -> Result<(), Self::Error> {
-        let mut buf: [u8; 4] = unsafe { uninitialized() };
+        let mut buf: [u8; 4] = [0; 4];
         self.write_str(c.encode_utf8(&mut buf))
     }
 }


### PR DESCRIPTION
According to the current Rust Reference [1], storing an uninitialized `u8` is undefined behavior. This may change in the future [2], but for now we should continue to assume it is undefined behavior.

Every use of `core::mem::uninitialized` in `ufmt` is to create a local `[u8; _]`, and therefore is an example of this undefined behavior. I removed the undefined behavior in the simplest way possible, which is to replace the initializers with `[u8; _]`.

[1] https://doc.rust-lang.org/reference/behavior-considered-undefined.html
[2] https://github.com/rust-lang/unsafe-code-guidelines/issues/77