### PR TITLE
Update the Rust toolchain to `nightly-2022-01-20`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ test: examples test-stable
 	LIBTOCK_PLATFORM=hifive1 cargo clippy $(EXCLUDE_STD) \
 		--target=riscv32imac-unknown-none-elf --workspace
 	cargo miri test $(EXCLUDE_MIRI) --workspace
-	MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-track-raw-pointers" \
+	MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-tag-raw-pointers" \
 		cargo miri test $(EXCLUDE_MIRI) --workspace
 	echo '[ SUCCESS ] libtock-rs tests pass'
 

--- a/platform/src/command_return.rs
+++ b/platform/src/command_return.rs
@@ -325,14 +325,14 @@ impl SuccessData for (u32, u32, u32) {
 /// This trait is [sealed], meaning foreign implementations cannot be defined,
 /// even though it can be referenced by foreign crates.
 ///
+/// # Safety
+/// [`RETURN_VARIANT`] must represent a failure variant, such that `r1` will
+/// always be a valid [`ErrorCode`].
+///
 /// [sealed]: https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed
 pub unsafe trait FailureData: sealed::Sealed {
     /// The return variant for this failure type, stored in `r0` after
     /// performing a `command` syscall.
-    ///
-    /// # Safety
-    /// This must represent a failure variant, such that `r1` will always be
-    /// a valid [`ErrorCode`].
     const RETURN_VARIANT: ReturnVariant;
 
     /// Constructs the error data given the raw register values.

--- a/platform/src/raw_syscalls.rs
+++ b/platform/src/raw_syscalls.rs
@@ -5,6 +5,10 @@ use crate::Register;
 /// `libtock_unittest::fake::Kernel`. **Components should not use `RawSyscalls`
 /// directly; instead, use the `Syscalls` trait, which provides higher-level
 /// interfaces to the system calls.**
+///
+/// # Safety
+/// `RawSyscalls` is unsafe because `unsafe` code depends on its methods to
+/// return the correct register values.
 
 // The RawSyscalls trait is designed to minimize the complexity and size of its
 // implementation, as its implementation is difficult to test (it cannot be used

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -18,7 +18,7 @@
 //! `no_auto_layout` feature on `libtock_runtime` to disable this functionality
 //! and provide its own layout file.
 
-#![feature(asm)]
+#![feature(asm_const)]
 #![no_std]
 #![warn(unsafe_op_in_unsafe_fn)]
 

--- a/runtime/src/syscalls_impl_arm.rs
+++ b/runtime/src/syscalls_impl_arm.rs
@@ -1,3 +1,4 @@
+use core::arch::asm;
 use libtock_platform::{RawSyscalls, Register};
 
 unsafe impl RawSyscalls for crate::TockSyscalls {

--- a/runtime/src/syscalls_impl_riscv.rs
+++ b/runtime/src/syscalls_impl_riscv.rs
@@ -1,3 +1,4 @@
+use core::arch::asm;
 use libtock_platform::{RawSyscalls, Register};
 
 unsafe impl RawSyscalls for crate::TockSyscalls {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 [toolchain]
 # See https://rust-lang.github.io/rustup-components-history/ for a list of
 # recently nightlies and what components are available for them.
-channel = "nightly-2021-05-27"
+channel = "nightly-2022-01-20"
 components = ["clippy", "miri", "rustfmt"]
 targets = ["thumbv7em-none-eabi",
            "riscv32imac-unknown-none-elf",


### PR DESCRIPTION
`clippy` now requires a `# Safety` comment on `unsafe` traits, which required a few changes. Also, Miri renamed `-Zmiri-track-raw-pointers` to `-Zmiri-tag-raw-pointers`.