### PR TITLE
Implement Read-Only Allow in `libtock_unittest::fake::Kernel`.

### DIFF
--- a/platform/src/constants.rs
+++ b/platform/src/constants.rs
@@ -3,8 +3,8 @@
 pub mod syscall_class {
     pub const SUBSCRIBE: usize = 1;
     pub const COMMAND: usize = 2;
-    pub const RW_ALLOW: usize = 3;
-    pub const RO_ALLOW: usize = 4;
+    pub const ALLOW_RW: usize = 3;
+    pub const ALLOW_RO: usize = 4;
     pub const MEMOP: usize = 5;
     pub const EXIT: usize = 6;
 }

--- a/unittest/src/allow_db.rs
+++ b/unittest/src/allow_db.rs
@@ -21,7 +21,6 @@ use libtock_platform::Register;
 // Therefore AllowDb does not need to check for overlaps with zero-sized
 // buffers.
 #[derive(Default)]
-#[allow(dead_code)] // TODO: Remove when used
 pub struct AllowDb {
     // List of all active buffers, excluding zero-sized buffers. Contains both
     // read-only buffers and read-write buffers.
@@ -33,7 +32,6 @@ pub struct AllowDb {
     buffers: std::collections::BTreeMap<*mut u8, NonZeroUsize>,
 }
 
-#[allow(dead_code)] // TODO: Remove when used
 impl AllowDb {
     // Adds a new buffer, or returns an error if it overlaps with any existing
     // buffers. Requires that address and len represent a valid slice.
@@ -109,6 +107,7 @@ impl AllowDb {
     /// # Safety
     /// `address` and `len` must be valid as specified in TRD 104: either `len`
     /// is 0 or `address` and `len` represent a valid slice.
+    #[allow(unused)] // TODO: Remove when RW Allow is implemented.
     pub unsafe fn insert_rw_buffer(
         &mut self,
         address: Register,
@@ -141,6 +140,7 @@ impl AllowDb {
     ///
     /// The returned value is the tuple (address, len) passed into the
     /// insert_rw_buffer call that created the RwAllowBuffer.
+    #[allow(unused)] // TODO: Remove when RW Allow is implemented.
     pub fn remove_rw_buffer(&mut self, buffer: RwAllowBuffer) -> (Register, Register) {
         self.buffers.remove(&buffer.address);
         (buffer.address.into(), buffer.len.into())
@@ -161,6 +161,15 @@ pub struct RoAllowBuffer {
     // references may overlap the slice described by address and len.
     address: *const u8,
     len: usize,
+}
+
+impl Default for RoAllowBuffer {
+    fn default() -> RoAllowBuffer {
+        RoAllowBuffer {
+            address: core::ptr::null(),
+            len: 0,
+        }
+    }
 }
 
 // Allows access to the pointed-to-buffer. The returned reference has the same

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -36,7 +36,19 @@ pub enum ExpectedSyscall {
         // return value.
         override_return: Option<libtock_platform::CommandReturn>,
     },
-    // TODO: Add Allow.
+
+    // -------------------------------------------------------------------------
+    // Read-Only Allow
+    // -------------------------------------------------------------------------
+    AllowRo {
+        driver_number: u32,
+        buffer_number: u32,
+
+        // If set to Some(_), the driver's allow_readonly method will not be
+        // invoked and the provided error will be returned instead.
+        return_error: Option<libtock_platform::ErrorCode>,
+    },
+    // TODO: Add Read-Write Allow.
     // TODO: Add Memop.
     // TODO: Add Exit.
 }

--- a/unittest/src/fake/driver.rs
+++ b/unittest/src/fake/driver.rs
@@ -1,4 +1,5 @@
-use libtock_platform::CommandReturn;
+use crate::RoAllowBuffer;
+use libtock_platform::{CommandReturn, ErrorCode};
 
 /// The `fake::Driver` trait is implemented by fake versions of Tock's kernel
 /// APIs. It is used by `fake::Kernel` to route system calls to the fake kernel
@@ -30,5 +31,17 @@ pub trait Driver: 'static {
     // Allow
     // -------------------------------------------------------------------------
 
-    // TODO: Add an Allow API.
+    /// Process a Read-Only Allow call. Because not all Driver implementations
+    /// need to support Read-Only Allow, a default implementation is provided
+    /// that rejects all Read-Only Allow calls.
+    fn allow_readonly(
+        &self,
+        buffer_number: u32,
+        buffer: RoAllowBuffer,
+    ) -> Result<RoAllowBuffer, (RoAllowBuffer, ErrorCode)> {
+        let _ = buffer_number; // Silences the unused variable warning.
+        Err((buffer, ErrorCode::NoSupport))
+    }
+
+    // TODO: Add a Read-Write Allow API.
 }

--- a/unittest/src/fake/kernel.rs
+++ b/unittest/src/fake/kernel.rs
@@ -30,6 +30,7 @@ impl Kernel {
     pub fn new() -> Kernel {
         let old_option = KERNEL_DATA.with(|kernel_data| {
             kernel_data.replace(Some(KernelData {
+                allow_db: Default::default(),
                 create_location: std::panic::Location::caller(),
                 drivers: Default::default(),
                 expected_syscalls: Default::default(),

--- a/unittest/src/fake/syscalls/allow_ro_impl.rs
+++ b/unittest/src/fake/syscalls/allow_ro_impl.rs
@@ -1,0 +1,98 @@
+use crate::kernel_data::with_kernel_data;
+use crate::{ExpectedSyscall, SyscallLogEntry};
+use libtock_platform::{return_variant, ErrorCode, Register};
+use std::convert::TryInto;
+
+pub(super) unsafe fn allow_ro(
+    driver_number: Register,
+    buffer_number: Register,
+    address: Register,
+    len: Register,
+) -> [Register; 4] {
+    let driver_number = driver_number.try_into().expect("Too large driver number");
+    let buffer_number = buffer_number.try_into().expect("Too large buffer number");
+    let result = with_kernel_data(|option_kernel_data| {
+        let kernel_data =
+            option_kernel_data.expect("Read-Only Allow called but no fake::Kernel exists");
+
+        kernel_data.syscall_log.push(SyscallLogEntry::AllowRo {
+            driver_number,
+            buffer_number,
+            len: len.into(),
+        });
+
+        // Check for an expected syscall entry. Returns an error from the lambda
+        // if this syscall was expected and return_error was specified. Panics
+        // if a different syscall was expected.
+        match kernel_data.expected_syscalls.pop_front() {
+            None => {}
+            Some(ExpectedSyscall::AllowRo {
+                driver_number: expected_driver_number,
+                buffer_number: expected_buffer_number,
+                return_error,
+            }) => {
+                assert_eq!(
+                    driver_number, expected_driver_number,
+                    "expected different driver_number"
+                );
+                assert_eq!(
+                    buffer_number, expected_buffer_number,
+                    "expected different buffer_number"
+                );
+                if let Some(error_code) = return_error {
+                    return Err(error_code);
+                }
+            }
+            Some(expected_syscall) => expected_syscall.panic_wrong_call("Read-Only Allow"),
+        };
+
+        let driver = match kernel_data.drivers.get(&driver_number) {
+            None => return Err(ErrorCode::NoDevice),
+            Some(driver_data) => driver_data.driver.clone(),
+        };
+
+        // Safety: RawSyscall requires the caller to specify address and len as
+        // required by TRD 104. That trivially satisfies the precondition of
+        // insert_ro_buffer, which also requires address and len to follow TRD
+        // 104.
+        let buffer = unsafe { kernel_data.allow_db.insert_ro_buffer(address, len) }
+            .expect("Read-Only Allow called with a buffer that overlaps an already-Allowed buffer");
+
+        Ok((driver, buffer))
+    });
+
+    let (driver, buffer) = match result {
+        Ok((driver, buffer)) => (driver, buffer),
+        Err(error_code) => {
+            let r0: u32 = return_variant::FAILURE_2_U32.into();
+            let r1: u32 = error_code as u32;
+            return [r0.into(), r1.into(), address, len];
+        }
+    };
+
+    let (error_code, buffer_out) = match driver.allow_readonly(buffer_number, buffer) {
+        Ok(buffer_out) => (None, buffer_out),
+        Err((buffer_out, error_code)) => (Some(error_code), buffer_out),
+    };
+
+    let (address_out, len_out) = with_kernel_data(|option_kernel_data| {
+        let kernel_data =
+            option_kernel_data.expect("fake::Kernel dropped during fake::Driver::allow_readonly");
+        kernel_data.allow_db.remove_ro_buffer(buffer_out)
+    });
+
+    match error_code {
+        None => {
+            let r0: u32 = return_variant::SUCCESS_2_U32.into();
+            // The value of r3 isn't specified in TRD 104, but in practice the
+            // kernel won't change it. This mimics that behavior, for lack of a
+            // better option.
+            [r0.into(), address_out, len_out, len]
+        }
+        Some(error_code) => {
+            let r0: u32 = return_variant::FAILURE_2_U32.into();
+            let r1: u32 = error_code as u32;
+            [r0.into(), r1.into(), address_out, len_out]
+        }
+    }
+}

--- a/unittest/src/fake/syscalls/allow_ro_impl_tests.rs
+++ b/unittest/src/fake/syscalls/allow_ro_impl_tests.rs
@@ -1,0 +1,145 @@
+use crate::{fake, ExpectedSyscall, SyscallLogEntry};
+use fake::syscalls::allow_ro_impl::*;
+use libtock_platform::{return_variant, ErrorCode};
+use std::convert::TryInto;
+use std::panic::catch_unwind;
+
+// TODO: Add a TestDriver, and add tests that use a driver:
+// 1. A test that passes buffers to the driver and retrieves them.
+// 2. A test with a driver that doesn't swap buffers (i.e. one that maintains a
+//    longer list of buffers).
+// 3. Fuzz tests
+// 4. Test the driver error handling code.
+
+// Tests calls that do not match the expected system call.
+#[test]
+fn expected_wrong() {
+    let kernel = fake::Kernel::new();
+
+    kernel.add_expected_syscall(ExpectedSyscall::Command {
+        driver_id: 1,
+        command_id: 2,
+        argument0: 3,
+        argument1: 4,
+        override_return: None,
+    });
+    assert!(catch_unwind(|| unsafe {
+        allow_ro(1u32.into(), 2u32.into(), 0u32.into(), 0u32.into())
+    })
+    .expect_err("failed to catch wrong syscall class")
+    .downcast_ref::<String>()
+    .expect("wrong panic payload type")
+    .contains("but Read-Only Allow was called instead"));
+
+    kernel.add_expected_syscall(ExpectedSyscall::AllowRo {
+        driver_number: 1,
+        buffer_number: 2,
+        return_error: None,
+    });
+    assert!(catch_unwind(|| unsafe {
+        allow_ro(7u32.into(), 2u32.into(), 0u32.into(), 0u32.into())
+    })
+    .expect_err("failed to catch wrong driver number")
+    .downcast_ref::<String>()
+    .expect("wrong panic payload type")
+    .contains("expected different driver_number"));
+
+    kernel.add_expected_syscall(ExpectedSyscall::AllowRo {
+        driver_number: 1,
+        buffer_number: 2,
+        return_error: None,
+    });
+    assert!(catch_unwind(|| unsafe {
+        allow_ro(1u32.into(), 7u32.into(), 0u32.into(), 0u32.into())
+    })
+    .expect_err("failed to catch wrong buffer number")
+    .downcast_ref::<String>()
+    .expect("wrong panic payload type")
+    .contains("expected different buffer_number"));
+}
+
+#[test]
+fn no_driver() {
+    let _kernel = fake::Kernel::new();
+    let [r0, r1, r2, r3] = unsafe { allow_ro(7u32.into(), 1u32.into(), 0u32.into(), 0u32.into()) };
+    assert_eq!(
+        r0.try_into(),
+        Ok(Into::<u32>::into(return_variant::FAILURE_2_U32))
+    );
+    assert_eq!(r1.try_into(), Ok(ErrorCode::NoDevice as u32));
+    assert_eq!(r2.try_into(), Ok(0u32));
+    assert_eq!(r3.try_into(), Ok(0u32));
+}
+
+#[test]
+fn no_kernel() {
+    let result =
+        catch_unwind(|| unsafe { allow_ro(1u32.into(), 1u32.into(), 0u32.into(), 0u32.into()) });
+    assert!(result
+        .expect_err("failed to catch missing kernel")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("no fake::Kernel exists"));
+}
+
+#[test]
+fn syscall_log() {
+    let kernel = fake::Kernel::new();
+    // We want to pass a buffer of nonzero length to verify the length is logged
+    // correctly.
+    let buffer = [0; 3];
+    unsafe {
+        allow_ro(
+            1u32.into(),
+            2u32.into(),
+            buffer.as_ptr().into(),
+            buffer.len().into(),
+        );
+    }
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::AllowRo {
+            driver_number: 1,
+            buffer_number: 2,
+            len: 3,
+        }]
+    );
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_buffer_number() {
+    let _kernel = fake::Kernel::new();
+    let result = catch_unwind(|| unsafe {
+        allow_ro(
+            1u32.into(),
+            (u32::MAX as usize + 1).into(),
+            0u32.into(),
+            0u32.into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large buffer number")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large buffer number"));
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_driver_number() {
+    let _kernel = fake::Kernel::new();
+    let result = catch_unwind(|| unsafe {
+        allow_ro(
+            (u32::MAX as usize + 1).into(),
+            1u32.into(),
+            0u32.into(),
+            0u32.into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large driver number")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large driver number"));
+}

--- a/unittest/src/fake/syscalls/mod.rs
+++ b/unittest/src/fake/syscalls/mod.rs
@@ -1,3 +1,4 @@
+mod allow_ro_impl;
 mod command_impl;
 mod raw_syscalls_impl;
 mod yield_impl;
@@ -8,7 +9,11 @@ mod yield_impl;
 pub struct Syscalls;
 
 #[cfg(test)]
+mod allow_ro_impl_tests;
+#[cfg(test)]
 mod command_impl_tests;
+#[cfg(test)]
+mod raw_syscalls_impl_tests;
 #[cfg(test)]
 mod yield_impl_tests;
 

--- a/unittest/src/fake/syscalls/raw_syscalls_impl.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl.rs
@@ -47,8 +47,8 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
         match CLASS {
             syscall_class::SUBSCRIBE => unimplemented!("TODO: Add Subscribe"),
             syscall_class::COMMAND => super::command_impl::command(r0, r1, r2, r3),
-            syscall_class::RW_ALLOW => unimplemented!("TODO: Add Allow"),
-            syscall_class::RO_ALLOW => unimplemented!("TODO: Add Allow"),
+            syscall_class::ALLOW_RW => unimplemented!("TODO: Add Allow"),
+            syscall_class::ALLOW_RO => unsafe { super::allow_ro_impl::allow_ro(r0, r1, r2, r3) },
             _ => panic!("Unknown syscall4 call. Class: {}", CLASS),
         }
     }

--- a/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
@@ -1,0 +1,40 @@
+// These tests verify the RawSyscalls implementation routes system calls to the
+// fake implementations (e.g. command(), yield_wait, etc) correctly. It does not
+// test the fake syscall implementations themselves, as they have their own unit
+// tests.
+
+use crate::{fake, SyscallLogEntry};
+use libtock_platform::{syscall_class, RawSyscalls};
+
+#[test]
+fn allow_ro() {
+    let kernel = fake::Kernel::new();
+    unsafe {
+        fake::Syscalls::syscall4::<{ syscall_class::ALLOW_RO }>([
+            1u32.into(),
+            2u32.into(),
+            0u32.into(),
+            0u32.into(),
+        ]);
+    }
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::AllowRo {
+            driver_number: 1,
+            buffer_number: 2,
+            len: 0,
+        }]
+    );
+}
+
+// TODO: Implement Read-Write Allow.
+
+// TODO: Move the syscall4 Command test here.
+
+// TODO: Implement Exit.
+
+// TODO: Implement Memop.
+
+// TODO: Implement Subscribe.
+
+// TODO: Move the yield1 and yield2 tests here.

--- a/unittest/src/kernel_data.rs
+++ b/unittest/src/kernel_data.rs
@@ -12,6 +12,8 @@
 use std::cell::RefCell;
 
 pub(crate) struct KernelData {
+    pub allow_db: crate::allow_db::AllowDb,
+
     // The location of the call to `fake::Kernel::new`. Used in the event a
     // duplicate `fake::Kernel` is created to tell the user which kernel they
     // did not clean up in a unit test.

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -19,7 +19,16 @@ pub enum SyscallLogEntry {
         argument0: u32,
         argument1: u32,
     },
-    // TODO: Add Allow.
+
+    // -------------------------------------------------------------------------
+    // Read-Only Allow
+    // -------------------------------------------------------------------------
+    AllowRo {
+        driver_number: u32,
+        buffer_number: u32,
+        len: usize,
+    },
+    // TODO: Add Read-Write Allow.
     // TODO: Add Memop.
     // TODO: Add Exit.
 }


### PR DESCRIPTION
This fake Read-Only Allow implementation will be used by unit tests for the Allow API in `libtock_platform::Syscalls` and code built on `Syscalls`.

This is missing some tests I wanted to write because this PR was getting too large. I'll add them in the future.

This PR implements the renaming discussed in #324, and starts the `raw_syscalls_impl_tests.rs` files. There are already some tests (for Yield and Command) that belong in `raw_syscalls_impl_tests.rs`, which I will move in a future PR.