### PR TITLE
Layout for esp32 c3 devkit m1

### DIFF
--- a/runtime/layouts/esp32-c3-devkitM-1.ld
+++ b/runtime/layouts/esp32-c3-devkitM-1.ld
@@ -1,0 +1,12 @@
+/* Layout for the Imix board, used by the examples in this repository. */
+
+MEMORY {
+  /* Note that the SRAM address may need to be changed depending on
+   * the kernel binary, check for the actual address of APP_MEMORY!
+   */
+  FLASH (X) : ORIGIN = 0x403B0000, LENGTH = 0x30000
+  RAM   (W) : ORIGIN = 0x3FCA1800, LENGTH = 0x2E800
+}
+
+TBF_HEADER_SIZE = 0x48;
+INCLUDE libtock_layout.ld

--- a/tools/flash.sh
+++ b/tools/flash.sh
@@ -30,6 +30,11 @@ case "${PLATFORM}" in
         binary_name=cortex-m4.elf
         tockload=n
         ;;
+    "esp32-c3-devkitM-1")
+        tockloader_flags=""
+        binary_name=rv32imac.elf
+        tockload=n
+        ;;
     "microbit_v2")
         tockloader_flags="--bundle-apps"
         binary_name=cortex-m4.elf


### PR DESCRIPTION
This PR adds the layout for the esp32 c3 dev kit m1.

While building works and the application starts, it faults when calling `rust_start` with illegal instruction. Modifying `rust_start` to a single loops seems to fail with `Illegal instruction access` as it seems to pass over the loop.

I am out of ideas on how to debug this further on, as I do not have a debugger for the esp, but I don't think the bug is related to the layout. The command used to build he app is 

```bash
alexandru:ibtock-rs/libtock2$ LIBTOCK_PLATFORM=esp32-c3-devkitM-1 APP_HEAP_SIZE=1024 KERNEL_HEAP_SIZE=1024 cargo run --target riscv32imac-unknown-none-elf --example low_level_debug
```