### PR TITLE
Rename `fake::driver` to `fake::SyscallDriver`.

### DIFF
--- a/syscalls_tests/src/allow_ro.rs
+++ b/syscalls_tests/src/allow_ro.rs
@@ -9,7 +9,7 @@ struct TestDriver {
     buffer_0: Cell<RoAllowBuffer>,
 }
 
-impl fake::Driver for TestDriver {
+impl fake::SyscallDriver for TestDriver {
     fn id(&self) -> u32 {
         42
     }

--- a/syscalls_tests/src/allow_rw.rs
+++ b/syscalls_tests/src/allow_rw.rs
@@ -9,7 +9,7 @@ struct TestDriver {
     buffer_0: Cell<RwAllowBuffer>,
 }
 
-impl fake::Driver for TestDriver {
+impl fake::SyscallDriver for TestDriver {
     fn id(&self) -> u32 {
         42
     }

--- a/syscalls_tests/src/subscribe_tests.rs
+++ b/syscalls_tests/src/subscribe_tests.rs
@@ -10,7 +10,7 @@ use libtock_unittest::{command_return, fake, upcall, SyscallLogEntry};
 // TODO: Replace with a real driver once a driver that accepts an upcall exists.
 struct MockDriver;
 
-impl fake::Driver for MockDriver {
+impl fake::SyscallDriver for MockDriver {
     fn id(&self) -> u32 {
         1
     }

--- a/unittest/src/fake/kernel.rs
+++ b/unittest/src/fake/kernel.rs
@@ -2,9 +2,9 @@ use crate::kernel_data::{with_kernel_data, DriverData, KernelData, KERNEL_DATA};
 use crate::{ExpectedSyscall, SyscallLogEntry};
 
 /// A fake implementation of the Tock kernel. Used with `fake::Syscalls`, which
-/// provides system calls that are routed to this kernel. `fake::Driver`s may be
-/// attached to a `fake::Kernel`, and the `fake::Kernel` will route system calls
-/// to the correct fake driver.
+/// provides system calls that are routed to this kernel. `fake::SyscallDriver`s
+/// may be attached to a `fake::Kernel`, and the `fake::Kernel` will route
+/// system calls to the correct fake driver.
 ///
 /// Note that there can only be one `fake::Kernel` instance per thread, as
 /// `fake::Syscalls` uses a thread-local variable to locate the `fake::Kernel`.
@@ -48,13 +48,14 @@ impl Kernel {
         Kernel { _private: () }
     }
 
-    /// Adds a `fake::Driver` to this `fake::Kernel`. After the call, system
-    /// calls with this driver's ID will be routed to the driver.
+    /// Adds a `fake::SyscallDriver` to this `fake::Kernel`. After the call,
+    /// system calls with this driver's ID will be routed to the driver.
     // TODO: It's kind of weird to implicitly clone the RC by default. Instead,
     // we should probably take the Rc by value. Also, after making that change,
-    // maybe we can take a Rc<dyn fake::Driver> instead of using generics?
+    // maybe we can take a Rc<dyn fake::SyscallDriver> instead of using
+    // generics?
     // TODO: Add a test for add_driver.
-    pub fn add_driver<D: crate::fake::Driver>(&self, driver: &std::rc::Rc<D>) {
+    pub fn add_driver<D: crate::fake::SyscallDriver>(&self, driver: &std::rc::Rc<D>) {
         let id = driver.id();
         let num_upcalls = driver.num_upcalls();
         let driver_data = DriverData {
@@ -74,7 +75,7 @@ impl Kernel {
     /// In addition to routing system calls to drivers, `Kernel` supports
     /// injecting artificial system call responses. The primary use case for
     /// this feature is to simulate errors without having to implement error
-    /// simulation in each `fake::Driver`.
+    /// simulation in each `fake::SyscallDriver`.
     ///
     /// The expected syscall queue is a FIFO queue containing anticipated
     /// upcoming system calls. It starts empty, and as long as it is empty, the

--- a/unittest/src/fake/low_level_debug/mod.rs
+++ b/unittest/src/fake/low_level_debug/mod.rs
@@ -25,7 +25,7 @@ impl LowLevelDebug {
     }
 }
 
-impl crate::fake::Driver for LowLevelDebug {
+impl crate::fake::SyscallDriver for LowLevelDebug {
     fn id(&self) -> u32 {
         DRIVER_NUMBER
     }

--- a/unittest/src/fake/low_level_debug/tests.rs
+++ b/unittest/src/fake/low_level_debug/tests.rs
@@ -4,7 +4,7 @@ use fake::low_level_debug::*;
 // Tests the command implementation.
 #[test]
 fn command() {
-    use fake::Driver;
+    use fake::SyscallDriver;
     let low_level_debug = LowLevelDebug::new();
     assert!(low_level_debug.command(DRIVER_CHECK, 1, 2).is_success());
     assert!(low_level_debug.command(PRINT_ALERT_CODE, 3, 4).is_success());

--- a/unittest/src/fake/mod.rs
+++ b/unittest/src/fake/mod.rs
@@ -9,14 +9,14 @@
 //! `use libtock_unittest::fake` and refer to the type with the `fake::` prefix
 //! (e.g. `fake::Console`).
 
-mod driver;
 mod kernel;
 mod low_level_debug;
+mod syscall_driver;
 mod syscalls;
 
-pub use driver::Driver;
 pub use kernel::Kernel;
 pub use low_level_debug::{LowLevelDebug, Message};
+pub use syscall_driver::SyscallDriver;
 pub use syscalls::Syscalls;
 
 #[cfg(test)]

--- a/unittest/src/fake/syscall_driver.rs
+++ b/unittest/src/fake/syscall_driver.rs
@@ -1,12 +1,12 @@
 use crate::{RoAllowBuffer, RwAllowBuffer};
 use libtock_platform::{CommandReturn, ErrorCode};
 
-/// The `fake::Driver` trait is implemented by fake versions of Tock's kernel
-/// APIs. It is used by `fake::Kernel` to route system calls to the fake kernel
-/// APIs.
-pub trait Driver: 'static {
+/// The `fake::SyscallDriver` trait is implemented by fake versions of Tock's
+/// kernel APIs. It is used by `fake::Kernel` to route system calls to the fake
+/// kernel APIs.
+pub trait SyscallDriver: 'static {
     /// Returns this driver's ID. Used by `fake::Kernel` to route syscalls to
-    /// the correct `fake::Driver` instance.
+    /// the correct `fake::SyscallDriver` instance.
     fn id(&self) -> u32;
 
     // -------------------------------------------------------------------------
@@ -31,9 +31,9 @@ pub trait Driver: 'static {
     // Allow
     // -------------------------------------------------------------------------
 
-    /// Process a Read-Only Allow call. Because not all Driver implementations
-    /// need to support Read-Only Allow, a default implementation is provided
-    /// that rejects all Read-Only Allow calls.
+    /// Process a Read-Only Allow call. Because not all `SyscallDriver`
+    /// implementations need to support Read-Only Allow, a default
+    /// implementation is provided that rejects all Read-Only Allow calls.
     fn allow_readonly(
         &self,
         buffer_number: u32,
@@ -43,9 +43,9 @@ pub trait Driver: 'static {
         Err((buffer, ErrorCode::NoSupport))
     }
 
-    /// Process a Read-Write Allow call. Because not all Driver implementations
-    /// need to support Read-Write Allow, a default implementation is provided
-    /// that rejects all Read-Write Allow calls.
+    /// Process a Read-Write Allow call. Because not all SyscallDriver
+    /// implementations need to support Read-Write Allow, a default
+    /// implementation is provided that rejects all Read-Write Allow calls.
     fn allow_readwrite(
         &self,
         buffer_number: u32,

--- a/unittest/src/fake/syscalls/allow_ro_impl.rs
+++ b/unittest/src/fake/syscalls/allow_ro_impl.rs
@@ -76,8 +76,8 @@ pub(super) unsafe fn allow_ro(
     };
 
     let (address_out, len_out) = with_kernel_data(|option_kernel_data| {
-        let kernel_data =
-            option_kernel_data.expect("fake::Kernel dropped during fake::Driver::allow_readonly");
+        let kernel_data = option_kernel_data
+            .expect("fake::Kernel dropped during fake::SyscallDriver::allow_readonly");
         kernel_data.allow_db.remove_ro_buffer(buffer_out)
     });
 

--- a/unittest/src/fake/syscalls/allow_rw_impl.rs
+++ b/unittest/src/fake/syscalls/allow_rw_impl.rs
@@ -77,8 +77,8 @@ pub(super) unsafe fn allow_rw(
     };
 
     let (address_out, len_out) = with_kernel_data(|option_kernel_data| {
-        let kernel_data =
-            option_kernel_data.expect("fake::Kernel dropped during fake::Driver::allow_readwrite");
+        let kernel_data = option_kernel_data
+            .expect("fake::Kernel dropped during fake::SyscallDriver::allow_readwrite");
         kernel_data.allow_db.remove_rw_buffer(buffer_out)
     });
 

--- a/unittest/src/fake/syscalls/command_impl_tests.rs
+++ b/unittest/src/fake/syscalls/command_impl_tests.rs
@@ -27,7 +27,7 @@ fn driver_support() {
     // driver), we should remove MockDriver and replace it with the fake driver,
     // so we have 1 fewer Driver implementations to maintain.
     struct MockDriver;
-    impl fake::Driver for MockDriver {
+    impl fake::SyscallDriver for MockDriver {
         fn id(&self) -> u32 {
             42
         }

--- a/unittest/src/kernel_data.rs
+++ b/unittest/src/kernel_data.rs
@@ -36,7 +36,7 @@ pub(crate) fn with_kernel_data<F: FnOnce(Option<&mut KernelData>) -> R, R>(f: F)
 
 // Per-driver data stored in KernelData.
 pub struct DriverData {
-    pub driver: std::rc::Rc<dyn crate::fake::Driver>,
+    pub driver: std::rc::Rc<dyn crate::fake::SyscallDriver>,
     pub num_upcalls: u32,
 
     // Currently-valid upcalls passed to Subscribe. The key is the subscribe

--- a/unittest/src/upcall.rs
+++ b/unittest/src/upcall.rs
@@ -117,7 +117,7 @@ mod tests {
     use super::*;
 
     struct MockDriver;
-    impl crate::fake::Driver for MockDriver {
+    impl crate::fake::SyscallDriver for MockDriver {
         fn id(&self) -> u32 {
             1
         }


### PR DESCRIPTION
https://github.com/tock/tock/pull/2659 renamed the Tock kernel's `Driver` trait to `SyscallDriver`, because the term "driver" has too many different meanings in Tock. This change does the same, but `libtock_unittest`'s fake version of the trait.