### PR TITLE
Rename DRIVER_ID to DRIVER_NUM

### DIFF
--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -11,6 +11,15 @@ use libtock_platform::{ErrorCode, Syscalls};
 /// // Turn on led 0
 /// let _ = Leds::on(0);
 /// ```
+
+const DRIVER_NUMBER: u32 = 2;
+
+// Command IDs
+const LEDS_COUNT: u32 = 0;
+const LED_ON: u32 = 1;
+const LED_OFF: u32 = 2;
+const LED_TOGGLE: u32 = 3;
+
 pub struct Leds<S: Syscalls>(S);
 
 impl<S: Syscalls> Leds<S> {
@@ -20,29 +29,21 @@ impl<S: Syscalls> Leds<S> {
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
     pub fn count() -> Result<u32, ErrorCode> {
-        S::command(DRIVER_ID, LEDS_COUNT, 0, 0).to_result()
+        S::command(DRIVER_NUMBER, LEDS_COUNT, 0, 0).to_result()
     }
 
     pub fn on(led: u32) -> Result<(), ErrorCode> {
-        S::command(DRIVER_ID, LED_ON, led, 0).to_result()
+        S::command(DRIVER_NUMBER, LED_ON, led, 0).to_result()
     }
 
     pub fn off(led: u32) -> Result<(), ErrorCode> {
-        S::command(DRIVER_ID, LED_OFF, led, 0).to_result()
+        S::command(DRIVER_NUMBER, LED_OFF, led, 0).to_result()
     }
 
     pub fn toggle(led: u32) -> Result<(), ErrorCode> {
-        S::command(DRIVER_ID, LED_TOGGLE, led, 0).to_result()
+        S::command(DRIVER_NUMBER, LED_TOGGLE, led, 0).to_result()
     }
 }
-
-const DRIVER_ID: u32 = 2;
-
-// Command IDs
-const LEDS_COUNT: u32 = 0;
-const LED_ON: u32 = 1;
-const LED_OFF: u32 = 2;
-const LED_TOGGLE: u32 = 3;
 
 #[cfg(test)]
 mod tests;

--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -12,7 +12,7 @@ use libtock_platform::{ErrorCode, Syscalls};
 /// let _ = Leds::on(0);
 /// ```
 
-const DRIVER_NUMBER: u32 = 2;
+const DRIVER_NUM: u32 = 2;
 
 // Command IDs
 const LEDS_COUNT: u32 = 0;
@@ -29,19 +29,19 @@ impl<S: Syscalls> Leds<S> {
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
     pub fn count() -> Result<u32, ErrorCode> {
-        S::command(DRIVER_NUMBER, LEDS_COUNT, 0, 0).to_result()
+        S::command(DRIVER_NUM, LEDS_COUNT, 0, 0).to_result()
     }
 
     pub fn on(led: u32) -> Result<(), ErrorCode> {
-        S::command(DRIVER_NUMBER, LED_ON, led, 0).to_result()
+        S::command(DRIVER_NUM, LED_ON, led, 0).to_result()
     }
 
     pub fn off(led: u32) -> Result<(), ErrorCode> {
-        S::command(DRIVER_NUMBER, LED_OFF, led, 0).to_result()
+        S::command(DRIVER_NUM, LED_OFF, led, 0).to_result()
     }
 
     pub fn toggle(led: u32) -> Result<(), ErrorCode> {
-        S::command(DRIVER_NUMBER, LED_TOGGLE, led, 0).to_result()
+        S::command(DRIVER_NUM, LED_TOGGLE, led, 0).to_result()
     }
 }
 

--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -12,14 +12,6 @@ use libtock_platform::{ErrorCode, Syscalls};
 /// let _ = Leds::on(0);
 /// ```
 
-const DRIVER_NUM: u32 = 2;
-
-// Command IDs
-const LEDS_COUNT: u32 = 0;
-const LED_ON: u32 = 1;
-const LED_OFF: u32 = 2;
-const LED_TOGGLE: u32 = 3;
-
 pub struct Leds<S: Syscalls>(S);
 
 impl<S: Syscalls> Leds<S> {
@@ -47,3 +39,15 @@ impl<S: Syscalls> Leds<S> {
 
 #[cfg(test)]
 mod tests;
+
+// -----------------------------------------------------------------------------
+// Driver number and command IDs
+// -----------------------------------------------------------------------------
+
+const DRIVER_NUM: u32 = 2;
+
+// Command IDs
+const LEDS_COUNT: u32 = 0;
+const LED_ON: u32 = 1;
+const LED_OFF: u32 = 2;
+const LED_TOGGLE: u32 = 3;

--- a/apis/low_level_debug/src/lib.rs
+++ b/apis/low_level_debug/src/lib.rs
@@ -16,7 +16,7 @@ use libtock_platform::Syscalls;
 /// LowLevelDebug::print_1(0x45);
 /// ```
 
-const DRIVER_NUMBER: u32 = 8;
+const DRIVER_NUM: u32 = 8;
 
 // Command IDs
 const DRIVER_CHECK: u32 = 0;
@@ -34,13 +34,13 @@ impl<S: Syscalls> LowLevelDebug<S> {
     /// memory.
     #[inline(always)]
     pub fn driver_check() -> bool {
-        S::command(DRIVER_NUMBER, DRIVER_CHECK, 0, 0).is_success()
+        S::command(DRIVER_NUM, DRIVER_CHECK, 0, 0).is_success()
     }
 
     /// Print one of the predefined alerts in [`AlertCode`].
     #[inline(always)]
     pub fn print_alert_code(code: AlertCode) {
-        let _ = S::command(DRIVER_NUMBER, PRINT_ALERT_CODE, code as u32, 0);
+        let _ = S::command(DRIVER_NUM, PRINT_ALERT_CODE, code as u32, 0);
     }
 
     /// Print a single number. The number will be printed in hexadecimal.
@@ -49,7 +49,7 @@ impl<S: Syscalls> LowLevelDebug<S> {
     /// should not be called by released library code.
     #[inline(always)]
     pub fn print_1(x: u32) {
-        let _ = S::command(DRIVER_NUMBER, PRINT_1, x, 0);
+        let _ = S::command(DRIVER_NUM, PRINT_1, x, 0);
     }
 
     /// Print two numbers. The numbers will be printed in hexadecimal.
@@ -60,7 +60,7 @@ impl<S: Syscalls> LowLevelDebug<S> {
     /// value is being printed.
     #[inline(always)]
     pub fn print_2(x: u32, y: u32) {
-        let _ = S::command(DRIVER_NUMBER, PRINT_2, x, y);
+        let _ = S::command(DRIVER_NUM, PRINT_2, x, y);
     }
 }
 

--- a/apis/low_level_debug/src/lib.rs
+++ b/apis/low_level_debug/src/lib.rs
@@ -16,14 +16,6 @@ use libtock_platform::Syscalls;
 /// LowLevelDebug::print_1(0x45);
 /// ```
 
-const DRIVER_NUM: u32 = 8;
-
-// Command IDs
-const DRIVER_CHECK: u32 = 0;
-const PRINT_ALERT_CODE: u32 = 1;
-const PRINT_1: u32 = 2;
-const PRINT_2: u32 = 3;
-
 pub struct LowLevelDebug<S: Syscalls>(S);
 
 impl<S: Syscalls> LowLevelDebug<S> {
@@ -76,3 +68,15 @@ pub enum AlertCode {
 
 #[cfg(test)]
 mod tests;
+
+// -----------------------------------------------------------------------------
+// Driver number and command IDs
+// -----------------------------------------------------------------------------
+
+const DRIVER_NUM: u32 = 8;
+
+// Command IDs
+const DRIVER_CHECK: u32 = 0;
+const PRINT_ALERT_CODE: u32 = 1;
+const PRINT_1: u32 = 2;
+const PRINT_2: u32 = 3;

--- a/apis/low_level_debug/src/lib.rs
+++ b/apis/low_level_debug/src/lib.rs
@@ -15,6 +15,15 @@ use libtock_platform::Syscalls;
 /// // Prints 0x45 and the app which called it.
 /// LowLevelDebug::print_1(0x45);
 /// ```
+
+const DRIVER_NUMBER: u32 = 8;
+
+// Command IDs
+const DRIVER_CHECK: u32 = 0;
+const PRINT_ALERT_CODE: u32 = 1;
+const PRINT_1: u32 = 2;
+const PRINT_2: u32 = 3;
+
 pub struct LowLevelDebug<S: Syscalls>(S);
 
 impl<S: Syscalls> LowLevelDebug<S> {
@@ -25,13 +34,13 @@ impl<S: Syscalls> LowLevelDebug<S> {
     /// memory.
     #[inline(always)]
     pub fn driver_check() -> bool {
-        S::command(DRIVER_ID, DRIVER_CHECK, 0, 0).is_success()
+        S::command(DRIVER_NUMBER, DRIVER_CHECK, 0, 0).is_success()
     }
 
     /// Print one of the predefined alerts in [`AlertCode`].
     #[inline(always)]
     pub fn print_alert_code(code: AlertCode) {
-        let _ = S::command(DRIVER_ID, PRINT_ALERT_CODE, code as u32, 0);
+        let _ = S::command(DRIVER_NUMBER, PRINT_ALERT_CODE, code as u32, 0);
     }
 
     /// Print a single number. The number will be printed in hexadecimal.
@@ -40,7 +49,7 @@ impl<S: Syscalls> LowLevelDebug<S> {
     /// should not be called by released library code.
     #[inline(always)]
     pub fn print_1(x: u32) {
-        let _ = S::command(DRIVER_ID, PRINT_1, x, 0);
+        let _ = S::command(DRIVER_NUMBER, PRINT_1, x, 0);
     }
 
     /// Print two numbers. The numbers will be printed in hexadecimal.
@@ -51,7 +60,7 @@ impl<S: Syscalls> LowLevelDebug<S> {
     /// value is being printed.
     #[inline(always)]
     pub fn print_2(x: u32, y: u32) {
-        let _ = S::command(DRIVER_ID, PRINT_2, x, y);
+        let _ = S::command(DRIVER_NUMBER, PRINT_2, x, y);
     }
 }
 
@@ -64,14 +73,6 @@ pub enum AlertCode {
     /// flash.
     WrongLocation = 0x02,
 }
-
-const DRIVER_ID: u32 = 8;
-
-// Command IDs
-const DRIVER_CHECK: u32 = 0;
-const PRINT_ALERT_CODE: u32 = 1;
-const PRINT_1: u32 = 2;
-const PRINT_2: u32 = 3;
 
 #[cfg(test)]
 mod tests;

--- a/apis/low_level_debug/src/tests.rs
+++ b/apis/low_level_debug/src/tests.rs
@@ -67,7 +67,7 @@ fn failed_print() {
     let driver = fake::LowLevelDebug::new();
     kernel.add_driver(&driver);
     kernel.add_expected_syscall(ExpectedSyscall::Command {
-        driver_id: DRIVER_ID,
+        driver_id: DRIVER_NUMBER,
         command_id: PRINT_1,
         argument0: 72,
         argument1: 0,

--- a/apis/low_level_debug/src/tests.rs
+++ b/apis/low_level_debug/src/tests.rs
@@ -67,7 +67,7 @@ fn failed_print() {
     let driver = fake::LowLevelDebug::new();
     kernel.add_driver(&driver);
     kernel.add_expected_syscall(ExpectedSyscall::Command {
-        driver_id: DRIVER_NUMBER,
+        driver_id: DRIVER_NUM,
         command_id: PRINT_1,
         argument0: 72,
         argument1: 0,

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -7,9 +7,25 @@
 use core::cell::Cell;
 use libtock_platform::{CommandReturn, ErrorCode};
 
+// -----------------------------------------------------------------------------
+// Driver number and command IDs
+// -----------------------------------------------------------------------------
+
+const DRIVER_NUMBER: u32 = 2;
+
+// Command numbers
+const DRIVER_CHECK: u32 = 0;
+const LED_ON: u32 = 1;
+const LED_OFF: u32 = 2;
+const LED_TOGGLE: u32 = 3;
+
 pub struct Leds<const LEDS_COUNT: usize> {
     leds: [Cell<bool>; LEDS_COUNT],
 }
+
+// -----------------------------------------------------------------------------
+// Implementation details below
+// -----------------------------------------------------------------------------
 
 impl<const LEDS_COUNT: usize> Leds<LEDS_COUNT> {
     pub fn new() -> std::rc::Rc<Leds<LEDS_COUNT>> {
@@ -61,23 +77,11 @@ impl<const LEDS_COUNT: usize> crate::fake::SyscallDriver for Leds<LEDS_COUNT> {
     }
 }
 
-// -----------------------------------------------------------------------------
-// Implementation details below
-// -----------------------------------------------------------------------------
-
-#[cfg(test)]
-mod tests;
-
-const DRIVER_NUMBER: u32 = 2;
-
-// Command numbers
-const DRIVER_CHECK: u32 = 0;
-const LED_ON: u32 = 1;
-const LED_OFF: u32 = 2;
-const LED_TOGGLE: u32 = 3;
-
 impl<const NUM_LEDS: usize> Leds<NUM_LEDS> {
     pub fn get_led(&self, led: u32) -> Option<bool> {
         self.leds.get(led as usize).map(|led| led.get())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -11,7 +11,7 @@ use libtock_platform::{CommandReturn, ErrorCode};
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUMBER: u32 = 2;
+const DRIVER_NUM: u32 = 2;
 
 // Command numbers
 const DRIVER_CHECK: u32 = 0;
@@ -39,7 +39,7 @@ impl<const LEDS_COUNT: usize> Leds<LEDS_COUNT> {
 
 impl<const LEDS_COUNT: usize> crate::fake::SyscallDriver for Leds<LEDS_COUNT> {
     fn id(&self) -> u32 {
-        DRIVER_NUMBER
+        DRIVER_NUM
     }
     fn num_upcalls(&self) -> u32 {
         0

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -7,25 +7,9 @@
 use core::cell::Cell;
 use libtock_platform::{CommandReturn, ErrorCode};
 
-// -----------------------------------------------------------------------------
-// Driver number and command IDs
-// -----------------------------------------------------------------------------
-
-const DRIVER_NUM: u32 = 2;
-
-// Command numbers
-const DRIVER_CHECK: u32 = 0;
-const LED_ON: u32 = 1;
-const LED_OFF: u32 = 2;
-const LED_TOGGLE: u32 = 3;
-
 pub struct Leds<const LEDS_COUNT: usize> {
     leds: [Cell<bool>; LEDS_COUNT],
 }
-
-// -----------------------------------------------------------------------------
-// Implementation details below
-// -----------------------------------------------------------------------------
 
 impl<const LEDS_COUNT: usize> Leds<LEDS_COUNT> {
     pub fn new() -> std::rc::Rc<Leds<LEDS_COUNT>> {
@@ -34,6 +18,10 @@ impl<const LEDS_COUNT: usize> Leds<LEDS_COUNT> {
         std::rc::Rc::new(Leds {
             leds: [OFF; LEDS_COUNT],
         })
+    }
+
+    pub fn get_led(&self, led: u32) -> Option<bool> {
+        self.leds.get(led as usize).map(|led| led.get())
     }
 }
 
@@ -77,11 +65,17 @@ impl<const LEDS_COUNT: usize> crate::fake::SyscallDriver for Leds<LEDS_COUNT> {
     }
 }
 
-impl<const NUM_LEDS: usize> Leds<NUM_LEDS> {
-    pub fn get_led(&self, led: u32) -> Option<bool> {
-        self.leds.get(led as usize).map(|led| led.get())
-    }
-}
-
 #[cfg(test)]
 mod tests;
+
+// -----------------------------------------------------------------------------
+// Implementation details below
+// -----------------------------------------------------------------------------
+
+const DRIVER_NUM: u32 = 2;
+
+// Command numbers
+const DRIVER_CHECK: u32 = 0;
+const LED_ON: u32 = 1;
+const LED_OFF: u32 = 2;
+const LED_TOGGLE: u32 = 3;

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -32,20 +32,20 @@ fn kernel_integration() {
     let kernel = fake::Kernel::new();
     let leds = Leds::<10>::new();
     kernel.add_driver(&leds);
-    let value = fake::Syscalls::command(DRIVER_NUMBER, DRIVER_CHECK, 1, 2);
+    let value = fake::Syscalls::command(DRIVER_NUM, DRIVER_CHECK, 1, 2);
     assert!(value.is_success_u32());
     assert_eq!(value.get_success_u32(), Some(10));
     assert_eq!(
-        fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 11, 0).get_failure(),
+        fake::Syscalls::command(DRIVER_NUM, LED_ON, 11, 0).get_failure(),
         Some(ErrorCode::Invalid)
     );
     assert_eq!(leds.get_led(0), Some(false));
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_ON, 0, 0).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, LED_ON, 0, 0).is_success());
     assert_eq!(leds.get_led(0), Some(true));
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_OFF, 0, 0).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, LED_OFF, 0, 0).is_success());
     assert_eq!(leds.get_led(0), Some(false));
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_TOGGLE, 0, 0).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, LED_TOGGLE, 0, 0).is_success());
     assert_eq!(leds.get_led(0), Some(true));
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, LED_TOGGLE, 0, 0).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, LED_TOGGLE, 0, 0).is_success());
     assert_eq!(leds.get_led(0), Some(false));
 }

--- a/unittest/src/fake/low_level_debug/mod.rs
+++ b/unittest/src/fake/low_level_debug/mod.rs
@@ -27,7 +27,7 @@ impl LowLevelDebug {
 
 impl crate::fake::SyscallDriver for LowLevelDebug {
     fn id(&self) -> u32 {
-        DRIVER_NUMBER
+        DRIVER_NUM
     }
     fn num_upcalls(&self) -> u32 {
         0
@@ -71,7 +71,7 @@ impl core::fmt::Display for Message {
 #[cfg(test)]
 mod tests;
 
-const DRIVER_NUMBER: u32 = 8;
+const DRIVER_NUM: u32 = 8;
 
 // Command numbers
 const DRIVER_CHECK: u32 = 0;

--- a/unittest/src/fake/low_level_debug/tests.rs
+++ b/unittest/src/fake/low_level_debug/tests.rs
@@ -25,11 +25,11 @@ fn kernel_integration() {
     let kernel = fake::Kernel::new();
     let low_level_debug = LowLevelDebug::new();
     kernel.add_driver(&low_level_debug);
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, DRIVER_CHECK, 1, 2).is_success());
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, PRINT_ALERT_CODE, 3, 4).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, DRIVER_CHECK, 1, 2).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, PRINT_ALERT_CODE, 3, 4).is_success());
     assert_eq!(low_level_debug.take_messages(), [Message::AlertCode(3)]);
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, PRINT_1, 5, 6).is_success());
-    assert!(fake::Syscalls::command(DRIVER_NUMBER, PRINT_2, 7, 8).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, PRINT_1, 5, 6).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, PRINT_2, 7, 8).is_success());
     assert_eq!(
         low_level_debug.take_messages(),
         [Message::Print1(5), Message::Print2(7, 8)]


### PR DESCRIPTION
This PR renames the `DRIVER_ID` to `DRIVER_NUMBER` to be consistent with the drivers TRD naming.