### PR TITLE
Add Command to `fake::Driver`, and invoke it from `fake::Kernel`.

### DIFF
--- a/unittest/src/driver.rs
+++ b/unittest/src/driver.rs
@@ -1,7 +1,8 @@
+use libtock_platform::CommandReturn;
+
 /// The `fake::Driver` trait is implemented by fake versions of Tock's kernel
 /// APIs. It is used by `fake::Kernel` to route system calls to the fake kernel
 /// APIs.
-
 pub trait Driver: 'static {
     /// Returns this driver's ID. Used by `fake::Kernel` to route syscalls to
     /// the correct `fake::Driver` instance.
@@ -17,7 +18,9 @@ pub trait Driver: 'static {
     // Command
     // -------------------------------------------------------------------------
 
-    // TODO: Add a Command API.
+    /// Process a Command system call. Fake drivers should use the methods in
+    /// `libtock_unittest::command_return` to construct the return value.
+    fn command(&self, command_id: u32, argument0: u32, argument1: u32) -> CommandReturn;
 
     // -------------------------------------------------------------------------
     // Allow

--- a/unittest/src/kernel/command_impl.rs
+++ b/unittest/src/kernel/command_impl.rs
@@ -58,8 +58,12 @@ pub(super) fn command(
         Some(expected_syscall) => expected_syscall.panic_wrong_call("Command"),
     };
 
-    // TODO: Add the Driver trait and implement driver support.
-    let driver_return = command_return::failure(ErrorCode::NoSupport);
+    // Call the driver if one is present. If not, return NoDevice as required by
+    // TRD 104.
+    let driver_return = match kernel.get_driver(driver_id) {
+        Some(driver) => driver.command(command_id, argument0, argument1),
+        None => command_return::failure(ErrorCode::NoDevice),
+    };
 
     // Convert the override return value (or the driver return value if no
     // override is present) into the representative register values.

--- a/unittest/src/kernel/mod.rs
+++ b/unittest/src/kernel/mod.rs
@@ -107,6 +107,14 @@ impl Drop for Kernel {
 // -----------------------------------------------------------------------------
 
 impl Kernel {
+    // Returns the driver with the given ID, if one is installed.
+    fn get_driver(&self, driver_id: u32) -> Option<std::rc::Rc<dyn crate::fake::Driver>> {
+        let drivers = self.drivers.take();
+        let driver = drivers.get(&driver_id).cloned();
+        self.drivers.set(drivers);
+        driver
+    }
+
     // Appends a log entry to the system call queue.
     fn log_syscall(&self, syscall: SyscallLogEntry) {
         let mut log = self.syscall_log.take();


### PR DESCRIPTION
I made `command` required, because I expect every well-designed driver to support Commands. For Subscribe and Allow calls, I will provide a default implementation, because there are drivers that don't use them (e.g. `LowLevelDebug`).