### PR TITLE
Remove our use of `#![feature(asm_const)]`.

### DIFF
--- a/platform/src/raw_syscalls.rs
+++ b/platform/src/raw_syscalls.rs
@@ -129,9 +129,9 @@ pub unsafe trait RawSyscalls: Sized {
     //            noreturn
     /// `syscall1` should only be called by `libtock_platform`.
     /// # Safety
-    /// This directly makes a system call. It can only be used for core kernel
-    /// system calls that accept 1 argument and only overwrite r0 and r1 on
-    /// return. It is unsafe any time the underlying system call is unsafe.
+    /// This directly makes a system call. It can only be used for Memop calls
+    /// that accept 1 argument and only overwrite r0 and r1 on return. It is
+    /// unsafe any time the underlying system call is unsafe.
     unsafe fn syscall1<const CLASS: usize>(_: [Register; 1]) -> [Register; 2];
 
     // syscall2 is used to invoke Exit as well as Memop operations that take an

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -18,7 +18,6 @@
 //! `no_auto_layout` feature on `libtock_runtime` to disable this functionality
 //! and provide its own layout file.
 
-#![feature(asm_const)]
 #![no_std]
 #![warn(unsafe_op_in_unsafe_fn)]
 


### PR DESCRIPTION
This is a temporary approach, that assumes (perhaps optimistically) that `asm_const` will be stabilized in a reasonable timeframe. If it looks like `asm_const` will not be stabilized for a while, we should redesign `RawSyscalls`.