### PR TITLE
Add the first libtock2 example.

### DIFF
--- a/libtock2/Cargo.toml
+++ b/libtock2/Cargo.toml
@@ -13,3 +13,7 @@ version = "0.1.0"
 libtock_platform = { path = "../platform" }
 libtock_runtime = { path = "../runtime" }
 libtock_low_level_debug = { path = "../apis/low_level_debug" }
+
+# TODO: Implement a panic handler with more debugging functionality, then
+# replace libtock_small_panic with the debug-heavy panic handler here.
+libtock_small_panic = { path = "../panic_handlers/small_panic" }

--- a/libtock2/examples/low_level_debug.rs
+++ b/libtock2/examples/low_level_debug.rs
@@ -1,0 +1,16 @@
+//! An extremely simple libtock-rs example. Just prints out a few numbers using
+//! the LowLevelDebug capsule then terminates.
+
+#![no_main]
+#![no_std]
+
+use libtock2::low_level_debug::LowLevelDebug;
+use libtock2::runtime::{set_main, stack_size};
+
+set_main! {main}
+stack_size! {0x100}
+
+fn main() {
+    LowLevelDebug::print_1(1);
+    LowLevelDebug::print_2(2, 3);
+}

--- a/libtock2/src/lib.rs
+++ b/libtock2/src/lib.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
+extern crate libtock_small_panic;
+
 pub use libtock_platform as platform;
 pub use libtock_runtime as runtime;
 


### PR DESCRIPTION
This example just tries to print 2 numbers using the LowLevelDebug capsule. It's primary benefit is as a testing and debugging tool, as it is almost as simple as possible while still providing enough output to know it's working.