### PR TITLE
Implement the Command system call.

### DIFF
--- a/platform/src/syscalls.rs
+++ b/platform/src/syscalls.rs
@@ -1,11 +1,17 @@
+use crate::{CommandReturn, YieldNoWaitReturn};
+
 /// `Syscalls` provides safe abstractions over Tock's system calls. It is
 /// implemented for `libtock_runtime::TockSyscalls` and
 /// `libtock_unittest::fake::Kernel` (by way of `RawSyscalls`).
 pub trait Syscalls {
+    // -------------------------------------------------------------------------
+    // Yield
+    // -------------------------------------------------------------------------
+
     /// Runs the next pending callback, if a callback is pending. Unlike
     /// `yield_wait`, `yield_no_wait` returns immediately if no callback is
     /// pending.
-    fn yield_no_wait() -> crate::YieldNoWaitReturn;
+    fn yield_no_wait() -> YieldNoWaitReturn;
 
     /// Puts the process to sleep until a callback becomes pending, invokes the
     /// callback, then returns.
@@ -13,7 +19,11 @@ pub trait Syscalls {
 
     // TODO: Add a subscribe interface.
 
-    // TODO: Add a command interface.
+    // -------------------------------------------------------------------------
+    // Command
+    // -------------------------------------------------------------------------
+
+    fn command(driver_id: u32, command_id: u32, argument0: u32, argument1: u32) -> CommandReturn;
 
     // TODO: Add a read-write allow interface.
 

--- a/syscalls_tests/src/command_tests.rs
+++ b/syscalls_tests/src/command_tests.rs
@@ -1,0 +1,30 @@
+//! Tests for the Command system call implementation in
+//! `libtock_platform::Syscalls`.
+
+use libtock_platform::Syscalls;
+use libtock_unittest::{command_return, fake, ExpectedSyscall, SyscallLogEntry};
+
+#[test]
+fn command() {
+    let kernel = fake::Kernel::new();
+    kernel.add_expected_syscall(ExpectedSyscall::Command {
+        driver_id: 1,
+        command_id: 2,
+        argument0: 3,
+        argument1: 4,
+        override_return: Some(command_return::success_3_u32(1, 2, 3)),
+    });
+    assert_eq!(
+        fake::Kernel::command(1, 2, 3, 4).get_success_3_u32(),
+        Some((1, 2, 3))
+    );
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::Command {
+            driver_id: 1,
+            command_id: 2,
+            argument0: 3,
+            argument1: 4,
+        }]
+    );
+}

--- a/syscalls_tests/src/lib.rs
+++ b/syscalls_tests/src/lib.rs
@@ -12,7 +12,8 @@
 
 // TODO: Add Allow.
 
-// TODO: Add Command.
+#[cfg(test)]
+mod command_tests;
 
 // TODO: Add Exit.
 


### PR DESCRIPTION
This adds `command` to the `libtock_platform::Syscalls` trait, as well as its implementation. This PR includes unit tests for Command.