### PR TITLE
Add microbit_v2 layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ usage:
 	@echo "libtock-rs currently includes support for the following platforms:"
 	@echo " - hail"
 	@echo " - nrf52840"
+	@echo " - microbit_v2"
 	@echo " - nucleo_f429zi"
 	@echo " - nucleo_f446re"
 	@echo " - opentitan"
@@ -152,6 +153,14 @@ hail:
 .PHONY: flash-hail
 flash-hail:
 	PLATFORM=hail cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
+
+.PHONY: microbit_v2
+microbit_v2:
+	PLATFORM=microbit_v2 cargo build $(release) --target=thumbv7em-none-eabi --examples $(features)
+
+.PHONY: flash-microbit_v2
+flash-microbit_v2:
+	PLATFORM=microbit_v2 cargo run $(release) --target=thumbv7em-none-eabi --example $(EXAMPLE) $(features)
 
 .PHONY: nucleo_f429zi
 nucleo_f429zi:

--- a/runtime/layouts/microbit_v2.ld
+++ b/runtime/layouts/microbit_v2.ld
@@ -1,0 +1,11 @@
+/* Layout for the micro:bit v2 board, used by the examples in this repository. */
+
+MEMORY {
+  FLASH (rx) : ORIGIN = 0x00040000, LENGTH = 256K
+  RAM (rwx) : ORIGIN = 0x20004000, LENGTH = 112K
+}
+
+MPU_MIN_ALIGN = 8K;
+
+TBF_HEADER_SIZE = 0x48;
+INCLUDE libtock_layout.ld

--- a/runtime/layouts/microbit_v2.ld
+++ b/runtime/layouts/microbit_v2.ld
@@ -1,11 +1,9 @@
 /* Layout for the micro:bit v2 board, used by the examples in this repository. */
 
 MEMORY {
-  FLASH (rx) : ORIGIN = 0x00040000, LENGTH = 256K
-  RAM (rwx) : ORIGIN = 0x20004000, LENGTH = 112K
+  FLASH (X) : ORIGIN = 0x00040000, LENGTH = 256K
+  RAM (W) : ORIGIN = 0x20004000, LENGTH = 112K
 }
-
-MPU_MIN_ALIGN = 8K;
 
 TBF_HEADER_SIZE = 0x48;
 INCLUDE libtock_layout.ld

--- a/tools/flash.sh
+++ b/tools/flash.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
-set -eux
-
 TBF_HEADER=64
+KERNEL_VERSION=""
+
+if [ ! -z $LIBTOCK_PLATFORM ]; then
+    # we are using libtock2
+	PLATFORM=$LIBTOCK_PLATFORM
+	TBF_HEADER=72
+    KERNEL_VERSION="--kernel-major 2 --kernel-minor 0"
+fi
+
+set -eux
 
 artifact="$(basename $1)"
 rust_target_folder="$(cd $(dirname $1)/../.. && pwd -P)"
@@ -14,13 +22,6 @@ fi
 if [ -z $KERNEL_HEAP_SIZE ]; then
 	echo "Set KERNEL_HEAP_SIZE to a value"
 	exit 1
-fi
-
-if [ ! -z $LIBTOCK_PLATFORM ]; then
-    # we are using libtock2
-	PLATFORM=$LIBTOCK_PLATFORM
-	TBF_HEADER=72
-    KERNEL_VERSION="--kernel-major 2 --kernel-minor 0"
 fi
 
 case "${PLATFORM}" in


### PR DESCRIPTION
The PR adds the microbit_v2 memory layout and modifies `flash.sh` to (hopefully) work with both versions of libtock.

It also adds the`microbit_v2` board to the Makefile, even tough Makefile uses libtock1.