### PR TITLE
Update the Rust toolchain to 2021-05-27.

### DIFF
--- a/examples-features/ble_scanning.rs
+++ b/examples-features/ble_scanning.rs
@@ -10,7 +10,6 @@ libtock_core::stack_size! {0x800}
 #[derive(Deserialize)]
 struct LedCommand {
     pub nr: u8,
-    pub st: bool,
 }
 
 #[libtock::main]

--- a/platform/src/command_return_tests.rs
+++ b/platform/src/command_return_tests.rs
@@ -10,16 +10,16 @@ fn failure() {
             1003,
         )
     };
-    assert_eq!(command_return.is_failure(), true);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), Some(ErrorCode::Reserve));
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);
@@ -46,16 +46,16 @@ fn failure_u32() {
             1003,
         )
     };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), true);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(
         command_return.get_failure_u32(),
@@ -85,16 +85,16 @@ fn failure_2_u32() {
             1003,
         )
     };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), true);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(
@@ -127,16 +127,16 @@ fn failure_u64() {
             0x1003,
         )
     };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), true);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);
@@ -159,16 +159,16 @@ fn failure_u64() {
 #[test]
 fn success() {
     let command_return = unsafe { CommandReturn::new(return_variant::SUCCESS, 1001, 1002, 1003) };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), true);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);
@@ -189,16 +189,16 @@ fn success() {
 fn success_u32() {
     let command_return =
         unsafe { CommandReturn::new(return_variant::SUCCESS_U32, 1001, 1002, 1003) };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), true);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);
@@ -219,16 +219,16 @@ fn success_u32() {
 fn success_2_u32() {
     let command_return =
         unsafe { CommandReturn::new(return_variant::SUCCESS_2_U32, 1001, 1002, 1003) };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), true);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);
@@ -252,16 +252,16 @@ fn success_2_u32() {
 fn success_u64() {
     let command_return =
         unsafe { CommandReturn::new(return_variant::SUCCESS_U64, 0x1001, 0x1002, 1003) };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), true);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);
@@ -285,16 +285,16 @@ fn success_u64() {
 fn success_3_u32() {
     let command_return =
         unsafe { CommandReturn::new(return_variant::SUCCESS_3_U32, 1001, 1002, 1003) };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), true);
-    assert_eq!(command_return.is_success_u32_u64(), false);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(command_return.is_success_3_u32());
+    assert!(!command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);
@@ -318,16 +318,16 @@ fn success_3_u32() {
 fn success_u32_u64() {
     let command_return =
         unsafe { CommandReturn::new(return_variant::SUCCESS_U32_U64, 1001, 0x1002, 0x1003) };
-    assert_eq!(command_return.is_failure(), false);
-    assert_eq!(command_return.is_failure_u32(), false);
-    assert_eq!(command_return.is_failure_2_u32(), false);
-    assert_eq!(command_return.is_failure_u64(), false);
-    assert_eq!(command_return.is_success(), false);
-    assert_eq!(command_return.is_success_u32(), false);
-    assert_eq!(command_return.is_success_2_u32(), false);
-    assert_eq!(command_return.is_success_u64(), false);
-    assert_eq!(command_return.is_success_3_u32(), false);
-    assert_eq!(command_return.is_success_u32_u64(), true);
+    assert!(!command_return.is_failure());
+    assert!(!command_return.is_failure_u32());
+    assert!(!command_return.is_failure_2_u32());
+    assert!(!command_return.is_failure_u64());
+    assert!(!command_return.is_success());
+    assert!(!command_return.is_success_u32());
+    assert!(!command_return.is_success_2_u32());
+    assert!(!command_return.is_success_u64());
+    assert!(!command_return.is_success_3_u32());
+    assert!(command_return.is_success_u32_u64());
     assert_eq!(command_return.get_failure(), None);
     assert_eq!(command_return.get_failure_u32(), None);
     assert_eq!(command_return.get_failure_2_u32(), None);

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 [toolchain]
 # See https://rust-lang.github.io/rustup-components-history/ for a list of
 # recently nightlies and what components are available for them.
-channel = "nightly-2021-03-25"
+channel = "nightly-2021-05-27"
 components = ["clippy", "miri", "rustfmt"]
 targets = ["thumbv7em-none-eabi",
            "riscv32imac-unknown-none-elf",

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -570,72 +570,57 @@ mod test {
 
     #[test]
     pub fn alarm_before_systick_wrap_expired() {
-        assert_eq!(
-            super::is_over(
-                super::ActiveTimer {
-                    instant: 2u32,
-                    set_at: 1u32
-                },
-                3u32
-            ),
-            true
-        );
+        assert!(super::is_over(
+            super::ActiveTimer {
+                instant: 2u32,
+                set_at: 1u32
+            },
+            3u32
+        ));
     }
 
     #[test]
     pub fn alarm_before_systick_wrap_not_expired() {
-        assert_eq!(
-            super::is_over(
-                super::ActiveTimer {
-                    instant: 3u32,
-                    set_at: 1u32
-                },
-                2u32
-            ),
-            false
-        );
+        assert!(!super::is_over(
+            super::ActiveTimer {
+                instant: 3u32,
+                set_at: 1u32
+            },
+            2u32
+        ));
     }
 
     #[test]
     pub fn alarm_after_systick_wrap_expired() {
-        assert_eq!(
-            super::is_over(
-                super::ActiveTimer {
-                    instant: 1u32,
-                    set_at: 3u32
-                },
-                2u32
-            ),
-            true
-        );
+        assert!(super::is_over(
+            super::ActiveTimer {
+                instant: 1u32,
+                set_at: 3u32
+            },
+            2u32
+        ));
     }
 
     #[test]
     pub fn alarm_after_systick_wrap_time_before_systick_wrap_not_expired() {
-        assert_eq!(
-            super::is_over(
-                super::ActiveTimer {
-                    instant: 1u32,
-                    set_at: 3u32
-                },
-                4u32
-            ),
-            false
-        );
+        assert!(!super::is_over(
+            super::ActiveTimer {
+                instant: 1u32,
+                set_at: 3u32
+            },
+            4u32
+        ));
     }
 
     #[test]
     pub fn alarm_after_systick_wrap_time_after_systick_wrap_not_expired() {
-        assert_eq!(
-            super::is_over(
-                super::ActiveTimer {
-                    instant: 1u32,
-                    set_at: 3u32
-                },
-                0u32
-            ),
-            false
-        );
+        assert!(!super::is_over(
+            super::ActiveTimer {
+                instant: 1u32,
+                set_at: 3u32
+            },
+            0u32
+        ));
     }
 
     #[test]
@@ -648,7 +633,7 @@ mod test {
             instant: 2u32,
             set_at: 1u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), true);
+        assert!(super::left_is_later(later, earlier));
     }
 
     #[test]
@@ -661,7 +646,7 @@ mod test {
             instant: 3u32,
             set_at: 1u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), false);
+        assert!(!super::left_is_later(later, earlier));
     }
 
     #[test]
@@ -674,7 +659,7 @@ mod test {
             instant: 2u32,
             set_at: 1u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), true);
+        assert!(super::left_is_later(later, earlier));
     }
 
     #[test]
@@ -687,7 +672,7 @@ mod test {
             instant: 1u32,
             set_at: 3u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), false);
+        assert!(!super::left_is_later(later, earlier));
     }
 
     #[test]
@@ -700,7 +685,7 @@ mod test {
             instant: 1u32,
             set_at: 3u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), true);
+        assert!(super::left_is_later(later, earlier));
     }
 
     #[test]
@@ -713,7 +698,7 @@ mod test {
             instant: 2u32,
             set_at: 3u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), false);
+        assert!(!super::left_is_later(later, earlier));
     }
 
     #[test]
@@ -726,7 +711,7 @@ mod test {
             instant: 2u32,
             set_at: 1u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), false);
+        assert!(!super::left_is_later(later, earlier));
     }
 
     #[test]
@@ -739,6 +724,6 @@ mod test {
             instant: 1u32,
             set_at: 2u32,
         };
-        assert_eq!(super::left_is_later(later, earlier), false);
+        assert!(!super::left_is_later(later, earlier));
     }
 }

--- a/unittest/src/exit_test/mod.rs
+++ b/unittest/src/exit_test/mod.rs
@@ -13,12 +13,19 @@ use std::panic::{catch_unwind, Location, UnwindSafe};
 /// is used as follows (inside a unit test case):
 ///
 /// ```
-/// use libtock_platform::Syscalls;
-/// let _kernel = libtock_unittest::fake::Kernel::new();
-/// let exit = libtock_unittest::exit_test("tests::foo", || {
-///     libtock_unittest::fake::Syscalls::exit_terminate(0);
-/// });
-/// assert_eq!(exit, libtock_unittest::ExitCall::Terminate(0));
+/// // Note: exit_test is not available in Miri
+/// #[cfg(miri)]
+/// fn main() {}
+///
+/// #[cfg(not(miri))]
+/// fn main() {
+///     use libtock_platform::Syscalls;
+///     let _kernel = libtock_unittest::fake::Kernel::new();
+///     let exit = libtock_unittest::exit_test("tests::foo", || {
+///         libtock_unittest::fake::Syscalls::exit_terminate(0);
+///     });
+///     assert_eq!(exit, libtock_unittest::ExitCall::Terminate(0));
+/// }
 /// ```
 ///
 /// `exit_test` will panic (to fail the test case) if the code does not call

--- a/unittest/src/fake/kernel.rs
+++ b/unittest/src/fake/kernel.rs
@@ -94,9 +94,7 @@ impl Kernel {
 
     /// Returns the system call log and empties it.
     pub fn take_syscall_log(&self) -> Vec<SyscallLogEntry> {
-        with_kernel_data(|kernel_data| {
-            std::mem::replace(&mut kernel_data.unwrap().syscall_log, Vec::new())
-        })
+        with_kernel_data(|kernel_data| std::mem::take(&mut kernel_data.unwrap().syscall_log))
     }
 }
 


### PR DESCRIPTION
This fixes CI. CI broke because `cargo miri test` runs `cargo install xargo`, and the latest `xargo` requires a newer toolchain than we were using.

`cargo miri test` now appears to run doc tests, regardless of whether or not they are marked `#[cfg(not(miri))]`. That caused a test failure when `exit_test` was run. To fix this, I added some manual config annotations into the `exit_test` doc test to make it a no-op under Miri.

Changes in lints led to the following tweaks:

1. A number of `assert_eq!(..., <bool>)` checks were replaced with `assert!(...)`.
2. An unused field was removed from the `ble_scanning` example.
3. A `std::mem::replace` call was migrated to `std::mem::take`.