### PR TITLE
Leds driver (v2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ debug = true
 [workspace]
 exclude = [ "tock" ]
 members = [
+    "apis/leds",
     "apis/low_level_debug",
     "codegen",
     "core",

--- a/apis/leds/Cargo.toml
+++ b/apis/leds/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "libtock_leds"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+license = "MIT/Apache-2.0"
+edition = "2018"
+repository = "https://www.github.com/tock/libtock-rs"
+description = "libtock low-level debug drivers"
+
+[dependencies]
+libtock_platform = { path = "../../platform" }
+
+[dev-dependencies]
+libtock_unittest = { path = "../../unittest" }

--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -1,0 +1,168 @@
+#![no_std]
+
+use libtock_platform::{ErrorCode, Syscalls};
+
+/// The LEDs driver
+///
+/// # Example
+/// ```ignore
+/// use libtock2::LedsFactory;
+///
+/// let mut leds_factory = LedsFactory::new();
+/// let leds_driver = leds_factory.init_driver()?;
+/// // Turn on led 0
+/// leds_driver.get(0)?.on()
+/// ```
+use core::marker::PhantomData;
+
+mod command_nr {
+    pub const COUNT: u32 = 0;
+    pub const ON: u32 = 1;
+    pub const OFF: u32 = 2;
+    pub const TOGGLE: u32 = 3;
+}
+
+#[non_exhaustive]
+pub struct LedsFactory<S: Syscalls>(PhantomData<S>);
+
+impl<S: Syscalls> LedsFactory<S> {
+    pub fn init_driver(&mut self) -> Result<LedsDriver<S>, ErrorCode> {
+        let num_leds = S::command(DRIVER_ID, command_nr::COUNT, 0, 0);
+        if num_leds.is_success_u32() {
+            let driver = LedsDriver {
+                num_leds: num_leds.get_success_u32().unwrap_or_default() as usize,
+                lifetime: PhantomData,
+            };
+            Ok(driver)
+        } else {
+            Err(num_leds.get_failure().unwrap_or(ErrorCode::Fail))
+        }
+    }
+
+    // temporary placeholder here so that driver is usable
+    // until a driver imfrastrucrure is put in place
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> LedsFactory<S> {
+        LedsFactory(PhantomData)
+    }
+}
+
+pub struct LedsDriver<'a, S: Syscalls> {
+    num_leds: usize,
+    lifetime: PhantomData<&'a S>,
+}
+
+impl<'a, S: Syscalls> LedsDriver<'a, S> {
+    pub fn num_leds(&self) -> usize {
+        self.num_leds
+    }
+
+    pub fn leds(&self) -> Leds<S> {
+        Leds {
+            num_leds: self.num_leds,
+            curr_led: 0,
+            lifetime: PhantomData,
+        }
+    }
+
+    /// Returns the led at 0-based index `led_num`
+    pub fn get(&self, led_num: usize) -> Result<Led<S>, ErrorCode> {
+        if led_num < self.num_leds {
+            Ok(Led {
+                led_num,
+                lifetime: PhantomData,
+            })
+        } else {
+            Err(ErrorCode::Invalid)
+        }
+    }
+}
+
+pub struct Leds<'a, S: Syscalls> {
+    num_leds: usize,
+    curr_led: usize,
+    lifetime: PhantomData<&'a S>,
+}
+
+impl<'a, S: Syscalls> Iterator for Leds<'a, S> {
+    type Item = Led<'a, S>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.curr_led < self.num_leds {
+            let item = Led {
+                led_num: self.curr_led,
+                lifetime: PhantomData,
+            };
+            self.curr_led += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+}
+
+pub struct Led<'a, S: Syscalls> {
+    led_num: usize,
+    lifetime: PhantomData<&'a S>,
+}
+
+impl<'a, S: Syscalls> Led<'a, S> {
+    pub fn led_num(&self) -> usize {
+        self.led_num
+    }
+
+    pub fn set(&self, state: impl Into<LedState>) -> Result<(), ErrorCode> {
+        match state.into() {
+            LedState::On => self.on(),
+            LedState::Off => self.off(),
+        }
+    }
+
+    pub fn on(&self) -> Result<(), ErrorCode> {
+        let value = S::command(DRIVER_ID, command_nr::ON, self.led_num as u32, 0);
+        if value.is_failure() {
+            Err(value.get_failure().unwrap_or(ErrorCode::Fail))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn off(&self) -> Result<(), ErrorCode> {
+        let value = S::command(DRIVER_ID, command_nr::OFF, self.led_num as u32, 0);
+        if value.is_failure() {
+            Err(value.get_failure().unwrap_or(ErrorCode::Fail))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn toggle(&self) -> Result<(), ErrorCode> {
+        let value = S::command(DRIVER_ID, command_nr::TOGGLE, self.led_num as u32, 0);
+        if value.is_failure() {
+            Err(value.get_failure().unwrap_or(ErrorCode::Fail))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum LedState {
+    On,
+    Off,
+}
+
+impl From<bool> for LedState {
+    fn from(from_value: bool) -> Self {
+        if from_value {
+            LedState::On
+        } else {
+            LedState::Off
+        }
+    }
+}
+
+const DRIVER_ID: u32 = 2;
+
+#[cfg(test)]
+mod tests;

--- a/apis/leds/src/tests.rs
+++ b/apis/leds/src/tests.rs
@@ -1,0 +1,105 @@
+use libtock_unittest::fake;
+
+type LedsFactory = super::LedsFactory<fake::Syscalls>;
+
+#[test]
+fn no_driver() {
+    let _kernel = fake::Kernel::new();
+    let mut leds_factory = LedsFactory::new();
+    assert!(leds_factory.init_driver().is_err());
+}
+
+#[test]
+fn driver_check() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    let mut leds_factory = LedsFactory::new();
+    let leds_driver = leds_factory.init_driver().unwrap();
+
+    for led in 0..10 {
+        assert!(leds_driver.get(led).is_ok());
+    }
+}
+
+#[test]
+fn num_leds() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    let mut leds_factory = LedsFactory::new();
+    let leds_driver = leds_factory.init_driver().unwrap();
+
+    assert_eq!(leds_driver.num_leds(), 10);
+}
+
+#[test]
+fn on() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    let mut leds_factory = LedsFactory::new();
+    let leds_driver = leds_factory.init_driver().unwrap();
+
+    leds_driver.get(0).unwrap().on().unwrap();
+    assert_eq!(driver.get_led(0), Some(true));
+}
+
+#[test]
+fn off() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    let mut leds_factory = LedsFactory::new();
+    let leds_driver = leds_factory.init_driver().unwrap();
+
+    leds_driver.get(0).unwrap().off().unwrap();
+
+    assert_eq!(driver.get_led(0), Some(false));
+}
+
+#[test]
+fn toggle() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    let mut leds_factory = LedsFactory::new();
+    let leds_driver = leds_factory.init_driver().unwrap();
+
+    leds_driver.get(0).unwrap().toggle().unwrap();
+    assert_eq!(driver.get_led(0), Some(true));
+    leds_driver.get(0).unwrap().toggle().unwrap();
+    assert_eq!(driver.get_led(0), Some(false));
+}
+
+#[test]
+fn on_off() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    let mut leds_factory = LedsFactory::new();
+    let leds_driver = leds_factory.init_driver().unwrap();
+
+    leds_driver.get(0).unwrap().on().unwrap();
+    assert_eq!(driver.get_led(0), Some(true));
+    leds_driver.get(0).unwrap().off().unwrap();
+    assert_eq!(driver.get_led(0), Some(false));
+}
+
+#[test]
+fn no_led() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Leds::<10>::new();
+    kernel.add_driver(&driver);
+
+    let mut leds_factory = LedsFactory::new();
+    let leds_driver = leds_factory.init_driver().unwrap();
+
+    assert!(leds_driver.get(11).is_err());
+}

--- a/libtock2/Cargo.toml
+++ b/libtock2/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.1.0"
 [dependencies]
 libtock_platform = { path = "../platform" }
 libtock_runtime = { path = "../runtime" }
+libtock_leds = { path = "../apis/leds" }
 libtock_low_level_debug = { path = "../apis/low_level_debug" }
 
 # TODO: Implement a panic handler with more debugging functionality, then

--- a/libtock2/examples/leds.rs
+++ b/libtock2/examples/leds.rs
@@ -1,0 +1,27 @@
+//! An extremely simple libtock-rs example. Just prints out a few numbers using
+//! the LowLevelDebug capsule then terminates.
+
+#![no_main]
+#![no_std]
+
+use libtock2::leds::LedsFactory;
+use libtock2::runtime::{set_main, stack_size};
+use libtock_platform::ErrorCode;
+
+set_main! {main}
+stack_size! {0x100}
+
+fn main() -> Result<(), ErrorCode> {
+    // placeholder until a driver infrastrucrure is built
+    let mut leds_factory = LedsFactory::new();
+
+    let leds_driver = leds_factory.init_driver()?;
+    for led in leds_driver.leds() {
+        led.on()?
+    }
+
+    for led in leds_driver.leds() {
+        led.off()?
+    }
+    leds_driver.get(0)?.on()
+}

--- a/libtock2/src/lib.rs
+++ b/libtock2/src/lib.rs
@@ -6,6 +6,10 @@ extern crate libtock_small_panic;
 pub use libtock_platform as platform;
 pub use libtock_runtime as runtime;
 
+pub mod leds {
+    use libtock_leds as leds;
+    pub type LedsFactory = leds::LedsFactory<super::runtime::TockSyscalls>;
+}
 pub mod low_level_debug {
     use libtock_low_level_debug as lldb;
     pub type LowLevelDebug = lldb::LowLevelDebug<super::runtime::TockSyscalls>;

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -1,0 +1,88 @@
+//! Fake implementation of the LowLevelDebug API, documented here:
+//! https://github.com/tock/tock/blob/master/doc/syscalls/00008_low_level_debug.md
+//!
+//! Like the real API, `LowLevelDebug` prints each message it is commanded to
+//! print. It also keeps a log of the messages as `Message` instances, which can
+//! be retrieved via `take_messages` for use in unit tests.
+
+use core::cell::Cell;
+use libtock_platform::{CommandReturn, ErrorCode};
+
+pub struct Leds<const LEDS_COUNT: usize> {
+    leds: [Cell<bool>; LEDS_COUNT],
+}
+
+impl<const LEDS_COUNT: usize> Leds<LEDS_COUNT> {
+    pub fn new() -> std::rc::Rc<Leds<LEDS_COUNT>> {
+        #[allow(clippy::declare_interior_mutable_const)]
+        const OFF: Cell<bool> = Cell::new(false);
+        std::rc::Rc::new(Leds {
+            leds: [OFF; LEDS_COUNT],
+        })
+    }
+}
+
+impl<const LEDS_COUNT: usize> crate::fake::SyscallDriver for Leds<LEDS_COUNT> {
+    fn id(&self) -> u32 {
+        DRIVER_NUMBER
+    }
+    fn num_upcalls(&self) -> u32 {
+        0
+    }
+
+    fn command(&self, command_number: u32, argument0: u32, _argument1: u32) -> CommandReturn {
+        match command_number {
+            DRIVER_CHECK => crate::command_return::success_u32(LEDS_COUNT as u32),
+            LED_ON => {
+                if argument0 < LEDS_COUNT as u32 {
+                    self.leds[argument0 as usize].set(true);
+                    crate::command_return::success()
+                } else {
+                    crate::command_return::failure(ErrorCode::Invalid)
+                }
+            }
+            LED_OFF => {
+                if argument0 < LEDS_COUNT as u32 {
+                    self.leds[argument0 as usize].set(false);
+                    crate::command_return::success()
+                } else {
+                    crate::command_return::failure(ErrorCode::Invalid)
+                }
+            }
+            LED_TOGGLE => {
+                if argument0 < LEDS_COUNT as u32 {
+                    self.leds[argument0 as usize].set(!self.leds[argument0 as usize].get());
+                    crate::command_return::success()
+                } else {
+                    crate::command_return::failure(ErrorCode::Invalid)
+                }
+            }
+            _ => crate::command_return::failure(ErrorCode::NoSupport),
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Implementation details below
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests;
+
+const DRIVER_NUMBER: u32 = 2;
+
+// Command numbers
+const DRIVER_CHECK: u32 = 0;
+const LED_ON: u32 = 1;
+const LED_OFF: u32 = 2;
+const LED_TOGGLE: u32 = 3;
+
+impl<const NUM_LEDS: usize> Leds<NUM_LEDS> {
+    pub fn get_led(&self, led: usize) -> Option<bool> {
+        if led < NUM_LEDS {
+            Some(self.leds[led].get())
+        } else {
+            None
+        }
+    }
+}

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -4,7 +4,6 @@
 //! Like the real API, `Leds` controls a set of fake LEDs. It provides
 //! a function `get_led` used to retrieve the state of an LED.
 
-
 use core::cell::Cell;
 use libtock_platform::{CommandReturn, ErrorCode};
 

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -1,9 +1,9 @@
-//! Fake implementation of the LowLevelDebug API, documented here:
-//! https://github.com/tock/tock/blob/master/doc/syscalls/00008_low_level_debug.md
+//! Fake implementation of the LEDs API, documented here:
+//! https://github.com/tock/tock/blob/master/doc/syscalls/00002_leds.md
 //!
-//! Like the real API, `LowLevelDebug` prints each message it is commanded to
-//! print. It also keeps a log of the messages as `Message` instances, which can
-//! be retrieved via `take_messages` for use in unit tests.
+//! Like the real API, `Leds` controls a set of fake LEDs. It provides
+//! a function `get_led` used to retrieve the state of an LED.
+
 
 use core::cell::Cell;
 use libtock_platform::{CommandReturn, ErrorCode};

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -1,0 +1,45 @@
+use crate::fake;
+use fake::leds::*;
+
+// Tests the command implementation.
+#[test]
+fn command() {
+    use fake::SyscallDriver;
+    let leds = Leds::<10>::new();
+    let value = leds.command(DRIVER_CHECK, 1, 2);
+    assert!(value.is_success_u32());
+    assert_eq!(value.get_success_u32(), Some(10));
+    assert!(leds.command(LED_ON, 11, 0).is_failure());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(leds.command(LED_ON, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(leds.command(LED_OFF, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(leds.command(LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(leds.command(LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+}
+
+// Integration test that verifies LowLevelDebug works with fake::Kernel and
+// libtock_platform::Syscalls.
+#[test]
+fn kernel_integration() {
+    use libtock_platform::Syscalls;
+    let kernel = fake::Kernel::new();
+    let leds = Leds::<10>::new();
+    kernel.add_driver(&leds);
+    let value = fake::Syscalls::command(DRIVER_NUMBER, DRIVER_CHECK, 1, 2);
+    assert!(value.is_success_u32());
+    assert_eq!(value.get_success_u32(), Some(10));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 11, 0).is_failure());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_OFF, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(true));
+    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_TOGGLE, 0, 0).is_success());
+    assert_eq!(leds.get_led(0), Some(false));
+}

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -21,7 +21,7 @@ fn command() {
     assert_eq!(leds.get_led(0), Some(false));
 }
 
-// Integration test that verifies LowLevelDebug works with fake::Kernel and
+// Integration test that verifies Leds works with fake::Kernel and
 // libtock_platform::Syscalls.
 #[test]
 fn kernel_integration() {

--- a/unittest/src/fake/mod.rs
+++ b/unittest/src/fake/mod.rs
@@ -10,11 +10,13 @@
 //! (e.g. `fake::Console`).
 
 mod kernel;
+mod leds;
 mod low_level_debug;
 mod syscall_driver;
 mod syscalls;
 
 pub use kernel::Kernel;
+pub use leds::Leds;
 pub use low_level_debug::{LowLevelDebug, Message};
 pub use syscall_driver::SyscallDriver;
 pub use syscalls::Syscalls;


### PR DESCRIPTION
This PR adds a LEDs driver that is similar to the previous one (libtock1).

The previous driver was designed with a driver infrastructure in mind. The library was providing a `drivers` struct that would hold the `DriverFactory` structure. As libtock v2 does not provide such a structure (yet?), the `LedsFactory` has a temporary `new` placeholder function. This means that it now *can* be instantiated several times.