### PR TITLE
ufmt: add support for hex printing and width specifiers

### DIFF
--- a/ufmt/macros/Cargo.toml
+++ b/ufmt/macros/Cargo.toml
@@ -16,6 +16,8 @@ proc-macro = true
 proc-macro-hack = "0.5.11"
 proc-macro2 = "1"
 quote = "1"
+regex = "1.5.4"
+lazy_static = "1.4.0"
 
 [dependencies.syn]
 features = ["full"]

--- a/ufmt/src/impls/core.rs
+++ b/ufmt/src/impls/core.rs
@@ -59,38 +59,38 @@ where
     }
 }
 
-// FIXME this (`escape_debug`) contains a panicking branch
-// impl uDebug for str {
-//     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
-//     where
-//         W: uWrite + ?Sized,
-//     {
-//         f.write_str("\"")?;
+// Below borrowed from https://github.com/japaric/ufmt/pull/25
+impl uDebug for str {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        f.write_str("\"")?;
+        let mut from = 0;
+        for (i, c) in self.char_indices() {
+            let esc = c.escape_debug();
 
-//         let mut from = 0;
-//         for (i, c) in self.char_indices() {
-//             let esc = c.escape_debug();
+            // If char needs escaping, flush backlog so far and write, else skip
+            if esc.len() != 1 {
+                // SAFETY: `char_indices()` guarantees that `i` is always the index of utf-8 boundary of `c`.
+                // In the first iteration `from` is zero and therefore also the index of the bounardy of `c`.
+                // In the following iterations `from` either keeps its value or is set to `i + c.len_utf8()`
+                // (with last rounds `i` and `c`), which means `from` is again `i` (this round), the index
+                // of this rounds `c`. Notice that this also implies `from <= i`.
+                f.write_str(unsafe { self.get_unchecked(from..i) })?;
+                for c in esc {
+                    f.write_char(c)?;
+                }
+                from = i + c.len_utf8();
+            }
+        }
 
-//             // If char needs escaping, flush backlog so far and write, else skip
-//             if esc.len() != 1 {
-//                 f.write_str(
-//                     self.get(from..i)
-//                         .unwrap_or_else(|| unsafe { assume_unreachable!() }),
-//                 )?;
-//                 for c in esc {
-//                     f.write_char(c)?;
-//                 }
-//                 from = i + c.len_utf8();
-//             }
-//         }
-
-//         f.write_str(
-//             self.get(from..)
-//                 .unwrap_or_else(|| unsafe { assume_unreachable!() }),
-//         )?;
-//         f.write_str("\"")
-//     }
-// }
+        // SAFETY: As seen above, `from` is the index of an utf-8 boundary in `self`.
+        // This also means that from is in bounds of `self`: `from <= self.len()`.
+        f.write_str(unsafe { self.get_unchecked(from..) })?;
+        f.write_str("\"")
+    }
+}
 
 impl uDisplay for str {
     #[inline(always)]

--- a/ufmt/src/impls/std.rs
+++ b/ufmt/src/impls/std.rs
@@ -76,15 +76,14 @@ where
     }
 }
 
-// TODO
-// impl uDebug for String {
-//     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
-//     where
-//         W: uWrite + ?Sized,
-//     {
-//         <str as uDebug>::fmt(self, f)
-//     }
-// }
+impl uDebug for String {
+    fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: uWrite + ?Sized,
+    {
+        <str as uDebug>::fmt(self, f)
+    }
+}
 
 impl uDisplay for String {
     fn fmt<W>(&self, f: &mut Formatter<'_, W>) -> Result<(), W::Error>

--- a/ufmt/tests/vs-std-write.rs
+++ b/ufmt/tests/vs-std-write.rs
@@ -99,6 +99,154 @@ fn ixx() {
 }
 
 #[test]
+fn hex() {
+    cmp!("{:x}", 0i8);
+    cmp!("{:x}", 10i8);
+    cmp!("{:x}", 100i8);
+    cmp!("{:x}", i8::min_value());
+    cmp!("{:x}", i8::max_value());
+    cmp!("{:x}", i16::min_value());
+    cmp!("{:x}", i16::max_value());
+    cmp!("{:x}", i32::min_value());
+    cmp!("{:x}", i32::max_value());
+    cmp!("{:x}", i64::min_value());
+    cmp!("{:x}", i64::max_value());
+    cmp!("{:x}", i128::min_value());
+    cmp!("{:x}", i128::max_value());
+    cmp!("{:x}", isize::min_value());
+    cmp!("{:x}", isize::max_value());
+    cmp!("{:x}", 0u8);
+    cmp!("{:x}", 10u8);
+    cmp!("{:x}", 100u8);
+    cmp!("{:x}", u8::max_value());
+    cmp!("{:x}", u16::max_value());
+    cmp!("{:x}", u32::max_value());
+    cmp!("{:x}", u64::max_value());
+    cmp!("{:x}", u128::max_value());
+    cmp!("{:x}", usize::max_value());
+}
+
+#[test]
+fn special_hex() {
+    cmp!("{:X}", 0i8);
+    cmp!("{:X}", 10i8);
+    cmp!("{:X}", 100i8);
+    cmp!("{:X}", u32::max_value());
+    cmp!("{:X}", u64::max_value());
+    cmp!("{:#X}", 0i8);
+    cmp!("{:#X}", 10i8);
+    cmp!("{:#X}", u32::max_value());
+    cmp!("{:#X}", u64::max_value());
+    cmp!("{:#x}", 0i8);
+    cmp!("{:#x}", 10i8);
+    cmp!("{:#x}", u32::max_value());
+    cmp!("{:#x}", u64::max_value());
+    cmp!("{:#x}", 0i8);
+    cmp!("{:#x}", 10i8);
+    cmp!("{:#9x}", u32::max_value());
+    cmp!("{:#09x}", u64::max_value());
+    cmp!("{:#9X}", u32::max_value());
+    cmp!("{:#09X}", u64::max_value());
+}
+
+// Verify padding, with spaces or zeroes, up to width 10, for any
+// numeric value.
+macro_rules! width_test {
+    ($tt:expr) => {{
+        cmp!("{:1}", $tt);
+        cmp!("{:3}", $tt);
+        cmp!("{:5}", $tt);
+        cmp!("{:7}", $tt);
+        cmp!("{:9}", $tt);
+        cmp!("{:10}", $tt);
+        cmp!("{:02}", $tt);
+        cmp!("{:04}", $tt);
+        cmp!("{:06}", $tt);
+        cmp!("{:08}", $tt);
+        cmp!("{:010}", $tt);
+        cmp!("{:018}", $tt);
+
+        cmp!("lead{:018}follow", $tt);
+        cmp!("lead{:10}follow", $tt);
+    }};
+}
+
+// Verify space padding for non-numeric values
+macro_rules! width_test_non_numeric {
+    ($tt:expr) => {{
+        cmp!("{:1}", $tt);
+        cmp!("{:3}", $tt);
+        cmp!("{:5}", $tt);
+        cmp!("{:7}", $tt);
+        cmp!("{:9}", $tt);
+        cmp!("{:10}", $tt);
+        cmp!("{:18}", $tt);
+        cmp!("lead{:18}follow", $tt);
+        cmp!("lead{:5}follow", $tt);
+    }};
+}
+
+#[test]
+fn width_format_numbers() {
+    width_test!(0i8);
+    width_test!(10i8);
+    width_test!(100i8);
+    width_test!(i8::min_value());
+    width_test!(i8::max_value());
+    width_test!(i16::min_value());
+    width_test!(i16::max_value());
+    width_test!(i32::min_value());
+    width_test!(i32::max_value());
+    width_test!(i64::min_value());
+    width_test!(i64::max_value());
+    width_test!(i128::min_value());
+    width_test!(i128::max_value());
+    width_test!(isize::min_value());
+    width_test!(isize::max_value());
+    width_test!(0u8);
+    width_test!(10u8);
+    width_test!(100u8);
+    width_test!(u8::max_value());
+    width_test!(u16::max_value());
+    width_test!(u32::max_value());
+    width_test!(u64::max_value());
+    width_test!(u128::max_value());
+    width_test!(usize::max_value());
+
+    width_test!(0i8);
+    width_test!(10i8);
+    width_test!(100i8);
+    width_test!(i8::min_value());
+    width_test!(i8::max_value());
+    width_test!(i16::min_value());
+    width_test!(i16::max_value());
+    width_test!(i32::min_value());
+    width_test!(i32::max_value());
+    width_test!(i64::min_value());
+    width_test!(i64::max_value());
+    width_test!(i128::min_value());
+    width_test!(i128::max_value());
+    width_test!(isize::min_value());
+    width_test!(isize::max_value());
+    width_test!(0u8);
+    width_test!(10u8);
+    width_test!(100u8);
+    width_test!(u8::max_value());
+    width_test!(u16::max_value());
+    width_test!(u32::max_value());
+    width_test!(u64::max_value());
+    width_test!(u128::max_value());
+    width_test!(usize::max_value());
+}
+
+#[test]
+fn width_non_numbers() {
+    width_test_non_numeric!(false);
+    width_test_non_numeric!("hi");
+    width_test_non_numeric!('P');
+}
+
+#[test]
 fn fmt() {
     cmp!("Hello, world!");
     cmp!("The answer is {}", 42);


### PR DESCRIPTION
This change adds ufmt support for hex printing of numbers and for fixed-width printing up to widths of 18 using 0s or spaces
as padding. 0 padding is only supported for numbers. Custom fill characters and specified alignment is not supported. This change does decrease the size savings of ufmt relative to core::fmt, but brings them much closer to feature parity.

This change has not been submitted to the upstream ufmt repo, as it includes variations on several changes already submitted as PRs to that repo which have not been accepted: https://github.com/japaric/ufmt/pull/25 and https://github.com/japaric/ufmt/pull/26 .

A number of tests were added to verify that ufmt formatting is identical to core::fmt formatting for the supported additions. These can be run using `cargo test --features=std` from the ufmt directory.

In a closed-source codebase, switching apps to use ufmt instead of core::fmt reduced code size by a total of 7200 bytes across 4 apps, with the only loss in functionality being two locations that used fixed alignment printing.

In the same codebase switching to unmodified ufmt saved 12,500 bytes, at the expense of
- not being able to print any numbers in hexadecimal
- not being able to print fixed width fields

Notably, this support is *somewhat* pay-for-what-you-use: The savings were ~10kB before I switched back to hex/fixed width formatting where it had been used before. Accordingly, for users of ufmt who do not need/want any of this functionality, the overhead is about a 20% increase in code size. I suspect I can get that number somewhat lower, but wanted to submit this as-is for feedback before I spend too much time optimizing.