### PR TITLE
Add a document describing a safe API for Tock 2.0's Subscribe syscall.

### DIFF
--- a/doc/SubscribeApiDesign.md
+++ b/doc/SubscribeApiDesign.md
@@ -1,0 +1,166 @@
+Subscribe Syscall API Design
+============================
+
+This document gives a high-level overview of a design for the interface to Tock
+2.0's Subscribe system call. It is designed to be approachable by an audience
+that is not familiar with Tock.
+
+## Tock 2.0 Subscribe system call overview
+
+The Subscribe system call is used by userspace processes to register callbacks
+with the Tock kernel, and for the purposes of this document can be represented
+by the following interface:
+
+```rust
+trait Callback<const ID: u32> {
+    fn callback(&self, args: [u32; 3]);
+}
+
+struct InvalidIdError;
+
+// Safety requirement: The process must call kernel_unsubscribe for this ID
+// before the `callback` argument becomes invalid.
+unsafe fn kernel_subscribe<CB: Callback<ID>, const ID: u32>(callback: &CB)
+    -> Result<(), InvalidIdError>;
+
+fn kernel_unsubscribe(id: u32) -> Result<(), InvalidIdError>;
+```
+
+Callbacks are not preemptive: they are only invoked when the process requests
+they be invoked (via a separate system call), removing most (all?) thread-safety
+concerns from the design.
+
+Each ID represents a particular event the process can subscribe to, and not all
+IDs are valid. If an ID is valid at one moment in time, it will remain valid
+indefinitely.
+
+Each call to `kernel_subscribe` overwrites the callback with the given ID,
+replacing whatever callback was previously registered. Calling
+`kernel_unsubscribe` removes the callback for the given ID, causing the kernel
+to drop those events.
+
+## Subscribe API design
+
+`kernel_subscribe` from the previous section is `unsafe`. This section describes
+an API intended to allow safe code to use the Subscribe system call.
+
+This API is designed to support `Callback`s allocated on the stack, which have a
+non-`'static` lifetime. The key difficulty in designing this API is making sure
+that subscriptions are cleaned up before their `Callback` is deallocated. A
+secondary goal is keeping the implementation lightweight: Tock is an embedded
+OS, and a typical Tock process will likely make many Subscribe calls.
+
+The first element of the API is `Unsubscriber`. `Unsubscriber` is a type that
+removes a subscription when it is dropped:
+
+```rust
+#[derive(Default)]
+struct Unsubscriber<'callback, const ID: u32> {
+    // Makes Unsubscriber invariant with respect to 'callback.
+    _phantom: PhantomData<Cell<&'callback ()>>,
+}
+
+impl<'callback, const ID: u32> Drop for Unsubscriber<'callback, ID> {
+    fn drop(&mut self) {
+        unsafe {
+            // Guaranteed to succeed if ID is valid. If ID is invalid, then we
+            // know there isn't a subscription to overwrite. Therefore we don't
+            // need to handle errors here.
+            let _ = kernel_unsubscribe(ID);
+        }
+    }
+}
+```
+
+However, the existence of an `Unsubscriber` does *not* guarantee the `Drop`
+implementation will be called (see the [safe `mem::forget`
+RFC](https://rust-lang.github.io/rfcs/1066-safe-mem-forget.html)). Therefore, we
+cannot soundly add a safe `subscribe` method to `Unsubscriber`.
+
+Instead, we introduce a new handle type, whose existence guarantees that the
+`Unsubscriber` will be dropped. The technique it uses to make the drop guarantee
+is inspired by [`Pin`](https://doc.rust-lang.org/core/pin/index.html): make
+`new` unsafe and tell the caller to guarantee it will be dropped correctly:
+
+```rust
+// Type invariant: a SubscribeHandle's existence guarantees that an Unsubscriber
+// will clear the subscription identified by ID before the 'callback lifetime
+// ends.
+#[derive(Clone, Copy)]
+struct SubscribeHandle<'callback, const ID: u32> {
+    // Makes SubscribeHandle invariant with respect to 'callback, and ties its
+    // lifetime to the Unsubscriber.
+    _phantom: PhantomData<&'callback Unsubscriber<'callback, ID>>,
+}
+
+impl<'callback, const ID: u32> SubscribeHandle<'callback, ID> {
+    // Safety: The caller is responsible for guaranteeing that `Drop::drop` will
+    // be invoked before the 'callback lifetime ends.
+    pub unsafe fn new(unsubscriber: &Unsubscriber<'callback, ID>) -> Self {
+        SubscribeHandle {
+            _phantom: PhantomData,
+        }
+    }
+}
+```
+
+`SubscribeHandle`'s invariant allows us to add a safe `subscribe` method to
+`SubscribeHandle`:
+
+```rust
+impl<'callback, const ID: u32> SubscribeHandle<'callback, ID> {
+    fn subscribe<CB: Callback<ID>>(self, callback: &'callback CB)
+        -> Result<(), InvalidIdError>
+    {
+        unsafe {
+            // Safety: kernel_subscribe requires that unsubscribe is called
+            // before callback becomes invalid, which happens at the end of the
+            // 'callback lifetime. That is guaranteed by the type invariant of
+            // SubscribeHandle.
+            kernel_subscribe(callback)
+        }
+    }
+}
+```
+
+We can use the same trick as
+[`pin-utils::pin_mut`](https://docs.rs/pin-utils/0.1.0/pin_utils/macro.pin_mut.html)
+to create a safe macro that creates a `SubscribeHandle`:
+
+```rust
+macro_rules! subscribe_handle {
+    ($($name:ident),* $(,)?) => { $(
+        let $name = Unsubscriber { _phantom: PhantomData };
+        // Shadow the variable to prevent the caller from forgetting the
+        // Unsubscriber.
+        let $name = unsafe { SubscribeHandle::new($name) };
+    )* }
+}
+```
+
+## Example usage
+
+Here is an example of how the Subscribe API would be used:
+
+```rust
+struct App;
+
+impl Callback<1> for App {
+    fn callback(&self, args: [u32; 3]) {
+        // Insert callback logic here.
+    }
+}
+
+impl App {
+    fn run<'self>(&'self self, handle: SubscribeHandle<'self, 1>) {
+        handle.subscribe(self);
+    }
+}
+
+fn main() {
+    let app = App;
+    subscribe_handle!(handle);
+    app.run(handle);
+    // Insert main loop here.
+}
+```

--- a/doc/SubscribeApiDesign.md
+++ b/doc/SubscribeApiDesign.md
@@ -18,8 +18,11 @@ trait Callback {
 
 struct InvalidIdError;
 
-// Safety requirement: The process must call kernel_unsubscribe for this ID
-// before the `callback` argument becomes invalid.
+// Safety requirement: The process must do one of the following before the
+// `callback` argument becomes invalid:
+// 1. Overwrite this callback using another `kernel_subscribe` call with the
+//    same ID.
+// 2. Erase this callback using a `kernel_unsubscribe` call with the same ID.
 unsafe fn kernel_subscribe<CB: Callback>(callback: &CB, id: u32)
     -> Result<(), InvalidIdError>;
 
@@ -27,7 +30,7 @@ fn kernel_unsubscribe(id: u32) -> Result<(), InvalidIdError>;
 ```
 
 Callbacks are not preemptive: they are only invoked when the process requests
-they be invoked (via a separate system call), removing most (all?) thread-safety
+they be invoked (via the Yield system call), removing most (all?) thread-safety
 concerns from the design.
 
 Each ID represents a particular event the process can subscribe to, and not all


### PR DESCRIPTION
Creating a safe, sound API for Subscribe that supports callbacks allocated on the stack is nontrivial, because it is difficult to guarantee the subscription is cleaned up before the callback is deallocated. This design, which is a continuation of https://github.com/tock/libtock-rs/issues/338, is an attempt to create a safe API for Subscribe.

It is inspired by `core::pin`, but for efficiency it uses a distinct handle type (`SubscribeHandle`) that is zero-sized.

I intend to have this PR reviewed by reviewers who are unfamiliar with Tock, and I wrote this document accordingly.

[Rendered](https://github.com/jrvanwhy/libtock-rs/blob/subscribe-api-design/doc/SubscribeApiDesign.md)