### PR TITLE
`libtock_unittest`: make Yield invoke queued upcalls.

### DIFF
--- a/unittest/src/fake/syscalls/yield_impl_tests.rs
+++ b/unittest/src/fake/syscalls/yield_impl_tests.rs
@@ -1,8 +1,24 @@
+use crate::kernel_data::with_kernel_data;
+use crate::upcall::{Upcall, UpcallId, UpcallQueueEntry};
 use crate::{fake, ExpectedSyscall, SyscallLogEntry};
 use libtock_platform::{RawSyscalls, YieldNoWaitReturn};
 use std::panic::catch_unwind;
 
 use fake::syscalls::yield_impl::*;
+
+// Upcall function that copies its arguments into the [u32; 3] pointed to by
+// `output`. Used by multiple tests in this file.
+unsafe extern "C" fn copy_args(
+    arg0: u32,
+    arg1: u32,
+    arg2: u32,
+    output: libtock_platform::Register,
+) {
+    let output: *mut [u32; 3] = output.into();
+    unsafe {
+        *output = [arg0, arg1, arg2];
+    }
+}
 
 #[test]
 fn yield_no_wait_test() {
@@ -58,6 +74,64 @@ fn yield_no_wait_test() {
         .downcast_ref::<String>()
         .expect("wrong panic payload type")
         .contains("yield-no-wait was called instead"));
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldNoWait]);
+
+    // Upcall structures for using copy_args.
+    let mut output_array = [0u32; 3];
+    let upcall_id = UpcallId {
+        driver_number: 1,
+        subscribe_number: 2,
+    };
+    let upcall = Upcall {
+        fn_pointer: Some(copy_args),
+        data: (&mut output_array as *mut u32).into(),
+    };
+
+    // Test yield_no_wait with an upcall queued.
+    with_kernel_data(|option_kernel_data| {
+        option_kernel_data
+            .unwrap()
+            .upcall_queue
+            .push_back(UpcallQueueEntry {
+                args: (1, 2, 3),
+                id: upcall_id,
+                upcall,
+            });
+    });
+    let mut return_value = core::mem::MaybeUninit::<YieldNoWaitReturn>::uninit();
+    unsafe {
+        yield_no_wait(return_value.as_mut_ptr());
+    }
+    assert_eq!(output_array, [1, 2, 3]);
+    let return_value = unsafe { return_value.assume_init() };
+    fake::syscalls::assert_valid(return_value);
+    assert_eq!(return_value, YieldNoWaitReturn::Upcall);
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldNoWait]);
+
+    // Test yield_no_wait with an upcall queued and a return override in an
+    // expected syscall.
+    kernel.add_expected_syscall(ExpectedSyscall::YieldNoWait {
+        override_return: Some(YieldNoWaitReturn::NoUpcall),
+    });
+    with_kernel_data(|option_kernel_data| {
+        option_kernel_data
+            .unwrap()
+            .upcall_queue
+            .push_back(UpcallQueueEntry {
+                args: (4, 5, 6),
+                id: upcall_id,
+                upcall,
+            });
+    });
+    let mut return_value = core::mem::MaybeUninit::<YieldNoWaitReturn>::uninit();
+    unsafe {
+        yield_no_wait(return_value.as_mut_ptr());
+    }
+    assert_eq!(output_array, [4, 5, 6]);
+    let return_value = unsafe { return_value.assume_init() };
+    fake::syscalls::assert_valid(return_value);
+    assert_eq!(return_value, YieldNoWaitReturn::NoUpcall);
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldNoWait]);
 }
 
 #[test]
@@ -82,9 +156,37 @@ fn yield_wait_test() {
         .contains("yield-wait was called instead"));
     assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldWait]);
 
+    // Upcall structures for using copy_args.
+    let mut output_array = [0u32; 3];
+    let upcall_id = UpcallId {
+        driver_number: 1,
+        subscribe_number: 2,
+    };
+    let upcall = Upcall {
+        fn_pointer: Some(copy_args),
+        data: (&mut output_array as *mut u32).into(),
+    };
+
     // Test yield_wait with a skipped upcall in an expected syscall.
+    with_kernel_data(|option_kernel_data| {
+        option_kernel_data
+            .unwrap()
+            .upcall_queue
+            .push_back(UpcallQueueEntry {
+                args: (1, 2, 3),
+                id: upcall_id,
+                upcall,
+            });
+    });
     kernel.add_expected_syscall(ExpectedSyscall::YieldWait { skip_upcall: true });
     yield_wait();
+    assert_eq!(output_array, [0; 3]);
+    assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldWait]);
+
+    // Test that yield_wait correctly invokes a queued upcall. The upcall was
+    // queued for the previous test (which confirmed that skip_upcall works).
+    yield_wait();
+    assert_eq!(output_array, [1, 2, 3]);
     assert_eq!(kernel.take_syscall_log(), [SyscallLogEntry::YieldWait]);
 }
 

--- a/unittest/src/upcall.rs
+++ b/unittest/src/upcall.rs
@@ -66,6 +66,19 @@ impl Upcall {
     pub fn is_null(&self) -> bool {
         self.fn_pointer.is_none()
     }
+
+    /// # Safety
+    /// An upcall may only be invoked if it is still active. As described in TRD
+    /// 104, an upcall is still active if it has not been replaced by another
+    /// Subscribe call with the same upcall ID. All upcalls in the upcall queue
+    /// in KernelData are active.
+    pub unsafe fn invoke(&self, args: (u32, u32, u32)) {
+        if let Some(fn_pointer) = self.fn_pointer {
+            unsafe {
+                fn_pointer(args.0, args.1, args.2, self.data);
+            }
+        }
+    }
 }
 
 // The type of the upcall queue in KernelData. Contains queued upcalls, which
@@ -93,10 +106,10 @@ pub(crate) struct UpcallQueueEntry {
     pub upcall: Upcall,
 }
 
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct UpcallId {
-    driver_number: u32,
-    subscribe_number: u32,
+    pub driver_number: u32,
+    pub subscribe_number: u32,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
With this PR, calling the Yield system calls will correctly invoke queued upcalls. This PR and #329 implement the fake Subscribe implementation in `libtock_unittest`.