### PR TITLE
Clean up several TODO messages.

### DIFF
--- a/platform/src/async_traits.rs
+++ b/platform/src/async_traits.rs
@@ -33,9 +33,6 @@
 //! implemented by `libtock_runtime::static_component!` (in real Tock apps) and
 //! `libtock_unittest::test_component!` (in unit tests), rather than directly by
 //! user code.
-// TODO: At the time of this writing, neither `libtock_runtime` nor
-// `libtock_unittest` are implemented. Remove this TODO when they are
-// implemented.
 
 /// `FreeCallback` is the callback equivalent of a free function: it does not
 /// have access to the client component's data. `FreeCallback` is used by

--- a/platform/src/raw_syscalls.rs
+++ b/platform/src/raw_syscalls.rs
@@ -1,6 +1,3 @@
-// TODO: Implement `libtock_unittest`, which is referenced in the comment on
-// `RawSyscalls`.
-
 use crate::Register;
 
 /// `RawSyscalls` allows a fake Tock kernel to be injected into components for

--- a/platform/src/syscalls.rs
+++ b/platform/src/syscalls.rs
@@ -1,9 +1,6 @@
-// TODO: Implement `libtock_runtime` and `libtock_unittest`, which are
-// referenced in the comment on `Syscalls`.
-
 /// `Syscalls` provides safe abstractions over Tock's system calls. It is
 /// implemented for `libtock_runtime::TockSyscalls` and
-/// `libtock_unittest::FakeSyscalls` (by way of `RawSyscalls`).
+/// `libtock_unittest::fake::Kernel` (by way of `RawSyscalls`).
 pub trait Syscalls {
     /// Runs the next pending callback, if a callback is pending. Unlike
     /// `yield_wait`, `yield_no_wait` returns immediately if no callback is

--- a/unittest/src/kernel/mod.rs
+++ b/unittest/src/kernel/mod.rs
@@ -90,7 +90,6 @@ impl Drop for Kernel {
 
 impl Kernel {
     // Appends a log entry to the system call queue.
-    #[allow(unused)] // TODO: Remove when a system call is implemented.
     fn log_syscall(&self, syscall: SyscallLogEntry) {
         let mut log = self.syscall_log.take();
         log.push(syscall);
@@ -99,7 +98,6 @@ impl Kernel {
 
     // Retrieves the first syscall in the expected syscalls queue, removing it
     // from the queue. Returns None if the queue was empty.
-    #[allow(unused)] // TODO: Remove when a system call is implemented.
     fn pop_expected_syscall(&self) -> Option<ExpectedSyscall> {
         let mut queue = self.expected_syscalls.take();
         let expected_syscall = queue.pop_front();
@@ -125,6 +123,51 @@ impl Kernel {
 mod tests {
     use super::*;
 
+    #[test]
+    fn expected_syscall_queue() {
+        use libtock_platform::YieldNoWaitReturn::Upcall;
+        use ExpectedSyscall::{YieldNoWait, YieldWait};
+        let kernel = Kernel::new();
+        assert_eq!(kernel.pop_expected_syscall(), None);
+        kernel.add_expected_syscall(YieldNoWait {
+            override_return: None,
+        });
+        kernel.add_expected_syscall(YieldNoWait {
+            override_return: Some(Upcall),
+        });
+        assert_eq!(
+            kernel.pop_expected_syscall(),
+            Some(YieldNoWait {
+                override_return: None
+            })
+        );
+        kernel.add_expected_syscall(YieldWait { skip_upcall: false });
+        assert_eq!(
+            kernel.pop_expected_syscall(),
+            Some(YieldNoWait {
+                override_return: Some(Upcall)
+            })
+        );
+        assert_eq!(
+            kernel.pop_expected_syscall(),
+            Some(YieldWait { skip_upcall: false })
+        );
+        assert_eq!(kernel.pop_expected_syscall(), None);
+    }
+
+    #[test]
+    fn syscall_log() {
+        use SyscallLogEntry::{YieldNoWait, YieldWait};
+        let kernel = Kernel::new();
+        assert_eq!(kernel.take_syscall_log(), []);
+        kernel.log_syscall(YieldNoWait);
+        kernel.log_syscall(YieldWait);
+        assert_eq!(kernel.take_syscall_log(), [YieldNoWait, YieldWait]);
+        kernel.log_syscall(YieldNoWait);
+        assert_eq!(kernel.take_syscall_log(), [YieldNoWait]);
+        assert_eq!(kernel.take_syscall_log(), []);
+    }
+
     // Verifies the location propagates correctly into the report_leaked() error
     // message.
     #[test]
@@ -139,9 +182,4 @@ mod tests {
             .expect("Wrong panic payload type");
         assert!(message.contains(&format!("{}:{}", new_location.file(), new_location.line())));
     }
-
-    // TODO: We cannot currently test the expected syscall queue or the syscall
-    // log, because ExpectedSyscall and SyscallLogEntry are currently
-    // uninhabited types. When we implement a system call, we should add tests
-    // for that functionality as well.
 }

--- a/unittest/src/kernel/thread_local.rs
+++ b/unittest/src/kernel/thread_local.rs
@@ -13,7 +13,6 @@ pub fn clear_kernel() {
 }
 
 // Retrieves this thread's Kernel instance, if one is available.
-#[allow(unused)] // TODO: Remove when a system call is implemented.
 pub fn get_kernel() -> Option<Rc<Kernel>> {
     let clone = THREAD_KERNEL.with(|thread_kernel| {
         let weak = thread_kernel.kernel.replace(Weak::new());


### PR DESCRIPTION
Most of these reference tasks that have been completed (e.g. creating the `libtock_unittest` crate). One mentions adding tests; this PR adds those tests and removes the TODO.

I also changed a reference to `libtock_unittest::FakeSyscalls` into `libtock_unittest::fake::Kernel`, as I have renamed the fake kernel.