### PR TITLE
Implement Read-Write Allow in `libtock_unittest::fake::Kernel`.

### DIFF
--- a/unittest/src/allow_db.rs
+++ b/unittest/src/allow_db.rs
@@ -107,7 +107,6 @@ impl AllowDb {
     /// # Safety
     /// `address` and `len` must be valid as specified in TRD 104: either `len`
     /// is 0 or `address` and `len` represent a valid slice.
-    #[allow(unused)] // TODO: Remove when RW Allow is implemented.
     pub unsafe fn insert_rw_buffer(
         &mut self,
         address: Register,
@@ -140,7 +139,6 @@ impl AllowDb {
     ///
     /// The returned value is the tuple (address, len) passed into the
     /// insert_rw_buffer call that created the RwAllowBuffer.
-    #[allow(unused)] // TODO: Remove when RW Allow is implemented.
     pub fn remove_rw_buffer(&mut self, buffer: RwAllowBuffer) -> (Register, Register) {
         self.buffers.remove(&buffer.address);
         (buffer.address.into(), buffer.len.into())
@@ -197,6 +195,15 @@ pub struct RwAllowBuffer {
     // references may overlap the slice described by address and len.
     address: *mut u8,
     len: usize,
+}
+
+impl Default for RwAllowBuffer {
+    fn default() -> RwAllowBuffer {
+        RwAllowBuffer {
+            address: core::ptr::null_mut(),
+            len: 0,
+        }
+    }
 }
 
 // Allows access to the pointed-to-buffer. The returned reference has the same

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -48,7 +48,18 @@ pub enum ExpectedSyscall {
         // invoked and the provided error will be returned instead.
         return_error: Option<libtock_platform::ErrorCode>,
     },
-    // TODO: Add Read-Write Allow.
+
+    // -------------------------------------------------------------------------
+    // Read-Write Allow
+    // -------------------------------------------------------------------------
+    AllowRw {
+        driver_number: u32,
+        buffer_number: u32,
+
+        // If set to Some(_), the driver's allow_readwrite method will not be
+        // invoked and the provided error will be returned instead.
+        return_error: Option<libtock_platform::ErrorCode>,
+    },
     // TODO: Add Memop.
     // TODO: Add Exit.
 }

--- a/unittest/src/fake/driver.rs
+++ b/unittest/src/fake/driver.rs
@@ -1,4 +1,4 @@
-use crate::RoAllowBuffer;
+use crate::{RoAllowBuffer, RwAllowBuffer};
 use libtock_platform::{CommandReturn, ErrorCode};
 
 /// The `fake::Driver` trait is implemented by fake versions of Tock's kernel
@@ -43,5 +43,15 @@ pub trait Driver: 'static {
         Err((buffer, ErrorCode::NoSupport))
     }
 
-    // TODO: Add a Read-Write Allow API.
+    /// Process a Read-Write Allow call. Because not all Driver implementations
+    /// need to support Read-Write Allow, a default implementation is provided
+    /// that rejects all Read-Write Allow calls.
+    fn allow_readwrite(
+        &self,
+        buffer_number: u32,
+        buffer: RwAllowBuffer,
+    ) -> Result<RwAllowBuffer, (RwAllowBuffer, ErrorCode)> {
+        let _ = buffer_number; // Silences the unused variable warning.
+        Err((buffer, ErrorCode::NoSupport))
+    }
 }

--- a/unittest/src/fake/syscalls/allow_rw_impl.rs
+++ b/unittest/src/fake/syscalls/allow_rw_impl.rs
@@ -1,0 +1,99 @@
+use crate::kernel_data::with_kernel_data;
+use crate::{ExpectedSyscall, SyscallLogEntry};
+use libtock_platform::{return_variant, ErrorCode, Register};
+use std::convert::TryInto;
+
+pub(super) unsafe fn allow_rw(
+    driver_number: Register,
+    buffer_number: Register,
+    address: Register,
+    len: Register,
+) -> [Register; 4] {
+    let driver_number = driver_number.try_into().expect("Too large driver number");
+    let buffer_number = buffer_number.try_into().expect("Too large buffer number");
+    let result = with_kernel_data(|option_kernel_data| {
+        let kernel_data =
+            option_kernel_data.expect("Read-Write Allow called but no fake::Kernel exists");
+
+        kernel_data.syscall_log.push(SyscallLogEntry::AllowRw {
+            driver_number,
+            buffer_number,
+            len: len.into(),
+        });
+
+        // Check for an expected syscall entry. Returns an error from the lambda
+        // if this syscall was expected and return_error was specified. Panics
+        // if a different syscall was expected.
+        match kernel_data.expected_syscalls.pop_front() {
+            None => {}
+            Some(ExpectedSyscall::AllowRw {
+                driver_number: expected_driver_number,
+                buffer_number: expected_buffer_number,
+                return_error,
+            }) => {
+                assert_eq!(
+                    driver_number, expected_driver_number,
+                    "expected different driver_number"
+                );
+                assert_eq!(
+                    buffer_number, expected_buffer_number,
+                    "expected different buffer_number"
+                );
+                if let Some(error_code) = return_error {
+                    return Err(error_code);
+                }
+            }
+            Some(expected_syscall) => expected_syscall.panic_wrong_call("Read-Write Allow"),
+        };
+
+        let driver = match kernel_data.drivers.get(&driver_number) {
+            None => return Err(ErrorCode::NoDevice),
+            Some(driver_data) => driver_data.driver.clone(),
+        };
+
+        // Safety: RawSyscall requires the caller to specify address and len as
+        // required by TRD 104. That trivially satisfies the precondition of
+        // insert_rw_buffer, which also requires address and len to follow TRD
+        // 104.
+        let buffer = unsafe { kernel_data.allow_db.insert_rw_buffer(address, len) }.expect(
+            "Read-Write Allow called with a buffer that overlaps an already-Allowed buffer",
+        );
+
+        Ok((driver, buffer))
+    });
+
+    let (driver, buffer) = match result {
+        Ok((driver, buffer)) => (driver, buffer),
+        Err(error_code) => {
+            let r0: u32 = return_variant::FAILURE_2_U32.into();
+            let r1: u32 = error_code as u32;
+            return [r0.into(), r1.into(), address, len];
+        }
+    };
+
+    let (error_code, buffer_out) = match driver.allow_readwrite(buffer_number, buffer) {
+        Ok(buffer_out) => (None, buffer_out),
+        Err((buffer_out, error_code)) => (Some(error_code), buffer_out),
+    };
+
+    let (address_out, len_out) = with_kernel_data(|option_kernel_data| {
+        let kernel_data =
+            option_kernel_data.expect("fake::Kernel dropped during fake::Driver::allow_readwrite");
+        kernel_data.allow_db.remove_rw_buffer(buffer_out)
+    });
+
+    match error_code {
+        None => {
+            let r0: u32 = return_variant::SUCCESS_2_U32.into();
+            // The value of r3 isn't specified in TRD 104, but in practice the
+            // kernel won't change it. This mimics that behavior, for lack of a
+            // better option.
+            [r0.into(), address_out, len_out, len]
+        }
+        Some(error_code) => {
+            let r0: u32 = return_variant::FAILURE_2_U32.into();
+            let r1: u32 = error_code as u32;
+            [r0.into(), r1.into(), address_out, len_out]
+        }
+    }
+}

--- a/unittest/src/fake/syscalls/allow_rw_impl_tests.rs
+++ b/unittest/src/fake/syscalls/allow_rw_impl_tests.rs
@@ -1,0 +1,145 @@
+use crate::{fake, ExpectedSyscall, SyscallLogEntry};
+use fake::syscalls::allow_rw_impl::*;
+use libtock_platform::{return_variant, ErrorCode};
+use std::convert::TryInto;
+use std::panic::catch_unwind;
+
+// TODO: Add a TestDriver, and add tests that use a driver:
+// 1. A test that passes buffers to the driver and retrieves them.
+// 2. A test with a driver that doesn't swap buffers (i.e. one that maintains a
+//    longer list of buffers).
+// 3. Fuzz tests
+// 4. Test the driver error handling code.
+
+// Tests calls that do not match the expected system call.
+#[test]
+fn expected_wrong() {
+    let kernel = fake::Kernel::new();
+
+    kernel.add_expected_syscall(ExpectedSyscall::Command {
+        driver_id: 1,
+        command_id: 2,
+        argument0: 3,
+        argument1: 4,
+        override_return: None,
+    });
+    assert!(catch_unwind(|| unsafe {
+        allow_rw(1u32.into(), 2u32.into(), 0u32.into(), 0u32.into())
+    })
+    .expect_err("failed to catch wrong syscall class")
+    .downcast_ref::<String>()
+    .expect("wrong panic payload type")
+    .contains("but Read-Write Allow was called instead"));
+
+    kernel.add_expected_syscall(ExpectedSyscall::AllowRw {
+        driver_number: 1,
+        buffer_number: 2,
+        return_error: None,
+    });
+    assert!(catch_unwind(|| unsafe {
+        allow_rw(7u32.into(), 2u32.into(), 0u32.into(), 0u32.into())
+    })
+    .expect_err("failed to catch wrong driver number")
+    .downcast_ref::<String>()
+    .expect("wrong panic payload type")
+    .contains("expected different driver_number"));
+
+    kernel.add_expected_syscall(ExpectedSyscall::AllowRw {
+        driver_number: 1,
+        buffer_number: 2,
+        return_error: None,
+    });
+    assert!(catch_unwind(|| unsafe {
+        allow_rw(1u32.into(), 7u32.into(), 0u32.into(), 0u32.into())
+    })
+    .expect_err("failed to catch wrong buffer number")
+    .downcast_ref::<String>()
+    .expect("wrong panic payload type")
+    .contains("expected different buffer_number"));
+}
+
+#[test]
+fn no_driver() {
+    let _kernel = fake::Kernel::new();
+    let [r0, r1, r2, r3] = unsafe { allow_rw(7u32.into(), 1u32.into(), 0u32.into(), 0u32.into()) };
+    assert_eq!(
+        r0.try_into(),
+        Ok(Into::<u32>::into(return_variant::FAILURE_2_U32))
+    );
+    assert_eq!(r1.try_into(), Ok(ErrorCode::NoDevice as u32));
+    assert_eq!(r2.try_into(), Ok(0u32));
+    assert_eq!(r3.try_into(), Ok(0u32));
+}
+
+#[test]
+fn no_kernel() {
+    let result =
+        catch_unwind(|| unsafe { allow_rw(1u32.into(), 1u32.into(), 0u32.into(), 0u32.into()) });
+    assert!(result
+        .expect_err("failed to catch missing kernel")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("no fake::Kernel exists"));
+}
+
+#[test]
+fn syscall_log() {
+    let kernel = fake::Kernel::new();
+    // We want to pass a buffer of nonzero length to verify the length is logged
+    // correctly.
+    let buffer = [0; 3];
+    unsafe {
+        allow_rw(
+            1u32.into(),
+            2u32.into(),
+            buffer.as_ptr().into(),
+            buffer.len().into(),
+        );
+    }
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::AllowRw {
+            driver_number: 1,
+            buffer_number: 2,
+            len: 3,
+        }]
+    );
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_buffer_number() {
+    let _kernel = fake::Kernel::new();
+    let result = catch_unwind(|| unsafe {
+        allow_rw(
+            1u32.into(),
+            (u32::MAX as usize + 1).into(),
+            0u32.into(),
+            0u32.into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large buffer number")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large buffer number"));
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_driver_number() {
+    let _kernel = fake::Kernel::new();
+    let result = catch_unwind(|| unsafe {
+        allow_rw(
+            (u32::MAX as usize + 1).into(),
+            1u32.into(),
+            0u32.into(),
+            0u32.into(),
+        )
+    });
+    assert!(result
+        .expect_err("failed to catch too-large driver number")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large driver number"));
+}

--- a/unittest/src/fake/syscalls/mod.rs
+++ b/unittest/src/fake/syscalls/mod.rs
@@ -1,4 +1,5 @@
 mod allow_ro_impl;
+mod allow_rw_impl;
 mod command_impl;
 mod raw_syscalls_impl;
 mod yield_impl;
@@ -10,6 +11,8 @@ pub struct Syscalls;
 
 #[cfg(test)]
 mod allow_ro_impl_tests;
+#[cfg(test)]
+mod allow_rw_impl_tests;
 #[cfg(test)]
 mod command_impl_tests;
 #[cfg(test)]

--- a/unittest/src/fake/syscalls/raw_syscalls_impl.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl.rs
@@ -47,7 +47,7 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
         match CLASS {
             syscall_class::SUBSCRIBE => unimplemented!("TODO: Add Subscribe"),
             syscall_class::COMMAND => super::command_impl::command(r0, r1, r2, r3),
-            syscall_class::ALLOW_RW => unimplemented!("TODO: Add Allow"),
+            syscall_class::ALLOW_RW => unsafe { super::allow_rw_impl::allow_rw(r0, r1, r2, r3) },
             syscall_class::ALLOW_RO => unsafe { super::allow_ro_impl::allow_ro(r0, r1, r2, r3) },
             _ => panic!("Unknown syscall4 call. Class: {}", CLASS),
         }

--- a/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
@@ -27,7 +27,26 @@ fn allow_ro() {
     );
 }
 
-// TODO: Implement Read-Write Allow.
+#[test]
+fn allow_rw() {
+    let kernel = fake::Kernel::new();
+    unsafe {
+        fake::Syscalls::syscall4::<{ syscall_class::ALLOW_RW }>([
+            1u32.into(),
+            2u32.into(),
+            0u32.into(),
+            0u32.into(),
+        ]);
+    }
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::AllowRw {
+            driver_number: 1,
+            buffer_number: 2,
+            len: 0,
+        }]
+    );
+}
 
 // TODO: Move the syscall4 Command test here.
 

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -28,7 +28,15 @@ pub enum SyscallLogEntry {
         buffer_number: u32,
         len: usize,
     },
-    // TODO: Add Read-Write Allow.
+
+    // -------------------------------------------------------------------------
+    // Read-Write Allow
+    // -------------------------------------------------------------------------
+    AllowRw {
+        driver_number: u32,
+        buffer_number: u32,
+        len: usize,
+    },
     // TODO: Add Memop.
     // TODO: Add Exit.
 }


### PR DESCRIPTION
Read-Only Allow and Read-Write Allow have very similar implementations, but unfortunately it's not easy to use a single implementation for both. I see the following possibilities:

1. Use a complex new trait with associated constants to combine `allow_ro` and `allow_rw` into a single generic function.
2. Use a single `macro_rules!` macro to implement both.
3. Have two very similar system call implementations.

Ultimately, I feel that option 3 is the most maintainable option, despite the extremely similar code for the two system calls. As a result, this PR is almost an exact copy of #326 but with "read-only" replaced with "read-write".