### PR TITLE
Add an upcall module to `libtock_unittest`.

### DIFF
--- a/platform/src/raw_syscalls.rs
+++ b/platform/src/raw_syscalls.rs
@@ -169,7 +169,7 @@ pub unsafe trait RawSyscalls {
     //            noreturn  (all these system calls are expected to return)
     //
     // For subscribe(), the callback pointer should be either 0 (for the null
-    // callback) or an `unsafe extern fn(u32, u32, u32, Userdata)`.
+    // callback) or an `unsafe extern fn(u32, u32, u32, Register)`.
     /// `syscall4` should only be called by `libtock_platform`.
     ///
     /// # Safety

--- a/platform/src/register.rs
+++ b/platform/src/register.rs
@@ -4,7 +4,10 @@
 /// type. `Register` wraps a raw pointer type that keeps that tags around. User
 /// code should not depend on the particular type of pointer that `Register`
 /// wraps, but instead use the conversion functions in this module.
+// Register is repr(transparent) so that an upcall's application data can be
+// soundly passed as a Register.
 #[derive(Clone, Copy, Debug)]
+#[repr(transparent)]
 pub struct Register(pub *mut ());
 
 // -----------------------------------------------------------------------------

--- a/unittest/Cargo.toml
+++ b/unittest/Cargo.toml
@@ -10,3 +10,4 @@ version = "0.1.0"
 
 [dependencies]
 libtock_platform = { path = "../platform" }
+thiserror = "1.0"

--- a/unittest/src/driver.rs
+++ b/unittest/src/driver.rs
@@ -12,7 +12,11 @@ pub trait Driver: 'static {
     // Subscribe
     // -------------------------------------------------------------------------
 
-    // TODO: Add a Subscribe API.
+    /// Like the real Tock kernel, `fake::Kernel` implements Subscribe for
+    /// drivers. Drivers must implement `num_upcalls` to tell `fake::Kernel` how
+    /// many upcalls to store. `fake::Kernel` will reject Subscribe calls for
+    /// any subscribe_number >= num_upcalls.
+    fn num_upcalls(&self) -> u32;
 
     // -------------------------------------------------------------------------
     // Command

--- a/unittest/src/kernel/command_impl.rs
+++ b/unittest/src/kernel/command_impl.rs
@@ -61,7 +61,10 @@ pub(super) fn command(
             Some(expected_syscall) => expected_syscall.panic_wrong_call("Command"),
         };
 
-        let driver = kernel_data.drivers.get(&driver_id).cloned();
+        let driver = kernel_data
+            .drivers
+            .get(&driver_id)
+            .map(|driver_data| driver_data.driver.clone());
 
         (driver, override_return)
     });

--- a/unittest/src/kernel/command_impl_tests.rs
+++ b/unittest/src/kernel/command_impl_tests.rs
@@ -22,10 +22,17 @@ fn driver_support() {
     assert_eq!(r1.try_into(), Ok(ErrorCode::NoDevice as u32));
 
     // A mock driver that returns a fixed value.
+    // TODO: This is growing every time we add a new required method to Driver.
+    // Once we have fake driver inside `crate::fake` (e.g. a fake LowLevelDebug
+    // driver), we should remove MockDriver and replace it with the fake driver,
+    // so we have 1 fewer Driver implementations to maintain.
     struct MockDriver;
     impl fake::Driver for MockDriver {
         fn id(&self) -> u32 {
             42
+        }
+        fn num_upcalls(&self) -> u32 {
+            0
         }
         fn command(&self, _command_id: u32, _argument0: u32, _argument1: u32) -> CommandReturn {
             command_return::success_3_u32(1, 2, 3)

--- a/unittest/src/kernel_data.rs
+++ b/unittest/src/kernel_data.rs
@@ -11,22 +11,33 @@
 
 use std::cell::RefCell;
 
-pub struct KernelData {
+pub(crate) struct KernelData {
     // The location of the call to `fake::Kernel::new`. Used in the event a
     // duplicate `fake::Kernel` is created to tell the user which kernel they
     // did not clean up in a unit test.
     pub create_location: &'static std::panic::Location<'static>,
 
-    pub drivers: std::collections::HashMap<u32, std::rc::Rc<dyn crate::fake::Driver>>,
+    pub drivers: std::collections::HashMap<u32, DriverData>,
     pub expected_syscalls: std::collections::VecDeque<crate::ExpectedSyscall>,
     pub syscall_log: Vec<crate::SyscallLogEntry>,
+    pub upcall_queue: crate::upcall::UpcallQueue,
 }
 
 // KERNEL_DATA is set to Some in `fake::Kernel::new` and set to None when the
 // `fake::Kernel` is dropped.
-thread_local!(pub static KERNEL_DATA: RefCell<Option<KernelData>> = RefCell::new(None));
+thread_local!(pub(crate) static KERNEL_DATA: RefCell<Option<KernelData>> = RefCell::new(None));
 
 // Convenience function to get mutable access to KERNEL_DATA.
-pub fn with_kernel_data<F: FnOnce(Option<&mut KernelData>) -> R, R>(f: F) -> R {
+pub(crate) fn with_kernel_data<F: FnOnce(Option<&mut KernelData>) -> R, R>(f: F) -> R {
     KERNEL_DATA.with(|refcell| f(refcell.borrow_mut().as_mut()))
+}
+
+// Per-driver data stored in KernelData.
+pub struct DriverData {
+    pub driver: std::rc::Rc<dyn crate::fake::Driver>,
+    pub num_upcalls: u32,
+
+    // Currently-valid upcalls passed to Subscribe. The key is the subscribe
+    // number.
+    pub upcalls: std::collections::HashMap<u32, crate::upcall::Upcall>,
 }

--- a/unittest/src/lib.rs
+++ b/unittest/src/lib.rs
@@ -9,6 +9,7 @@ mod expected_syscall;
 mod kernel;
 mod kernel_data;
 mod syscall_log;
+pub mod upcall;
 
 /// `fake` contains fake implementations of Tock kernel components. Fake
 /// components emulate the behavior of the real Tock kernel components, but in

--- a/unittest/src/upcall.rs
+++ b/unittest/src/upcall.rs
@@ -1,0 +1,242 @@
+/// Adds an upcall to the upcall queue, to be invoked during a future Yield
+/// call. Operate's on this thread's `fake::Kernel`.
+///
+/// Like the real kernel, this does nothing and returns success if there is no
+/// upcall or the upcall is a null upcall.
+pub fn schedule(
+    driver_number: u32,
+    subscribe_number: u32,
+    args: (u32, u32, u32),
+) -> Result<(), ScheduleError> {
+    crate::kernel_data::with_kernel_data(|kernel_data| {
+        let kernel_data = kernel_data.ok_or(ScheduleError::NoKernel)?;
+        let driver_data = kernel_data
+            .drivers
+            .get(&driver_number)
+            .ok_or(ScheduleError::NoDriver(driver_number))?;
+        if subscribe_number >= driver_data.num_upcalls {
+            return Err(ScheduleError::TooLargeSubscribeNumber {
+                num_upcalls: driver_data.num_upcalls,
+                requested: subscribe_number,
+            });
+        }
+        let upcall = match driver_data.upcalls.get(&subscribe_number) {
+            Some(&upcall) => upcall,
+            None => return Ok(()),
+        };
+        // Don't bother queueing a null upcall, as they don't do anything when
+        // invoked anyway.
+        if upcall.is_null() {
+            return Ok(());
+        }
+        kernel_data.upcall_queue.push_back(UpcallQueueEntry {
+            args,
+            id: UpcallId {
+                driver_number,
+                subscribe_number,
+            },
+            upcall,
+        });
+        Ok(())
+    })
+}
+
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum ScheduleError {
+    #[error("Driver number {0} does not exist.")]
+    NoDriver(u32),
+
+    #[error("No fake::Kernel exists in this thread")]
+    NoKernel,
+
+    #[error("Upcall number {requested} too large, expected < {num_upcalls}.")]
+    TooLargeSubscribeNumber { num_upcalls: u32, requested: u32 },
+}
+
+/// Raw upcall data, as it was passed to Subscribe. This upcall is not
+/// guaranteed to still be valid.
+#[derive(Clone, Copy)]
+pub struct Upcall {
+    pub fn_pointer: Option<unsafe extern "C" fn(u32, u32, u32, libtock_platform::Register)>,
+    pub data: libtock_platform::Register,
+}
+
+impl Upcall {
+    /// Returns true if this is a null callback, false otherwise.
+    pub fn is_null(&self) -> bool {
+        self.fn_pointer.is_none()
+    }
+}
+
+// The type of the upcall queue in KernelData. Contains queued upcalls, which
+// are waiting to be invoked during a Yield call.
+//
+// Based on this discussion:
+// https://mailman.stanford.edu/pipermail/tock-version2/2020-November/000025.html
+// this queue is a FIFO queue. New entries should be pushed to the back of the
+// queue, and Yield should invoke upcalls starting with the front of the queue.
+//
+// A note on performance: When an upcall is replaced via Subscribe and becomes
+// invalid, Subscribe has to iterate through this queue and remove all instances
+// of that upcall. That takes linear time in the length of the queue, so it can
+// be slow if the queue is long. A long queue is unrealistic, so we shouldn't
+// need a long queue in test cases, so that is acceptable. There are alternative
+// data structures that avoid that slowdown, but they are more complex and
+// likely slower in the common case.
+pub(crate) type UpcallQueue = std::collections::VecDeque<crate::upcall::UpcallQueueEntry>;
+
+// An entry in the fake kernel's upcall queue.
+pub(crate) struct UpcallQueueEntry {
+    pub args: (u32, u32, u32),
+    pub id: UpcallId,
+    pub upcall: Upcall,
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub(crate) struct UpcallId {
+    driver_number: u32,
+    subscribe_number: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockDriver;
+    impl crate::fake::Driver for MockDriver {
+        fn id(&self) -> u32 {
+            1
+        }
+        fn num_upcalls(&self) -> u32 {
+            10
+        }
+        fn command(&self, _: u32, _: u32, _: u32) -> libtock_platform::CommandReturn {
+            crate::command_return::failure(libtock_platform::ErrorCode::NoSupport)
+        }
+    }
+
+    #[test]
+    fn schedule_errors() {
+        use ScheduleError::{NoDriver, NoKernel, TooLargeSubscribeNumber};
+
+        assert_eq!(schedule(1, 2, (3, 4, 5)), Err(NoKernel));
+
+        let kernel = crate::fake::Kernel::new();
+        assert_eq!(schedule(1, 2, (3, 4, 5)), Err(NoDriver(1)));
+
+        kernel.add_driver(&std::rc::Rc::new(MockDriver));
+        assert_eq!(
+            schedule(1, 10, (3, 4, 5)),
+            Err(TooLargeSubscribeNumber {
+                num_upcalls: 10,
+                requested: 10
+            })
+        );
+    }
+
+    #[test]
+    fn schedule_success() {
+        let kernel = crate::fake::Kernel::new();
+        kernel.add_driver(&std::rc::Rc::new(MockDriver));
+
+        // Call schedule with no registered upcall.
+        assert_eq!(schedule(1, 2, (3, 4, 5)), Ok(()));
+        crate::kernel_data::with_kernel_data(|kernel_data| {
+            let kernel_data = kernel_data.unwrap();
+
+            // There was no upcall to schedule, so the queue should still be
+            // empty.
+            assert!(kernel_data.upcall_queue.is_empty());
+
+            // Register a null upcall.
+            kernel_data.drivers.get_mut(&1).unwrap().upcalls.insert(
+                2,
+                Upcall {
+                    fn_pointer: None,
+                    data: 1234u32.into(),
+                },
+            );
+        });
+        // Call schedule again. This should still do nothing, because the upcall
+        // is a null upcall.
+        assert_eq!(schedule(1, 2, (3, 4, 5)), Ok(()));
+        unsafe extern "C" fn upcall(_: u32, _: u32, _: u32, _: libtock_platform::Register) {}
+        crate::kernel_data::with_kernel_data(|kernel_data| {
+            let kernel_data = kernel_data.unwrap();
+
+            // Very the upcall was not queued.
+            assert!(kernel_data.upcall_queue.is_empty());
+
+            // Register a non-null upcall.
+            kernel_data.drivers.get_mut(&1).unwrap().upcalls.insert(
+                2,
+                Upcall {
+                    fn_pointer: Some(upcall),
+                    data: 1111usize.into(),
+                },
+            );
+        });
+        // Call schedule again. This should schedule the upcall.
+        assert_eq!(schedule(1, 2, (3, 4, 5)), Ok(()));
+        crate::kernel_data::with_kernel_data(|kernel_data| {
+            let kernel_data = kernel_data.unwrap();
+
+            // Very the upcall was queued.
+            assert_eq!(kernel_data.upcall_queue.len(), 1);
+            let upcall_queue_entry = kernel_data.upcall_queue.front().expect("Upcall not queued");
+            assert_eq!(upcall_queue_entry.args, (3, 4, 5));
+            assert_eq!(
+                upcall_queue_entry.id,
+                UpcallId {
+                    driver_number: 1,
+                    subscribe_number: 2
+                }
+            );
+            assert!(upcall_queue_entry.upcall.fn_pointer == Some(upcall));
+            let data: usize = upcall_queue_entry.upcall.data.into();
+            assert_eq!(data, 1111);
+
+            // Register a non-null upcall.
+            kernel_data.drivers.get_mut(&1).unwrap().upcalls.insert(
+                2,
+                Upcall {
+                    fn_pointer: Some(upcall),
+                    data: 2222u32.into(),
+                },
+            );
+        });
+        // Call schedule again. This should schedule another upcall, after the
+        // first.
+        assert_eq!(schedule(1, 2, (30, 40, 50)), Ok(()));
+        crate::kernel_data::with_kernel_data(|kernel_data| {
+            let kernel_data = kernel_data.unwrap();
+
+            // Very the upcall was queued.
+            assert_eq!(kernel_data.upcall_queue.len(), 2);
+            let front_queue_entry = kernel_data.upcall_queue.front().expect("Upcall not queued");
+            assert_eq!(front_queue_entry.args, (3, 4, 5));
+            assert_eq!(
+                front_queue_entry.id,
+                UpcallId {
+                    driver_number: 1,
+                    subscribe_number: 2
+                }
+            );
+            assert!(front_queue_entry.upcall.fn_pointer == Some(upcall));
+            let front_data: usize = front_queue_entry.upcall.data.into();
+            assert_eq!(front_data, 1111);
+            let back_queue_entry = kernel_data.upcall_queue.back().expect("Upcall not queued");
+            assert_eq!(back_queue_entry.args, (30, 40, 50));
+            assert_eq!(
+                back_queue_entry.id,
+                UpcallId {
+                    driver_number: 1,
+                    subscribe_number: 2
+                }
+            );
+            assert!(back_queue_entry.upcall.fn_pointer == Some(upcall));
+            let back_data: usize = back_queue_entry.upcall.data.into();
+            assert_eq!(back_data, 2222);
+        });
+    }
+}

--- a/unittest/src/upcall.rs
+++ b/unittest/src/upcall.rs
@@ -25,7 +25,7 @@ pub fn schedule(
             None => return Ok(()),
         };
         // Don't bother queueing a null upcall, as they don't do anything when
-        // invoked anyway.
+        // invoked anyway, and the core kernel does not queue them either.
         if upcall.is_null() {
             return Ok(());
         }
@@ -181,7 +181,7 @@ mod tests {
         crate::kernel_data::with_kernel_data(|kernel_data| {
             let kernel_data = kernel_data.unwrap();
 
-            // Very the upcall was queued.
+            // Verify the upcall was queued.
             assert_eq!(kernel_data.upcall_queue.len(), 1);
             let upcall_queue_entry = kernel_data.upcall_queue.front().expect("Upcall not queued");
             assert_eq!(upcall_queue_entry.args, (3, 4, 5));


### PR DESCRIPTION
This change adds an upcall queue to the kernel data. I plan to implement the following in separate PRs:

1. Upcall invocation in Yield
2. Subscribe

I added a TODO to write a test for fake::Kernel::add_driver. There are a couple refactorings I want to do to it, and if I write the test now, I'll have to change it significantly when I do those refactorings. Therefore I left the test out of this PR.