### PR TITLE
Add padding to `.start` so that `.text` is aligned to a multiple of 4 bytes.

### DIFF
--- a/runtime/libtock_layout.ld
+++ b/runtime/libtock_layout.ld
@@ -71,6 +71,12 @@ SECTIONS {
         LONG(ADDR(.bss));
 
         *(.start)
+
+        /* .text must be aligned to a multiple of 4 bytes. elf2tab always puts
+         * .text immediately after .start, even if the ELF file specifies a
+         * different address (with alignment padding). Therefore, we have to
+         * add the alignment padding into .start. */
+        . = ALIGN(4);
     } > FLASH
 
     /* Text section -- the application's code. */


### PR DESCRIPTION
I found that elf2tab was leaving out the padding between `.start` and `.text`. I *think* this is an elf2tab bug, but I'm not sure and regardless I want to be able to run libtock2 binaries without waiting for another elf2tab release. Therefore, I added the padding into the `.start` section directly via the linker script, which results in a correct TBF file.

This fixer #362 