### PR TITLE
Add a runner for libtock2 examples.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -12,4 +12,4 @@ rustflags = [
     "-C", "relocation-model=static",
     "-C", "link-arg=-Tlayout.ld",
 ]
-runner = "./tools/flash.sh"
+runner = ["cargo", "run", "-p", "runner", "--release"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build and Test
         run: |
           sudo apt-get install binutils-arm-none-eabi \
-            binutils-riscv64-unknown-elf
+            binutils-riscv64-unknown-elf ninja-build
           cd "${GITHUB_WORKSPACE}"
           echo "[target.'cfg(all())']" >> .cargo/config
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ members = [
     "libtock2",
     "panic_handlers/small_panic",
     "platform",
+    "runner",
     "runtime",
     "syscalls_tests",
     "test_runner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ lto = true
 debug = true
 
 [workspace]
-exclude = [ "tock" ]
+exclude = ["tock", "tock2"]
 members = [
     "apis/low_level_debug",
     "codegen",

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ test-stable:
 		$(EXCLUDE_RUNTIME) --exclude libtock --exclude libtock_core
 
 .PHONY: test
-test: examples test-qemu-hifive test-stable
+test: examples test-stable
 	PLATFORM=nrf52 cargo test $(EXCLUDE_RUNTIME) --workspace
 	# TODO: When we have a working embedded test harness, change the libtock2
 	# builds to --all-targets rather than --examples.
@@ -251,3 +251,4 @@ flash-msp432:
 clean:
 	cargo clean
 	$(MAKE) -C tock clean
+	$(MAKE) -C tock2 clean

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,14 @@ kernel-hifive-2:
 	$(MAKE) -C tock2/boards/hifive1 \
 		$(CURDIR)/tock2/target/riscv32imac-unknown-none-elf/release/hifive1.elf
 
+# Builds a Tock kernel for the OpenTitan board on the cw310 FPGA for use by QEMU
+# tests.
+.PHONY: kernel-opentitan
+kernel-opentitan:
+	CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF_RUNNER="[]" \
+		$(MAKE) -C tock2/boards/opentitan/earlgrey-cw310 \
+		$(CURDIR)/tock2/target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.elf
+
 # Prints out the sizes of the example binaries.
 .PHONY: print-sizes
 print-sizes: examples

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+description = """Tool used to run libtock-rs process binaries."""
+edition = "2018"
+license = "Apache-2.0 OR MIT"
+name = "runner"
+publish = false
+repository = "https://www.github.com/tock/libtock-rs"
+version = "0.1.0"
+
+[dependencies]
+clap = { features = ["derive"], version = "3.0.10" }
+elf = "0.0.10"
+signal-hook = "0.3.13"

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -11,4 +11,5 @@ version = "0.1.0"
 [dependencies]
 clap = { features = ["derive"], version = "3.0.10" }
 elf = "0.0.10"
-signal-hook = "0.3.13"
+libc = "0.2.113"
+termion = "1.5.6"

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -88,7 +88,9 @@ pub struct OutFiles {
     pub tbf_path: PathBuf,
 }
 
-// The amount of space to reserve for the TBF header.
+// The amount of space to reserve for the TBF header. This must match the
+// TBF_HEADER_SIZE value in the layout file for the platform, which is currently
+// 0x48 for all platforms.
 const TBF_HEADER_SIZE: u32 = 0x48;
 
 // Reads the stack size, and returns it as a String for use on elf2tab's command

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -1,0 +1,113 @@
+use super::Cli;
+use std::fs::{metadata, remove_file};
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use std::process::Command;
+
+// Converts the ELF file specified on the command line into TBF and TAB files,
+// and returns the paths to those files.
+pub fn convert_elf(cli: &Cli) -> OutFiles {
+    let package_name = cli.elf.file_stem().expect("ELF must be a file");
+    let mut tab_path = cli.elf.clone();
+    tab_path.set_extension("tab");
+    let protected_size = TBF_HEADER_SIZE.to_string();
+    if cli.verbose {
+        println!("Package name: {:?}", package_name);
+        println!("TAB path: {}", tab_path.display());
+        println!("Protected region size: {}", protected_size);
+    }
+    let stack_size = read_stack_size(cli);
+    let elf = cli.elf.as_os_str();
+    let mut tbf_path = cli.elf.clone();
+    tbf_path.set_extension("tbf");
+    if cli.verbose {
+        println!("ELF file: {:?}", elf);
+        println!("TBF path: {}", tbf_path.display());
+    }
+
+    // If elf2tab returns a successful status but does not write to the TBF
+    // file, then we run the risk of using an outdated TBF file, creating a
+    // hard-to-debug situation. Therefore, we delete the TBF file, forcing
+    // elf2tab to create it, and later verify that it exists.
+    if let Err(io_error) = remove_file(&tbf_path) {
+        // Ignore file-no-found errors, panic on any other error.
+        assert_eq!(
+            io_error.kind(),
+            ErrorKind::NotFound,
+            "Unable to remove the TBF file"
+        );
+    }
+
+    let mut command = Command::new("elf2tab");
+    #[rustfmt::skip]
+    command.args([
+        // TODO: libtock-rs' crates are designed for Tock 2.1's Allow interface,
+        // so we should increment this as soon as the Tock kernel will accept a
+        // 2.1 app.
+        "--kernel-major".as_ref(), "2".as_ref(),
+        "--kernel-minor".as_ref(), "0".as_ref(),
+        "-n".as_ref(), package_name,
+        "-o".as_ref(), tab_path.as_os_str(),
+        "--protected-region-size".as_ref(), protected_size.as_ref(),
+        "--stack".as_ref(), stack_size.as_ref(),
+        elf,
+    ]);
+    if cli.verbose {
+        command.arg("-v");
+        println!("elf2tab command: {:?}", command);
+        println!("Spawning elf2tab");
+    }
+    let mut child = command.spawn().expect("failed to spawn elf2tab");
+    let status = child.wait().expect("failed to wait for elf2tab");
+    if cli.verbose {
+        println!("elf2tab finished. {}", status);
+    }
+    assert!(status.success(), "elf2tab returned an error. {}", status);
+
+    // Verify that elf2tab created the TBF file, and that it is a file.
+    match metadata(&tbf_path) {
+        Err(io_error) => {
+            if io_error.kind() == ErrorKind::NotFound {
+                panic!("elf2tab did not create {}", tbf_path.display());
+            }
+            panic!(
+                "Unable to query metadata for {}: {}",
+                tbf_path.display(),
+                io_error
+            );
+        }
+        Ok(metadata) => {
+            assert!(metadata.is_file(), "{} is not a file", tbf_path.display());
+        }
+    }
+
+    OutFiles { tab_path, tbf_path }
+}
+
+// Paths to the files output by elf2tab.
+pub struct OutFiles {
+    pub tab_path: PathBuf,
+    pub tbf_path: PathBuf,
+}
+
+// The amount of space to reserve for the TBF header.
+const TBF_HEADER_SIZE: u32 = 0x48;
+
+// Reads the stack size, and returns it as a String for use on elf2tab's command
+// line.
+fn read_stack_size(cli: &Cli) -> String {
+    let file = elf::File::open_path(&cli.elf).expect("Unable to open ELF");
+    for section in file.sections {
+        // This section name comes from runtime/libtock_layout.ld, and it
+        // matches the size (and location) of the process binary's stack.
+        if section.shdr.name == ".stack" {
+            let stack_size = section.shdr.size.to_string();
+            if cli.verbose {
+                println!("Found .stack section, size: {}", stack_size);
+            }
+            return stack_size;
+        }
+    }
+
+    panic!("Unable to find the .stack section in {}", cli.elf.display());
+}

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -31,11 +31,9 @@ pub fn convert_elf(cli: &Cli) -> OutFiles {
     // elf2tab to create it, and later verify that it exists.
     if let Err(io_error) = remove_file(&tbf_path) {
         // Ignore file-no-found errors, panic on any other error.
-        assert_eq!(
-            io_error.kind(),
-            ErrorKind::NotFound,
-            "Unable to remove the TBF file"
-        );
+        if io_error.kind() != ErrorKind::NotFound {
+            panic!("Unable to remove the TBF file. Error: {}", io_error);
+        }
     }
 
     let mut command = Command::new("elf2tab");

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,0 +1,41 @@
+mod elf2tab;
+mod output_processor;
+mod qemu;
+mod tockloader;
+
+use clap::{ArgEnum, Parser};
+use std::path::PathBuf;
+
+/// Converts ELF binaries into Tock Binary Format binaries and runs them on a
+/// Tock system.
+#[derive(Debug, Parser)]
+pub struct Cli {
+    /// Where to deploy the process binary. If not specified, runner will only
+    /// make a TBF file and not attempt to run it.
+    #[clap(arg_enum, long, short)]
+    deploy: Option<Deploy>,
+
+    /// The executable to convert into Tock Binary Format and run.
+    elf: PathBuf,
+
+    /// Whether to output verbose debugging information to the console.
+    #[clap(long, short)]
+    verbose: bool,
+}
+
+#[derive(ArgEnum, Clone, Debug)]
+pub enum Deploy {
+    Qemu,
+    Tockloader,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let paths = elf2tab::convert_elf(&cli);
+    let child = match cli.deploy {
+        None => return,
+        Some(Deploy::Qemu) => qemu::deploy(&cli, paths.tbf_path),
+        Some(Deploy::Tockloader) => tockloader::deploy(&cli, paths.tab_path),
+    };
+    output_processor::process(&cli, child);
+}

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -1,43 +1,129 @@
 use super::Cli;
-use signal_hook::flag::{register, register_conditional_default};
-use std::io::{stdout, BufReader, Read, Write};
+use libc::{kill, pid_t, SIGINT};
+use std::io::{stderr, stdin, stdout, BufRead, BufReader, ErrorKind, Stdout, Write};
 use std::process::Child;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::thread::spawn;
+use termion::raw::{IntoRawMode, RawTerminal};
 
 /// Reads the console messages from `child`'s standard output, sending SIGTERM
 /// to the child when the process is terminated.
 pub fn process(cli: &Cli, mut child: Child) {
-    // When Ctrl+C is pressed, Bash sends SIGINT to both us and our child
-    // process. If we finish before the child process does, then bash will print
-    // the shell prompt before the child process prints its final messages,
-    // which is annoying for the user.
-    //
-    // So instead, we ignore the first SIGINT we receive. Ctrl+C should
-    // therefore result in a clean shutdown: the child process exits, then we
-    // see that it finished and terminates. As a fail-safe in case we fail to
-    // terminate, this combination will make us exit if SIGINT is received a
-    // second time.
-    let sigint_received = Arc::new(AtomicBool::new(false));
-    register_conditional_default(signal_hook::consts::SIGINT, sigint_received.clone())
-        .expect("Unable to register SIGINT conditional handler.");
-    register(signal_hook::consts::SIGINT, sigint_received)
-        .expect("Unable to register SIGINT handler.");
-
-    let reader = BufReader::new(child.stdout.as_mut().expect("Child's stdout not piped."));
-    for byte in reader.bytes() {
-        let byte = byte.expect("Unexpected IO error.");
+    let raw_mode = forward_stdin_if_piped(&mut child);
+    forward_stderr_if_piped(&mut child, raw_mode.is_some());
+    let mut to_print = Vec::new();
+    let mut reader = BufReader::new(child.stdout.as_mut().expect("Child's stdout not piped."));
+    loop {
+        let buffer = reader
+            .fill_buf()
+            .expect("Unable to read from child process.");
+        if buffer.is_empty() {
+            // The child process has closed its stdout, likely by exiting.
+            break;
+        }
+        // Print the bytes received over stdout. If the terminal is in raw mode,
+        // translate '\n' into '\r\n'.
+        for &byte in buffer {
+            if raw_mode.is_some() && byte == b'\n' {
+                to_print.push(b'\r');
+            }
+            to_print.push(byte);
+        }
         stdout()
-            .write_all(&[byte])
-            .expect("Failed to write to stdout.");
+            .write_all(&to_print)
+            .expect("Unable to echo child's stdout.");
+        to_print.clear();
+
+        let buffer_len = buffer.len();
+        reader.consume(buffer_len);
     }
     if cli.verbose {
-        println!("Waiting for child process to exit");
+        println!("Waiting for child process.\r");
     }
     let status = child.wait().expect("Unable to wait for child process");
+    drop(raw_mode);
     assert!(
         status.success(),
         "Child process did not exit successfully. {}",
         status
     );
+}
+
+// If child's stdin is piped, this sets the terminal to raw mode and spawns a
+// thread that forwards our stdin to child's stdin. The thread sends SIGINT to
+// the child if Ctrl+C is pressed. Returns a RawTerminal, which reverts the
+// terminal to its previous configuration on drop.
+fn forward_stdin_if_piped(child: &mut Child) -> Option<RawTerminal<Stdout>> {
+    let mut child_stdin = child.stdin.take()?;
+    let child_id = child.id();
+    spawn(move || {
+        let our_stdin = stdin();
+        let mut our_stdin = our_stdin.lock();
+        loop {
+            let buffer = our_stdin.fill_buf().expect("Failed to read stdin.");
+            if buffer.is_empty() {
+                // Our stdin was closed. We interpret this as a signal to exit,
+                // because pressing Ctrl+C to trigger an exit is no longer
+                // possible.
+                break;
+            }
+            // In raw mode, pressing Ctrl+C will send a '3' byte to stdin ("end
+            // of message" ASCII value) instead of sending SIGINT. Identify that
+            // case, and exit if it occurs.
+            if buffer.contains(&3) {
+                break;
+            }
+            match child_stdin.write(buffer) {
+                // A BrokenPipe error occurs when the child has exited. Exit
+                // without sending SIGINT.
+                Err(error) if error.kind() == ErrorKind::BrokenPipe => return,
+
+                Err(error) => panic!("Failed to forward stdin: {}", error),
+                Ok(bytes) => our_stdin.consume(bytes),
+            }
+        }
+        // Send SIGINT to the child, telling it to exit. After the child exits,
+        // the main loop will detect the exit and we will shut down cleanly.
+        //
+        // Safety: Sending SIGINT to a process is a safe operation -- kill is
+        // marked unsafe because it is a FFI function.
+        unsafe {
+            kill(child_id as pid_t, SIGINT);
+        }
+    });
+    Some(
+        stdout()
+            .into_raw_mode()
+            .expect("Failed to set terminal to raw mode."),
+    )
+}
+
+// Forwards child's stderr to our stderr if child's stderr is piped, converting
+// line endings to CRLF if raw_mode is true.
+fn forward_stderr_if_piped(child: &mut Child, raw_mode: bool) {
+    let child_stderr = match child.stderr.take() {
+        None => return,
+        Some(child_stderr) => child_stderr,
+    };
+    spawn(move || {
+        let mut to_print = Vec::new();
+        let mut reader = BufReader::new(child_stderr);
+        loop {
+            let buffer = reader.fill_buf().expect("Unable to read child's stderr.");
+            if buffer.is_empty() {
+                return;
+            }
+            for &byte in buffer {
+                if raw_mode && byte == b'\n' {
+                    to_print.push(b'\r');
+                }
+                to_print.push(byte);
+            }
+            stderr()
+                .write_all(&to_print)
+                .expect("Unable to echo child's stderr.");
+            to_print.clear();
+            let buffer_len = buffer.len();
+            reader.consume(buffer_len);
+        }
+    });
 }

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -1,0 +1,43 @@
+use super::Cli;
+use signal_hook::flag::{register, register_conditional_default};
+use std::io::{stdout, BufReader, Read, Write};
+use std::process::Child;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+/// Reads the console messages from `child`'s standard output, sending SIGTERM
+/// to the child when the process is terminated.
+pub fn process(cli: &Cli, mut child: Child) {
+    // When Ctrl+C is pressed, Bash sends SIGINT to both us and our child
+    // process. If we finish before the child process does, then bash will print
+    // the shell prompt before the child process prints its final messages,
+    // which is annoying for the user.
+    //
+    // So instead, we ignore the first SIGINT we receive. Ctrl+C should
+    // therefore result in a clean shutdown: the child process exits, then we
+    // see that it finished and terminates. As a fail-safe in case we fail to
+    // terminate, this combination will make us exit if SIGINT is received a
+    // second time.
+    let sigint_received = Arc::new(AtomicBool::new(false));
+    register_conditional_default(signal_hook::consts::SIGINT, sigint_received.clone())
+        .expect("Unable to register SIGINT conditional handler.");
+    register(signal_hook::consts::SIGINT, sigint_received)
+        .expect("Unable to register SIGINT handler.");
+
+    let reader = BufReader::new(child.stdout.as_mut().expect("Child's stdout not piped."));
+    for byte in reader.bytes() {
+        let byte = byte.expect("Unexpected IO error.");
+        stdout()
+            .write_all(&[byte])
+            .expect("Failed to write to stdout.");
+    }
+    if cli.verbose {
+        println!("Waiting for child process to exit");
+    }
+    let status = child.wait().expect("Unable to wait for child process");
+    assert!(
+        status.success(),
+        "Child process did not exit successfully. {}",
+        status
+    );
+}

--- a/runner/src/qemu.rs
+++ b/runner/src/qemu.rs
@@ -4,11 +4,11 @@ use std::process::{Child, Command, Stdio};
 
 // Spawns a QEMU VM with a simulated Tock system and the process binary. Returns
 // the handle for the spawned QEMU process.
-pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
+pub fn deploy(cli: &Cli, platform: String, tbf_path: PathBuf) -> Child {
     let platform_args = get_platform_args(platform);
     let device = format!(
         "loader,file={},addr={}",
-        tab_path
+        tbf_path
             .into_os_string()
             .into_string()
             .expect("Non-UTF-8 path"),

--- a/runner/src/qemu.rs
+++ b/runner/src/qemu.rs
@@ -1,0 +1,33 @@
+use super::Cli;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+
+// Spawns a QEMU VM with a simulated Tock system and the process binary. Returns
+// the handle for the spawned QEMU process.
+pub fn deploy(cli: &Cli, tab_path: PathBuf) -> Child {
+    let device = format!(
+        "loader,file={},addr=0x20040000",
+        tab_path
+            .into_os_string()
+            .into_string()
+            .expect("Non-UTF-8 path")
+    );
+    let mut qemu = Command::new("tock2/tools/qemu/build/qemu-system-riscv32");
+    #[rustfmt::skip]
+    qemu.args([
+        "-device", &device,
+        "-kernel", "tock2/target/riscv32imac-unknown-none-elf/release/hifive1",
+        "-M", "sifive_e,revb=true",
+        "-nographic",
+    ]);
+    // QEMU does something to its stdin that prevents Ctrl+C from generating
+    // SIGINT. If we set QEMU's stdin to be our stdin, then Ctrl+C will not
+    // close us. To prevent that, we set QEMU's stdin to null.
+    qemu.stdin(Stdio::null());
+    qemu.stdout(Stdio::piped());
+    if cli.verbose {
+        println!("QEMU command: {:?}", qemu);
+        println!("Spawning QEMU")
+    }
+    qemu.spawn().expect("failed to spawn QEMU")
+}

--- a/runner/src/tockloader.rs
+++ b/runner/src/tockloader.rs
@@ -1,5 +1,4 @@
 use super::Cli;
-use std::env::{var, VarError};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 
@@ -8,22 +7,7 @@ use std::process::{Child, Command, Stdio};
 // Note: This function is untested, as its author does not have hardware that
 // works with tockloader. If you use it, please report back on how it works so
 // we can fix it or remove this notice!
-pub fn deploy(cli: &Cli, tab_path: PathBuf) -> Child {
-    // The flags we pass to tockloader depend on the platform we are deploying
-    // to. Read the platform from the LIBTOCK_PLATFORM variable and look up the
-    // flags to use.
-    let platform = match var("LIBTOCK_PLATFORM") {
-        Err(VarError::NotPresent) => {
-            panic!("LIBTOCK_PLATFORM must be specified to deploy using tockloader")
-        }
-        Err(VarError::NotUnicode(platform)) => {
-            panic!("Non-UTF-8 LIBTOCK_PLATFORM value: {:?}", platform)
-        }
-        Ok(platform) => platform,
-    };
-    if cli.verbose {
-        println!("Detected platform {}", platform);
-    }
+pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
     let flags: &[_] = match platform.as_str() {
         "hail" => &[],
         "microbit_v2" => &["--bundle-apps"],

--- a/runner/src/tockloader.rs
+++ b/runner/src/tockloader.rs
@@ -1,0 +1,120 @@
+use super::Cli;
+use std::env::{var, VarError};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+
+// Uses tockloader to deploy the provided TAB file to a Tock system. Returns the
+// handle for the spawned 'tockloader listen' process.
+// Note: This function is untested, as its author does not have hardware that
+// works with tockloader. If you use it, please report back on how it works so
+// we can fix it or remove this notice!
+pub fn deploy(cli: &Cli, tab_path: PathBuf) -> Child {
+    // The flags we pass to tockloader depend on the platform we are deploying
+    // to. Read the platform from the LIBTOCK_PLATFORM variable and look up the
+    // flags to use.
+    let platform = match var("LIBTOCK_PLATFORM") {
+        Err(VarError::NotPresent) => {
+            panic!("LIBTOCK_PLATFORM must be specified to deploy using tockloader")
+        }
+        Err(VarError::NotUnicode(platform)) => {
+            panic!("Non-UTF-8 LIBTOCK_PLATFORM value: {:?}", platform)
+        }
+        Ok(platform) => platform,
+    };
+    if cli.verbose {
+        println!("Detected platform {}", platform);
+    }
+    let flags: &[_] = match platform.as_str() {
+        "hail" => &[],
+        "microbit_v2" => &["--bundle-apps"],
+        "nrf52" | "nrf52840" => &[
+            "--jlink",
+            "--arch",
+            "cortex-m4",
+            "--board",
+            "nrf52dk",
+            "--jtag-device",
+            "nrf52",
+        ],
+        _ => panic!("Cannot deploy to platform {} via tockloader", platform),
+    };
+    if cli.verbose {
+        println!("Tockloader flags: {:?}", flags);
+    }
+
+    // Tockloader listen's ability to receive every message from the Tock system
+    // varies from platform to platform. We look up the platform, and if it is
+    // not satisfactorily reliable we output a warning for the user.
+    let reliable_listen = match platform.as_str() {
+        // tockloader listen will reset the Hail, allowing it to capture all
+        // printed messages.
+        "hail" => true,
+
+        // Microbit uses CDC over USB, which buffers messages so that tockloader
+        // listen can receive messages sent before it was started. As long as
+        // tockloader listen launches before the timeout, there will not be
+        // dropped messages. This is good enough for our purposes.
+        "microbit_v2" => true,
+
+        // tockloader listen doesn't reset the nrf52, and there's no message
+        // queueing mechanism. Therefore, tockloader listen will likely miss
+        // messages printed quickly after the process binary is deployed.
+        "nrf52" | "nrf52840" => false,
+
+        // We shouldn't hit this case, because the flag determination code above
+        // should error out on unknown platforms.
+        _ => panic!("Unknown reliability for {}", platform),
+    };
+    if !reliable_listen {
+        println!(
+            "Warning: tockloader listen may miss early messages on platform {}",
+            platform
+        );
+    }
+
+    // Invoke tockloader uninstall to remove the process binary, if present.
+    let mut uninstall = Command::new("tockloader");
+    uninstall.arg("uninstall");
+    uninstall.args(flags);
+    if cli.verbose {
+        println!("tockloader uninstall command: {:?}", uninstall);
+    }
+    let mut child = uninstall
+        .spawn()
+        .expect("failed to spawn tockloader uninstall");
+    let status = child
+        .wait()
+        .expect("failed to wait for tockloader uninstall");
+    if cli.verbose {
+        println!("tockloader uninstall finished. {}", status);
+    }
+
+    // Invoke tockloader install to deploy the new process binary.
+    let mut install = Command::new("tockloader");
+    install.arg("install");
+    install.args(flags);
+    install.arg(tab_path);
+    if cli.verbose {
+        println!("tockloader install command: {:?}", install);
+    }
+    let mut child = install.spawn().expect("failed to spawn tockloader install");
+    let status = child.wait().expect("failed to wait for tockloader install");
+    if cli.verbose {
+        println!("tockloader install finished. {}", status);
+    }
+    assert!(
+        status.success(),
+        "tockloader install returned unsuccessful status {}",
+        status
+    );
+
+    // Invoke tockloader listen to receive messages from the Tock system.
+    let mut listen = Command::new("tockloader");
+    listen.arg("listen");
+    listen.args(flags);
+    listen.stdout(Stdio::piped());
+    if cli.verbose {
+        println!("tockloader listen command: {:?}", listen);
+    }
+    listen.spawn().expect("failed to spawn tockloader listen")
+}


### PR DESCRIPTION
This replaces `tools/flash.sh`. In the future, it will have functionality to process test output, and will therefore replace `test_runner` as well.

It can currently deploy to HiFive1 on QEMU, and has untested logic to deploy via `tockloader`.

It is no longer possible to deploy Tock 1.0 libtock-rs apps using `cargo run`, as `cargo run` will now invoke the new tool. This prevents us from running the Tock 1.0 libtock-rs integration test, so I have removed it from `make test`.

I also make the following changes to the submodule setup:
1. I added a `setup-qemu-2` target to build QEMU in the tock2/ submodule. When I remove the `tock/` submodule, I'll also remove the `setup-qemu` target and rename `setup-qemu-2` to `setup-qemu` to replace it.
2. I updated the `tock2/` submodule to a newer kernel. Because `libtock-rs` depends on the new Allow API implementation that is not in a released Tock version, I used the latest master branch commit.