### PR TITLE
Adjust `make setup` to install the latest `elf2tab` release rather than pinning `0.6.0`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 
 .PHONY: setup
 setup: setup-qemu
-	cargo install elf2tab --version 0.6.0
+	cargo install elf2tab
 	cargo install stack-sizes
 	cargo miri setup
 


### PR DESCRIPTION
As discussed at https://github.com/tock/libtock-rs/pull/363, issue #362 is fixed in the latest `elf2tab`. I did not have the latest `elf2tab`, because I used `make setup` to install `elf2tab`.

I traced the version number argument back to #157, and did not see a discussion about the version number, so I think it's safe to remove it.