### PR TITLE
Rename `.rgignore` to `.ignore` so it works with other tools.

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,4 +1,4 @@
-# Tells ripgrep to ignore the Tock submodule. Usually when someone wants to
+# Tell search tools to ignore the Tock submodule. Usually when someone wants to
 # search this repository they want to search libtock-rs' codebase, not the Tock
 # kernel.
 /tock/


### PR DESCRIPTION
Ripgrep and [tokei](https://github.com/XAMPPRocky/tokei) both support `.ignore` (and presumably other tools as well).