### PR TITLE
Add must_use to CommandReturn

### DIFF
--- a/platform/src/command_return.rs
+++ b/platform/src/command_return.rs
@@ -2,8 +2,44 @@ use crate::{return_variant, ErrorCode, ReturnVariant};
 
 use core::mem::transmute;
 
-/// The response type from `command`. Can represent a successful value or a
-/// failure.
+/// The response type from the [`command`](crate::Syscalls::command) syscall.
+/// Can represent a success or a failure with or without associated data.
+///
+/// After a syscall is made, registers `r1`-`r3` contain the output as
+/// described by [TRD 104][trd-104]. Some syscalls only return success/failure,
+/// while others provide associated data. This is done by placing the _return
+/// variant_ in `r0`, which specifies how the output registers should be
+/// interpreted. For syscalls other than `command`, the possible output
+/// variants are fixed; you always know which variants are expected given the
+/// syscall class.
+///
+/// However, the `command` syscall is flexible - there must be one success
+/// variant and one failure variant for a given driver/command ID, but
+/// which variants those are, and what data is expected, cannot be checked
+/// statically. Capsules and userspace APIs must agree on the expected
+/// variants for success and failure.
+///
+/// # Example
+///
+/// This uses the `get_*` methods to check the variants explicitly and extract
+/// the associated data.
+///
+/// ```no_run
+/// let command_return = Syscalls::command(314, 1, 1, 2);
+/// if let Some((val1, val2)) = command_return.get_success_2_u32() {
+///     // If there was a success, there is an associated data (u32, u32).
+/// } else if let Some(error_code) = command_return.get_failure() {
+///     // If there was a failure, there's no associated data and we only
+///     // have an error code.
+/// } else {
+///     // Incorrect return variant! If this occurs, your capsule and userspace
+///     // API do not agree on what the return variants should be.
+///     // An application may want to panic in this case to catch this early.
+/// }
+/// ```
+///
+/// [trd-104]: https://github.com/tock/tock/blob/master/doc/reference/trd104-syscalls.md#32-return-values
+#[must_use = "this `CommandReturn` may represent an error, which should be handled"]
 #[derive(Clone, Copy, Debug)]
 pub struct CommandReturn {
     return_variant: ReturnVariant,
@@ -26,16 +62,6 @@ impl CommandReturn {
             r3,
         }
     }
-    // I generally expect CommandReturn to be used with pattern matching, e.g.:
-    //
-    //     let command_return = Syscalls::command(314, 1, 1, 2);
-    //     if let Some((val1, val2)) = command_return.get_success_2_u32() {
-    //         // ...
-    //     } else if let Some(error_code) = command_return.get_failure() {
-    //         // ...
-    //     } else {
-    //         // Incorrect return variant
-    //     }
 
     /// Returns true if this CommandReturn is of type Failure. Note that this
     /// does not return true for other failure types, such as Failure with u32.


### PR DESCRIPTION
Conceptually, this is very similar to `Result`, which is `#[must_use]`.
This also fleshes out the root documentation for the type.