### PR TITLE
Provide elf architecture to elf2tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ analyse-stack-sizes:
 .PHONY: apollo3
 apollo3:
 	LIBTOCK_PLATFORM=apollo3 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release) 
 	mkdir -p target/tbf/apollo3
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
@@ -137,7 +137,7 @@ apollo3:
 .PHONY: hail
 hail:
 	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release) 
 	mkdir -p target/tbf/hail
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
@@ -146,67 +146,67 @@ hail:
 .PHONY: flash-hail
 flash-hail:
 	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
 
 .PHONY: microbit_v2
 microbit_v2:
 	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --verbose --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/microbit_v2
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/microbit_v2
 
 .PHONY: flash-microbit_v2
 flash-microbit_v2:
 	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
 
 .PHONY: nucleo_f429zi
 nucleo_f429zi:
 	LIBTOCK_PLATFORM=nucleo_f429zi cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/nucleo_f429zi
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/nucleo_f429zi
 
 .PHONY: nucleo_f446re
 nucleo_f446re:
 	LIBTOCK_PLATFORM=nucleo_f446re cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/nucleo_f446re
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/nucleo_f446re
 
 .PHONY: nrf52840
 nrf52840:
 	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/nrf52840
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/nrf52840
 
 .PHONY: flash-nrf52840
 flash-nrf52840:
 	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
 
 .PHONY: stm32f3discovery
 stm32f3discovery:
 	LIBTOCK_PLATFORM=stm32f3discovery cargo run --example $(EXAMPLE) \
-		$(features) --target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		$(features) --target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/stm32f3discovery
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/stm32f3discovery
 
 .PHONY: opentitan
 opentitan:
 	LIBTOCK_PLATFORM=opentitan cargo run --example $(EXAMPLE) $(features) \
-		--target=riscv32imc-unknown-none-elf $(release) -- --architecture riscv32imc
+		--target=riscv32imc-unknown-none-elf $(release)
 	mkdir -p target/tbf/opentitan
 	cp target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tab \
 		target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tbf \
@@ -215,7 +215,7 @@ opentitan:
 .PHONY: hifive1
 hifive1:
 	LIBTOCK_PLATFORM=hifive1 cargo run --example $(EXAMPLE) $(features) \
-		--target=riscv32imac-unknown-none-elf $(release) -- --architecture riscv32imac
+		--target=riscv32imac-unknown-none-elf $(release)
 	mkdir -p target/tbf/hifive1
 	cp target/riscv32imac-unknown-none-elf/release/examples/$(EXAMPLE).tab \
 		target/riscv32imac-unknown-none-elf/release/examples/$(EXAMPLE).tbf \
@@ -224,33 +224,33 @@ hifive1:
 .PHONY: nrf52
 nrf52:
 	LIBTOCK_PLATFORM=nrf52 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/nrf52
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/nrf52
 
 .PHONY: flash-nrf52
 flash-nrf52:
 	LIBTOCK_PLATFORM=nrf52 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
 
 .PHONY: imxrt1050
 imxrt1050:
 	LIBTOCK_PLATFORM=imxrt1050 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m7
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/imxrt1050
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m7.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/imxrt1050
 
 .PHONY: msp432
 msp432:
 	LIBTOCK_PLATFORM=msp432 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/msp432
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/msp432
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ analyse-stack-sizes:
 .PHONY: apollo3
 apollo3:
 	LIBTOCK_PLATFORM=apollo3 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) 
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/apollo3
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
@@ -137,7 +137,7 @@ apollo3:
 .PHONY: hail
 hail:
 	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) 
+		--target=thumbv7em-none-eabi $(release)
 	mkdir -p target/tbf/hail
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
@@ -146,7 +146,7 @@ hail:
 .PHONY: flash-hail
 flash-hail:
 	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: microbit_v2
 microbit_v2:
@@ -160,7 +160,7 @@ microbit_v2:
 .PHONY: flash-microbit_v2
 flash-microbit_v2:
 	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: nucleo_f429zi
 nucleo_f429zi:
@@ -192,7 +192,7 @@ nrf52840:
 .PHONY: flash-nrf52840
 flash-nrf52840:
 	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: stm32f3discovery
 stm32f3discovery:
@@ -233,7 +233,7 @@ nrf52:
 .PHONY: flash-nrf52
 flash-nrf52:
 	LIBTOCK_PLATFORM=nrf52 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) --  --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
 .PHONY: imxrt1050
 imxrt1050:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ analyse-stack-sizes:
 .PHONY: apollo3
 apollo3:
 	LIBTOCK_PLATFORM=apollo3 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/apollo3
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
@@ -137,7 +137,7 @@ apollo3:
 .PHONY: hail
 hail:
 	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/hail
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
@@ -146,67 +146,67 @@ hail:
 .PHONY: flash-hail
 flash-hail:
 	LIBTOCK_PLATFORM=hail cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
 
 .PHONY: microbit_v2
 microbit_v2:
 	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --verbose --architecture cortex-m4
 	mkdir -p target/tbf/microbit_v2
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
 		target/tbf/microbit_v2
 
 .PHONY: flash-microbit_v2
 flash-microbit_v2:
 	LIBTOCK_PLATFORM=microbit_v2 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
 
 .PHONY: nucleo_f429zi
 nucleo_f429zi:
 	LIBTOCK_PLATFORM=nucleo_f429zi cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/nucleo_f429zi
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
 		target/tbf/nucleo_f429zi
 
 .PHONY: nucleo_f446re
 nucleo_f446re:
 	LIBTOCK_PLATFORM=nucleo_f446re cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/nucleo_f446re
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
 		target/tbf/nucleo_f446re
 
 .PHONY: nrf52840
 nrf52840:
 	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/nrf52840
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
 		target/tbf/nrf52840
 
 .PHONY: flash-nrf52840
 flash-nrf52840:
 	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
 
 .PHONY: stm32f3discovery
 stm32f3discovery:
 	LIBTOCK_PLATFORM=stm32f3discovery cargo run --example $(EXAMPLE) \
-		$(features) --target=thumbv7em-none-eabi $(release)
+		$(features) --target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/stm32f3discovery
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
 		target/tbf/stm32f3discovery
 
 .PHONY: opentitan
 opentitan:
 	LIBTOCK_PLATFORM=opentitan cargo run --example $(EXAMPLE) $(features) \
-		--target=riscv32imc-unknown-none-elf $(release)
+		--target=riscv32imc-unknown-none-elf $(release) -- --architecture riscv32imc
 	mkdir -p target/tbf/opentitan
 	cp target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tab \
 		target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tbf \
@@ -215,7 +215,7 @@ opentitan:
 .PHONY: hifive1
 hifive1:
 	LIBTOCK_PLATFORM=hifive1 cargo run --example $(EXAMPLE) $(features) \
-		--target=riscv32imac-unknown-none-elf $(release)
+		--target=riscv32imac-unknown-none-elf $(release) -- --architecture riscv32imac
 	mkdir -p target/tbf/hifive1
 	cp target/riscv32imac-unknown-none-elf/release/examples/$(EXAMPLE).tab \
 		target/riscv32imac-unknown-none-elf/release/examples/$(EXAMPLE).tbf \
@@ -224,33 +224,33 @@ hifive1:
 .PHONY: nrf52
 nrf52:
 	LIBTOCK_PLATFORM=nrf52 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/nrf52
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
 		target/tbf/nrf52
 
 .PHONY: flash-nrf52
 flash-nrf52:
 	LIBTOCK_PLATFORM=nrf52 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4 --deploy=tockloader
 
 .PHONY: imxrt1050
 imxrt1050:
 	LIBTOCK_PLATFORM=imxrt1050 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m7
 	mkdir -p target/tbf/imxrt1050
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m7.tbf \
 		target/tbf/imxrt1050
 
 .PHONY: msp432
 msp432:
 	LIBTOCK_PLATFORM=msp432 cargo run --example $(EXAMPLE) $(features) \
-		--target=thumbv7em-none-eabi $(release)
+		--target=thumbv7em-none-eabi $(release) -- --architecture cortex-m4
 	mkdir -p target/tbf/msp432
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
-		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
+		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).cortex-m4.tbf \
 		target/tbf/msp432
 
 .PHONY: clean

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -19,7 +19,11 @@ pub fn convert_elf(cli: &Cli) -> OutFiles {
     let stack_size = read_stack_size(cli);
     let elf = cli.elf.as_os_str();
     let mut tbf_path = cli.elf.clone();
-    tbf_path.set_extension("tbf");
+    if let Some(ref architecture) = cli.architecture {
+        tbf_path.set_extension(format!("{architecture}.tbf"));
+    } else {
+        tbf_path.set_extension("tbf");
+    }
     if cli.verbose {
         println!("ELF file: {:?}", elf);
         println!("TBF path: {}", tbf_path.display());
@@ -37,6 +41,7 @@ pub fn convert_elf(cli: &Cli) -> OutFiles {
     }
 
     let mut command = Command::new("elf2tab");
+
     #[rustfmt::skip]
     command.args([
         // TODO: libtock-rs' crates are designed for Tock 2.1's Allow interface,
@@ -48,7 +53,11 @@ pub fn convert_elf(cli: &Cli) -> OutFiles {
         "-o".as_ref(), tab_path.as_os_str(),
         "--protected-region-size".as_ref(), protected_size.as_ref(),
         "--stack".as_ref(), stack_size.as_ref(),
-        elf,
+        format!("{}{}", elf.to_str().unwrap(), if let Some(ref architecture) = cli.architecture { 
+                format!(",{architecture}") 
+            } else { 
+                String::from("") 
+            }).as_ref(),
     ]);
     if cli.verbose {
         command.arg("-v");

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -43,7 +43,8 @@ pub fn convert_elf(cli: &Cli, platform: &str) -> OutFiles {
     let elf = cli.elf.as_os_str();
     let mut tbf_path = cli.elf.clone();
     tbf_path.set_extension("tbf");
-    let architecture = get_platform_architecture(platform);
+    let architecture =
+        get_platform_architecture(platform).expect("Failed to determine ELF's architecture");
     if cli.verbose {
         println!("ELF file: {:?}", elf);
         println!("TBF path: {}", tbf_path.display());
@@ -73,11 +74,7 @@ pub fn convert_elf(cli: &Cli, platform: &str) -> OutFiles {
         "-o".as_ref(), tab_path.as_os_str(),
         "--protected-region-size".as_ref(), protected_size.as_ref(),
         "--stack".as_ref(), stack_size.as_ref(),
-        format!("{}{}", elf.to_str().unwrap(), if let Some(ref architecture) = architecture { 
-                format!(",{}", architecture) 
-            } else { 
-                "".to_string() 
-            }).as_ref(),
+        format!("{},{}", elf.to_str().unwrap(), architecture).as_ref(),
     ]);
     if cli.verbose {
         command.arg("-v");

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -62,7 +62,6 @@ pub fn convert_elf(cli: &Cli, platform: &str) -> OutFiles {
     }
 
     let mut command = Command::new("elf2tab");
-
     #[rustfmt::skip]
     command.args([
         // TODO: libtock-rs' crates are designed for Tock 2.1's Allow interface,

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -22,6 +22,10 @@ pub struct Cli {
     /// Whether to output verbose debugging information to the console.
     #[clap(long, short)]
     verbose: bool,
+
+    /// The architecture of the elf file
+    #[clap(long, short)]
+    architecture: Option<String>,
 }
 
 #[derive(ArgEnum, Clone, Copy, Debug)]


### PR DESCRIPTION
This PR changes the runner to provide the architecture of elf files to elf2tab. It requires https://github.com/tock/elf2tab/pull/38.