### PR TITLE
Tell ripgrep not to search tock/ and tock2/.

### DIFF
--- a/.rgignore
+++ b/.rgignore
@@ -1,0 +1,5 @@
+# Tells ripgrep to ignore the Tock submodules. Usually when someone wants to
+# search this repository they want to search libtock-rs' codebase, not the Tock
+# kernel.
+/tock/
+/tock2/


### PR DESCRIPTION
I use ripgrep all the time in this repository, and by default it searches the Tock submodules. I almost never want that behavior. This file makes ripgrep skip those paths. It can be overridden with ripgrep's `--no-ignore` flag, although that will ignore `.gitignore` as well.