### PR TITLE
Remove owners who have not contributed in the past year.

### DIFF
--- a/doc/CodeReview.md
+++ b/doc/CodeReview.md
@@ -46,5 +46,3 @@ The owners of `libtock-rs` are:
 * The [Tock Core Working
   Group](https://github.com/tock/tock/tree/master/doc/wg/core#members).
 * Alistair Francis, [alistair23](https://github.com/alistair23), Western Digital
-* [torfmaster](https://github.com/torfmaster)
-* [Woyten](https://github.com/Woyten)


### PR DESCRIPTION
Thank you to @torfmaster and @Woyten for all the work you have put into `libtock-rs`!