### PR TITLE
Leds driver (v1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ debug = true
 [workspace]
 exclude = [ "tock" ]
 members = [
+    "apis/leds",
     "apis/low_level_debug",
     "codegen",
     "core",

--- a/apis/leds/Cargo.toml
+++ b/apis/leds/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "libtock_leds"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+license = "MIT/Apache-2.0"
+edition = "2018"
+repository = "https://www.github.com/tock/libtock-rs"
+description = "libtock low-level debug drivers"
+
+[dependencies]
+libtock_platform = { path = "../../platform" }
+
+[dev-dependencies]
+libtock_unittest = { path = "../../unittest" }

--- a/apis/leds/Cargo.toml
+++ b/apis/leds/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
 repository = "https://www.github.com/tock/libtock-rs"
-description = "libtock low-level debug drivers"
+description = "libtock leds driver"
 
 [dependencies]
 libtock_platform = { path = "../../platform" }

--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -1,0 +1,60 @@
+#![no_std]
+
+use libtock_platform::Syscalls;
+
+/// The LEDs driver
+///
+/// # Example
+/// ```ignore
+/// use libtock2::Leds;
+///
+/// // Turn on led 0
+/// Leds::on(0);
+/// ```
+pub struct Leds<S: Syscalls>(S);
+
+impl<S: Syscalls> Leds<S> {
+    /// Run a check against the leds capsule to ensure it is present.
+    ///
+    /// Returns `true` if the driver was present. This does not necessarily mean
+    /// that the driver is working, as it may still fail to allocate grant
+    /// memory.
+    #[inline(always)]
+    pub fn driver_check() -> bool {
+        S::command(DRIVER_ID, DRIVER_CHECK, 0, 0).is_success_u32()
+    }
+
+    #[inline(always)]
+    pub fn count() -> usize {
+        S::command(DRIVER_ID, LEDS_COUNT, 0, 0)
+            .get_success_u32()
+            .unwrap_or_default() as usize
+    }
+
+    #[inline(always)]
+    pub fn on(led: usize) {
+        S::command(DRIVER_ID, LED_ON, led as u32, 0);
+    }
+
+    #[inline(always)]
+    pub fn off(led: usize) {
+        S::command(DRIVER_ID, LED_OFF, led as u32, 0);
+    }
+
+    #[inline(always)]
+    pub fn toggle(led: usize) {
+        S::command(DRIVER_ID, LED_TOGGLE, led as u32, 0);
+    }
+}
+
+const DRIVER_ID: u32 = 2;
+
+// Command IDs
+const DRIVER_CHECK: u32 = 0;
+const LEDS_COUNT: u32 = 0;
+const LED_ON: u32 = 1;
+const LED_OFF: u32 = 2;
+const LED_TOGGLE: u32 = 3;
+
+#[cfg(test)]
+mod tests;

--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -20,10 +20,7 @@ impl<S: Syscalls> Leds<S> {
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
     pub fn count() -> Option<u32> {
-        S::command(DRIVER_ID, LEDS_COUNT, 0, 0)
-            .get_success_u32()
-            .map(|leds_count| Some(leds_count))
-            .unwrap_or(None)
+        S::command(DRIVER_ID, LEDS_COUNT, 0, 0).get_success_u32()
     }
 
     pub fn on(led: u32) {

--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -19,10 +19,10 @@ impl<S: Syscalls> Leds<S> {
     /// Returns `Some(number_of_leds)` if the driver was present. This does not necessarily mean
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
-    pub fn count() -> Option<usize> {
+    pub fn count() -> Option<u32> {
         S::command(DRIVER_ID, LEDS_COUNT, 0, 0)
             .get_success_u32()
-            .map(|leds_count| Some(leds_count as usize))
+            .map(|leds_count| Some(leds_count))
             .unwrap_or(None)
     }
 

--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -16,41 +16,32 @@ pub struct Leds<S: Syscalls>(S);
 impl<S: Syscalls> Leds<S> {
     /// Run a check against the leds capsule to ensure it is present.
     ///
-    /// Returns `true` if the driver was present. This does not necessarily mean
+    /// Returns `Some(number_of_leds)` if the driver was present. This does not necessarily mean
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
-    #[inline(always)]
-    pub fn driver_check() -> bool {
-        S::command(DRIVER_ID, DRIVER_CHECK, 0, 0).is_success_u32()
-    }
-
-    #[inline(always)]
-    pub fn count() -> usize {
+    pub fn count() -> Option<usize> {
         S::command(DRIVER_ID, LEDS_COUNT, 0, 0)
             .get_success_u32()
-            .unwrap_or_default() as usize
+            .map(|leds_count| Some(leds_count as usize))
+            .unwrap_or(None)
     }
 
-    #[inline(always)]
-    pub fn on(led: usize) {
-        S::command(DRIVER_ID, LED_ON, led as u32, 0);
+    pub fn on(led: u32) {
+        S::command(DRIVER_ID, LED_ON, led, 0);
     }
 
-    #[inline(always)]
-    pub fn off(led: usize) {
-        S::command(DRIVER_ID, LED_OFF, led as u32, 0);
+    pub fn off(led: u32) {
+        S::command(DRIVER_ID, LED_OFF, led, 0);
     }
 
-    #[inline(always)]
-    pub fn toggle(led: usize) {
-        S::command(DRIVER_ID, LED_TOGGLE, led as u32, 0);
+    pub fn toggle(led: u32) {
+        S::command(DRIVER_ID, LED_TOGGLE, led, 0);
     }
 }
 
 const DRIVER_ID: u32 = 2;
 
 // Command IDs
-const DRIVER_CHECK: u32 = 0;
 const LEDS_COUNT: u32 = 0;
 const LED_ON: u32 = 1;
 const LED_OFF: u32 = 2;

--- a/apis/leds/src/tests.rs
+++ b/apis/leds/src/tests.rs
@@ -1,0 +1,85 @@
+use libtock_unittest::fake;
+
+type Leds = super::Leds<fake::Syscalls>;
+
+#[test]
+fn no_driver() {
+    let _kernel = fake::Kernel::new();
+    assert!(!Leds::driver_check());
+}
+
+#[test]
+fn driver_check() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    assert!(Leds::driver_check());
+    for led in 0..10 {
+        assert_eq!(driver.get_led(led), Some(false));
+    }
+}
+
+#[test]
+fn num_leds() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+    assert_eq!(Leds::count(), 10);
+}
+
+#[test]
+fn on() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    Leds::on(0);
+    assert_eq!(driver.get_led(0), Some(true));
+}
+
+#[test]
+fn off() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    Leds::off(0);
+    assert_eq!(driver.get_led(0), Some(false));
+}
+
+#[test]
+fn toggle() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    Leds::toggle(0);
+    assert_eq!(driver.get_led(0), Some(true));
+    Leds::toggle(0);
+    assert_eq!(driver.get_led(0), Some(false));
+}
+
+#[test]
+fn on_off() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    Leds::on(0);
+    assert_eq!(driver.get_led(0), Some(true));
+    Leds::off(0);
+    assert_eq!(driver.get_led(0), Some(false));
+}
+
+#[test]
+fn no_led() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    Leds::on(11);
+    for led in 0..Leds::count() {
+        assert_eq!(driver.get_led(led), Some(false));
+    }
+}

--- a/apis/leds/src/tests.rs
+++ b/apis/leds/src/tests.rs
@@ -5,7 +5,7 @@ type Leds = super::Leds<fake::Syscalls>;
 #[test]
 fn no_driver() {
     let _kernel = fake::Kernel::new();
-    assert!(Leds::count().is_none());
+    assert_eq!(Leds::count(), None);
 }
 
 #[test]

--- a/apis/leds/src/tests.rs
+++ b/apis/leds/src/tests.rs
@@ -5,7 +5,7 @@ type Leds = super::Leds<fake::Syscalls>;
 #[test]
 fn no_driver() {
     let _kernel = fake::Kernel::new();
-    assert!(!Leds::driver_check());
+    assert!(Leds::count().is_none());
 }
 
 #[test]
@@ -14,7 +14,7 @@ fn driver_check() {
     let driver = fake::Leds::<10>::new();
     kernel.add_driver(&driver);
 
-    assert!(Leds::driver_check());
+    assert!(Leds::count().is_some());
     for led in 0..10 {
         assert_eq!(driver.get_led(led), Some(false));
     }
@@ -25,7 +25,7 @@ fn num_leds() {
     let kernel = fake::Kernel::new();
     let driver = fake::Leds::<10>::new();
     kernel.add_driver(&driver);
-    assert_eq!(Leds::count(), 10);
+    assert_eq!(Leds::count().unwrap_or_default(), 10);
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn no_led() {
     kernel.add_driver(&driver);
 
     Leds::on(11);
-    for led in 0..Leds::count() {
+    for led in 0..Leds::count().unwrap_or_default() {
         assert_eq!(driver.get_led(led), Some(false));
     }
 }

--- a/libtock2/Cargo.toml
+++ b/libtock2/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 [dependencies]
 libtock_platform = { path = "../platform" }
 libtock_runtime = { path = "../runtime" }
+libtock_leds = { path = "../apis/leds" }
 libtock_low_level_debug = { path = "../apis/low_level_debug" }
 
 # TODO: Implement a panic handler with more debugging functionality, then

--- a/libtock2/examples/leds.rs
+++ b/libtock2/examples/leds.rs
@@ -1,0 +1,15 @@
+//! An extremely simple libtock-rs example. Just prints out a few numbers using
+//! the LowLevelDebug capsule then terminates.
+
+#![no_main]
+#![no_std]
+
+use libtock2::leds::Leds;
+use libtock2::runtime::{set_main, stack_size};
+
+set_main! {main}
+stack_size! {0x100}
+
+fn main() {
+    Leds::on(0);
+}

--- a/libtock2/examples/leds.rs
+++ b/libtock2/examples/leds.rs
@@ -1,5 +1,4 @@
-//! An extremely simple libtock-rs example. Just prints out a few numbers using
-//! the LowLevelDebug capsule then terminates.
+//! An extremely simple libtock-rs example. Just turns on all the LEDs.
 
 #![no_main]
 #![no_std]
@@ -11,5 +10,9 @@ set_main! {main}
 stack_size! {0x100}
 
 fn main() {
-    Leds::on(0);
+    if let Some(leds_count) = Leds::count() {
+        for led_index in 0..leds_count {
+            Leds::on(led_index as u32);
+        }
+    }
 }

--- a/libtock2/src/lib.rs
+++ b/libtock2/src/lib.rs
@@ -6,6 +6,10 @@ extern crate libtock_small_panic;
 pub use libtock_platform as platform;
 pub use libtock_runtime as runtime;
 
+pub mod leds {
+    use libtock_leds as leds;
+    pub type Leds = leds::Leds<super::runtime::TockSyscalls>;
+}
 pub mod low_level_debug {
     use libtock_low_level_debug as lldb;
     pub type LowLevelDebug = lldb::LowLevelDebug<super::runtime::TockSyscalls>;

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -1,0 +1,88 @@
+//! Fake implementation of the LowLevelDebug API, documented here:
+//! https://github.com/tock/tock/blob/master/doc/syscalls/00008_low_level_debug.md
+//!
+//! Like the real API, `LowLevelDebug` prints each message it is commanded to
+//! print. It also keeps a log of the messages as `Message` instances, which can
+//! be retrieved via `take_messages` for use in unit tests.
+
+use core::cell::Cell;
+use libtock_platform::{CommandReturn, ErrorCode};
+
+pub struct Leds<const LEDS_COUNT: usize> {
+    leds: [Cell<bool>; LEDS_COUNT],
+}
+
+impl<const LEDS_COUNT: usize> Leds<LEDS_COUNT> {
+    pub fn new() -> std::rc::Rc<Leds<LEDS_COUNT>> {
+        #[allow(clippy::declare_interior_mutable_const)]
+        const OFF: Cell<bool> = Cell::new(false);
+        std::rc::Rc::new(Leds {
+            leds: [OFF; LEDS_COUNT],
+        })
+    }
+}
+
+impl<const LEDS_COUNT: usize> crate::fake::SyscallDriver for Leds<LEDS_COUNT> {
+    fn id(&self) -> u32 {
+        DRIVER_NUMBER
+    }
+    fn num_upcalls(&self) -> u32 {
+        0
+    }
+
+    fn command(&self, command_number: u32, argument0: u32, _argument1: u32) -> CommandReturn {
+        match command_number {
+            DRIVER_CHECK => crate::command_return::success_u32(LEDS_COUNT as u32),
+            LED_ON => {
+                if argument0 < LEDS_COUNT as u32 {
+                    self.leds[argument0 as usize].set(true);
+                    crate::command_return::success()
+                } else {
+                    crate::command_return::failure(ErrorCode::Invalid)
+                }
+            }
+            LED_OFF => {
+                if argument0 < LEDS_COUNT as u32 {
+                    self.leds[argument0 as usize].set(false);
+                    crate::command_return::success()
+                } else {
+                    crate::command_return::failure(ErrorCode::Invalid)
+                }
+            }
+            LED_TOGGLE => {
+                if argument0 < LEDS_COUNT as u32 {
+                    self.leds[argument0 as usize].set(!self.leds[argument0 as usize].get());
+                    crate::command_return::success()
+                } else {
+                    crate::command_return::failure(ErrorCode::Invalid)
+                }
+            }
+            _ => crate::command_return::failure(ErrorCode::NoSupport),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Implementation details below
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests;
+
+const DRIVER_NUMBER: u32 = 2;
+
+// Command numbers
+const DRIVER_CHECK: u32 = 0;
+const LED_ON: u32 = 1;
+const LED_OFF: u32 = 2;
+const LED_TOGGLE: u32 = 3;
+
+impl<const NUM_LEDS: usize> Leds<NUM_LEDS> {
+    pub fn get_led(&self, led: usize) -> Option<bool> {
+        if led < NUM_LEDS {
+            Some(self.leds[led].get())
+        } else {
+            None
+        }
+    }
+}

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -78,10 +78,6 @@ const LED_TOGGLE: u32 = 3;
 
 impl<const NUM_LEDS: usize> Leds<NUM_LEDS> {
     pub fn get_led(&self, led: usize) -> Option<bool> {
-        if led < NUM_LEDS {
-            Some(self.leds[led].get())
-        } else {
-            None
-        }
+        self.leds.get(led).map(|led| led.get())
     }
 }

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -1,9 +1,8 @@
-//! Fake implementation of the LowLevelDebug API, documented here:
-//! https://github.com/tock/tock/blob/master/doc/syscalls/00008_low_level_debug.md
+//! Fake implementation of the LEDs API, documented here:
+//! https://github.com/tock/tock/blob/master/doc/syscalls/00002_leds.md
 //!
-//! Like the real API, `LowLevelDebug` prints each message it is commanded to
-//! print. It also keeps a log of the messages as `Message` instances, which can
-//! be retrieved via `take_messages` for use in unit tests.
+//! Like the real API, `Leds` controls a set of fake LEDs. It provides
+//! a function `get_led` used to retrieve the state of an LED.
 
 use core::cell::Cell;
 use libtock_platform::{CommandReturn, ErrorCode};

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -77,7 +77,7 @@ const LED_OFF: u32 = 2;
 const LED_TOGGLE: u32 = 3;
 
 impl<const NUM_LEDS: usize> Leds<NUM_LEDS> {
-    pub fn get_led(&self, led: usize) -> Option<bool> {
-        self.leds.get(led).map(|led| led.get())
+    pub fn get_led(&self, led: u32) -> Option<bool> {
+        self.leds.get(led as usize).map(|led| led.get())
     }
 }

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -1,0 +1,45 @@
+use crate::fake;
+use fake::leds::*;
+
+// Tests the command implementation.
+#[test]
+fn command() {
+    use fake::SyscallDriver;
+    let leds = Leds::<10>::new();
+    let value = leds.command(DRIVER_CHECK, 1, 2);
+    assert!(value.is_success_u32());
+    assert_eq!(value.get_success_u32(), Some(10));
+    assert!(leds.command(LED_ON, 11, 0).is_failure());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(leds.command(LED_ON, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(leds.command(LED_OFF, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(leds.command(LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(leds.command(LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+}
+
+// Integration test that verifies LowLevelDebug works with fake::Kernel and
+// libtock_platform::Syscalls.
+#[test]
+fn kernel_integration() {
+    use libtock_platform::Syscalls;
+    let kernel = fake::Kernel::new();
+    let leds = Leds::<10>::new();
+    kernel.add_driver(&leds);
+    let value = fake::Syscalls::command(DRIVER_NUMBER, DRIVER_CHECK, 1, 2);
+    assert!(value.is_success_u32());
+    assert_eq!(value.get_success_u32(), Some(10));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 11, 0).is_failure());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_OFF, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+}

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -1,5 +1,6 @@
 use crate::fake;
 use fake::leds::*;
+use libtock_platform::ErrorCode;
 
 // Tests the command implementation.
 #[test]
@@ -8,7 +9,10 @@ fn command() {
     let leds = Leds::<10>::new();
     let value = leds.command(DRIVER_CHECK, 1, 2);
     assert_eq!(value.get_success_u32(), Some(10));
-    assert!(leds.command(LED_ON, 11, 0).is_failure());
+    assert_eq!(
+        leds.command(LED_ON, 11, 0).get_failure(),
+        Some(ErrorCode::Invalid)
+    );
     assert_eq!(leds.get_led(0), Some(false));
     assert!(leds.command(LED_ON, 0, 0).is_success());
     assert_eq!(leds.get_led(0), Some(true));
@@ -31,7 +35,10 @@ fn kernel_integration() {
     let value = fake::Syscalls::command(DRIVER_NUMBER, DRIVER_CHECK, 1, 2);
     assert!(value.is_success_u32());
     assert_eq!(value.get_success_u32(), Some(10));
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 11, 0).is_failure());
+    assert_eq!(
+        fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 11, 0).get_failure(),
+        Some(ErrorCode::Invalid)
+    );
     assert_eq!(leds.get_led(0), Some(false));
     assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 0, 0).is_success());
     assert_eq!(leds.get_led(0), Some(true));

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -7,7 +7,6 @@ fn command() {
     use fake::SyscallDriver;
     let leds = Leds::<10>::new();
     let value = leds.command(DRIVER_CHECK, 1, 2);
-    assert!(value.is_success_u32());
     assert_eq!(value.get_success_u32(), Some(10));
     assert!(leds.command(LED_ON, 11, 0).is_failure());
     assert_eq!(leds.get_led(0), Some(false));

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -21,7 +21,7 @@ fn command() {
     assert_eq!(leds.get_led(0), Some(false));
 }
 
-// Integration test that verifies LowLevelDebug works with fake::Kernel and
+// Integration test that verifies Leds works with fake::Kernel and
 // libtock_platform::Syscalls.
 #[test]
 fn kernel_integration() {

--- a/unittest/src/fake/mod.rs
+++ b/unittest/src/fake/mod.rs
@@ -10,11 +10,13 @@
 //! (e.g. `fake::Console`).
 
 mod kernel;
+mod leds;
 mod low_level_debug;
 mod syscall_driver;
 mod syscalls;
 
 pub use kernel::Kernel;
+pub use leds::Leds;
 pub use low_level_debug::{LowLevelDebug, Message};
 pub use syscall_driver::SyscallDriver;
 pub use syscalls::Syscalls;


### PR DESCRIPTION
This PR adds a LEDs driver similar to the `LowLevelDebug` one, but very different from the previous LEDs driver (libtock1). 
