### PR TITLE
Migrate the RISC-V entry point to `global_asm!`.

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -12,8 +12,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install binutils-arm-none-eabi \
-            binutils-riscv64-unknown-elf
+          sudo apt-get install binutils-arm-none-eabi
           cargo install elf2tab
 
       - name: Build LEDs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,7 @@ jobs:
       # relocation.
       - name: Build and Test
         run: |
-          sudo apt-get install binutils-arm-none-eabi \
-            binutils-riscv64-unknown-elf ninja-build
+          sudo apt-get install binutils-arm-none-eabi ninja-build
           cd "${GITHUB_WORKSPACE}"
           echo "[target.'cfg(all())']" >> .cargo/config
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -26,3 +26,5 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           LIBTOCK_PLATFORM=nrf52 cargo build -p libtock2 \
             --target=thumbv7em-none-eabi
+          LIBTOCK_PLATFORM=hifive1 cargo build -p libtock2 \
+            --target=riscv32imac-unknown-none-elf

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -39,8 +39,7 @@ jobs:
       # master.
       - name: Compute sizes
         run: |
-          sudo apt-get install binutils-arm-none-eabi \
-            binutils-riscv64-unknown-elf
+          sudo apt-get install binutils-arm-none-eabi
           UPSTREAM_REMOTE_NAME="${UPSTREAM_REMOTE_NAME:-origin}"
           GITHUB_BASE_REF="${GITHUB_BASE_REF:-master}"
           cd "${GITHUB_WORKSPACE}"

--- a/runtime/extern_asm.rs
+++ b/runtime/extern_asm.rs
@@ -18,29 +18,9 @@ pub(crate) fn build_and_link(out_dir: &str) {
             as_extra_args: &[],
             strip: false,
         }],
-        "riscv32" => &[
-            // First try riscv64-unknown-elf, as it is the toolchain used by
-            // libtock-c and the toolchain used in the CI environment.
-            AsmBuildConfig {
-                prefix: "riscv64-unknown-elf",
-                as_extra_args: &["-march=rv32imc"],
-                strip: true,
-            },
-            // Second try riscv32-unknown-elf. This is the best match for Tock's
-            // risc-v targets, but is not as widely available (and has not been
-            // tested with libtock-rs yet).
-            AsmBuildConfig {
-                prefix: "riscv32-unknown-elf",
-                as_extra_args: &[],
-                strip: false, // Untested, may need to change.
-            },
-            // Last try riscv64-linux-gnu, as it is the only option on Debian 10
-            AsmBuildConfig {
-                prefix: "riscv64-linux-gnu",
-                as_extra_args: &["-march=rv32imc"],
-                strip: true,
-            },
-        ],
+        // RISC-V's entry point is compiled using global_asm! rather than an
+        // external toolchain.
+        "riscv32" => return,
         unknown_arch => {
             panic!("Unsupported architecture {}", unknown_arch);
         }

--- a/runtime/src/startup/asm_riscv32.s
+++ b/runtime/src/startup/asm_riscv32.s
@@ -33,7 +33,7 @@ start:
 	 * check is performed by comparing the program counter at the start to the
 	 * address of `start`, which is stored in rt_header. */
 	auipc s0, 0            /* s0 = pc */
-	mv a5, a0              /* Save rt_header so syscalls don't overwrite it */
+	mv a5, a0;             /* Save rt_header so syscalls don't overwrite it */
 	lw s1, 0(a5)           /* s1 = rt_header.start */
 	beq s0, s1, .Lset_brk  /* Skip error handling code if pc is correct */
 	/* If the beq on the previous line did not jump, then the binary is not at

--- a/runtime/src/startup/mod.rs
+++ b/runtime/src/startup/mod.rs
@@ -1,5 +1,11 @@
 //! Runtime components related to process startup.
 
+// Include the correct `start` symbol (the program entry point) for the
+// architecture.
+// TODO: Migrate ARM to global_asm! and delete extern_asm.rs.
+#[cfg(target_arch = "riscv32")]
+core::arch::global_asm!(include_str!("asm_riscv32.s"));
+
 /// `set_main!` is used to tell `libtock_runtime` where the process binary's
 /// `main` function is. The process binary's `main` function must have the
 /// signature `FnOnce() -> T`, where T is some concrete type that implements

--- a/runtime/src/startup/start_prototype.rs
+++ b/runtime/src/startup/start_prototype.rs
@@ -1,7 +1,6 @@
 // This file is not compiled or tested! It is kept in this repository in case
-// future libtock_runtime developers want to use it. To use this file, copy it
-// into libtock_runtime's src/ directory and add mod start_prototype; to
-// libtock_runtime's lib.rs.
+// future libtock_runtime developers want to use it. To use this file, add
+// `mod start_prototype;` to mod.rs.
 
 // The `start` symbol must be written purely in assembly, because it has an ABI
 // that the Rust compiler doesn't know (e.g. it does not expect the stack to be


### PR DESCRIPTION
Building `libtock_runtime` on RISC-V no longer requires an external toolchain! We use `global_asm!` instead.

This runs into a LLVM bug where it fails to parse a comment after a `mv` instruction unless the `mv` instruction has a semicolon after it, so I added a semicolon. I'm not sure where to put a descriptive comment, though.

I have not migrated the ARM entry point to `global_asm!`. When I tried, it generated significantly different code from the external toolchain, and I have no way to test if the new code works. Perhaps it's a Thumb 1 vs. Thumb 2 thing? I'll leave debugging that to someone else.