### PR TITLE
Add Esp32C3 DevKitM 1 to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ usage:
 	@echo " - imxrt1050"
 	@echo " - apollo3"
 	@echo " - stm32f3discovery"
+	@echo " - esp32_c3_devkitm_1"
 	@echo
 	@echo "Run 'make setup' to setup Rust to build libtock-rs."
 	@echo "Run 'make <board> EXAMPLE=<>' to build EXAMPLE for that board."
@@ -133,6 +134,15 @@ apollo3:
 	cp target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv7em-none-eabi/release/examples/$(EXAMPLE).tbf \
 		target/tbf/apollo3
+
+.PHONY: esp32_c3_devkitm_1
+esp32_c3_devkitm_1:
+	LIBTOCK_PLATFORM=esp32_c3_devkitm_1 cargo run --example $(EXAMPLE) $(features) \
+		--target=riscv32imc-unknown-none-elf $(release)
+	mkdir -p target/tbf/esp32_c3_devkitm_1
+	cp target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tab \
+		target/riscv32imc-unknown-none-elf/release/examples/$(EXAMPLE).tbf \
+		target/tbf/esp32_c3_devkitm_1
 
 .PHONY: hail
 hail:

--- a/runtime/layouts/esp32_c3_devkitm_1.ld
+++ b/runtime/layouts/esp32_c3_devkitm_1.ld
@@ -1,4 +1,4 @@
-/* Layout for the Imix board, used by the examples in this repository. */
+/* Layout for the esp32c3 DevKit M1 board, used by the examples in this repository. */
 
 MEMORY {
   /* Note that the SRAM address may need to be changed depending on


### PR DESCRIPTION
This PR adds the Esp32C3 DevKitM 1 to the makefile.

As boards are not placed in alphabetical order in the makefile, I added it at the end. I will submit a new PR when this gets merged with the makefile targets sorted.