### PR TITLE
Replace `_number` with `_num` for consistency.

### DIFF
--- a/syscalls_tests/src/allow_ro.rs
+++ b/syscalls_tests/src/allow_ro.rs
@@ -24,10 +24,10 @@ impl fake::SyscallDriver for TestDriver {
 
     fn allow_readonly(
         &self,
-        buffer_number: u32,
+        buffer_num: u32,
         buffer: RoAllowBuffer,
     ) -> Result<RoAllowBuffer, (RoAllowBuffer, ErrorCode)> {
-        if buffer_number != 0 {
+        if buffer_num != 0 {
             return Err((buffer, ErrorCode::NoSupport));
         }
         Ok(self.buffer_0.replace(buffer))
@@ -63,8 +63,8 @@ fn allow_ro() {
         assert_eq!(
             kernel.take_syscall_log(),
             [SyscallLogEntry::AllowRo {
-                driver_number: 42,
-                buffer_number: 1,
+                driver_num: 42,
+                buffer_num: 1,
                 len: 4,
             }]
         );
@@ -74,8 +74,8 @@ fn allow_ro() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRo {
-            driver_number: 42,
-            buffer_number: 1,
+            driver_num: 42,
+            buffer_num: 1,
             len: 0,
         }]
     );
@@ -88,8 +88,8 @@ fn allow_ro() {
         assert_eq!(
             kernel.take_syscall_log(),
             [SyscallLogEntry::AllowRo {
-                driver_number: 42,
-                buffer_number: 0,
+                driver_num: 42,
+                buffer_num: 0,
                 len: 4,
             }]
         );
@@ -101,8 +101,8 @@ fn allow_ro() {
         assert_eq!(
             kernel.take_syscall_log(),
             [SyscallLogEntry::AllowRo {
-                driver_number: 42,
-                buffer_number: 0,
+                driver_num: 42,
+                buffer_num: 0,
                 len: 2,
             }]
         );
@@ -112,8 +112,8 @@ fn allow_ro() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRo {
-            driver_number: 42,
-            buffer_number: 0,
+            driver_num: 42,
+            buffer_num: 0,
             len: 0,
         }]
     );

--- a/syscalls_tests/src/allow_rw.rs
+++ b/syscalls_tests/src/allow_rw.rs
@@ -24,10 +24,10 @@ impl fake::SyscallDriver for TestDriver {
 
     fn allow_readwrite(
         &self,
-        buffer_number: u32,
+        buffer_num: u32,
         buffer: RwAllowBuffer,
     ) -> Result<RwAllowBuffer, (RwAllowBuffer, ErrorCode)> {
-        if buffer_number != 0 {
+        if buffer_num != 0 {
             return Err((buffer, ErrorCode::NoSupport));
         }
         Ok(self.buffer_0.replace(buffer))
@@ -63,8 +63,8 @@ fn allow_rw() {
         assert_eq!(
             kernel.take_syscall_log(),
             [SyscallLogEntry::AllowRw {
-                driver_number: 42,
-                buffer_number: 1,
+                driver_num: 42,
+                buffer_num: 1,
                 len: 4,
             }]
         );
@@ -74,8 +74,8 @@ fn allow_rw() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRw {
-            driver_number: 42,
-            buffer_number: 1,
+            driver_num: 42,
+            buffer_num: 1,
             len: 0,
         }]
     );
@@ -88,8 +88,8 @@ fn allow_rw() {
         assert_eq!(
             kernel.take_syscall_log(),
             [SyscallLogEntry::AllowRw {
-                driver_number: 42,
-                buffer_number: 0,
+                driver_num: 42,
+                buffer_num: 0,
                 len: 4,
             }]
         );
@@ -101,8 +101,8 @@ fn allow_rw() {
         assert_eq!(
             kernel.take_syscall_log(),
             [SyscallLogEntry::AllowRw {
-                driver_number: 42,
-                buffer_number: 0,
+                driver_num: 42,
+                buffer_num: 0,
                 len: 2,
             }]
         );
@@ -118,8 +118,8 @@ fn allow_rw() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRw {
-            driver_number: 42,
-            buffer_number: 0,
+            driver_num: 42,
+            buffer_num: 0,
             len: 0,
         }]
     );

--- a/syscalls_tests/src/subscribe_tests.rs
+++ b/syscalls_tests/src/subscribe_tests.rs
@@ -81,8 +81,8 @@ fn success() {
         assert_eq!(
             kernel.take_syscall_log(),
             [SyscallLogEntry::Subscribe {
-                driver_number: 1,
-                subscribe_number: 0
+                driver_num: 1,
+                subscribe_num: 0
             }]
         );
         upcall::schedule(1, 0, (2, 3, 4)).unwrap();
@@ -95,8 +95,8 @@ fn success() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::Subscribe {
-            driver_number: 1,
-            subscribe_number: 0
+            driver_num: 1,
+            subscribe_num: 0
         }]
     );
     upcall::schedule(1, 0, (2, 3, 4)).unwrap();

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -23,8 +23,8 @@ pub enum ExpectedSyscall {
     // Subscribe
     // -------------------------------------------------------------------------
     Subscribe {
-        driver_number: u32,
-        subscribe_number: u32,
+        driver_num: u32,
+        subscribe_num: u32,
 
         /// If not None, the Subscribe call will be skipped and the provided
         /// error code will be returned (along with the passed upcall).
@@ -51,8 +51,8 @@ pub enum ExpectedSyscall {
     // Read-Only Allow
     // -------------------------------------------------------------------------
     AllowRo {
-        driver_number: u32,
-        buffer_number: u32,
+        driver_num: u32,
+        buffer_num: u32,
 
         // If set to Some(_), the driver's allow_readonly method will not be
         // invoked and the provided error will be returned instead.
@@ -63,8 +63,8 @@ pub enum ExpectedSyscall {
     // Read-Write Allow
     // -------------------------------------------------------------------------
     AllowRw {
-        driver_number: u32,
-        buffer_number: u32,
+        driver_num: u32,
+        buffer_num: u32,
 
         // If set to Some(_), the driver's allow_readwrite method will not be
         // invoked and the provided error will be returned instead.

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -33,8 +33,8 @@ impl<const LEDS_COUNT: usize> crate::fake::SyscallDriver for Leds<LEDS_COUNT> {
         0
     }
 
-    fn command(&self, command_number: u32, argument0: u32, _argument1: u32) -> CommandReturn {
-        match command_number {
+    fn command(&self, command_num: u32, argument0: u32, _argument1: u32) -> CommandReturn {
+        match command_num {
             DRIVER_CHECK => crate::command_return::success_u32(LEDS_COUNT as u32),
             LED_ON => {
                 if argument0 < LEDS_COUNT as u32 {

--- a/unittest/src/fake/low_level_debug/mod.rs
+++ b/unittest/src/fake/low_level_debug/mod.rs
@@ -33,8 +33,8 @@ impl crate::fake::SyscallDriver for LowLevelDebug {
         0
     }
 
-    fn command(&self, command_number: u32, argument0: u32, argument1: u32) -> CommandReturn {
-        match command_number {
+    fn command(&self, command_num: u32, argument0: u32, argument1: u32) -> CommandReturn {
+        match command_num {
             DRIVER_CHECK => {}
             PRINT_ALERT_CODE => self.handle_message(Message::AlertCode(argument0)),
             PRINT_1 => self.handle_message(Message::Print1(argument0)),

--- a/unittest/src/fake/syscall_driver.rs
+++ b/unittest/src/fake/syscall_driver.rs
@@ -16,7 +16,7 @@ pub trait SyscallDriver: 'static {
     /// Like the real Tock kernel, `fake::Kernel` implements Subscribe for
     /// drivers. Drivers must implement `num_upcalls` to tell `fake::Kernel` how
     /// many upcalls to store. `fake::Kernel` will reject Subscribe calls for
-    /// any subscribe_number >= num_upcalls.
+    /// any subscribe_num >= num_upcalls.
     fn num_upcalls(&self) -> u32;
 
     // -------------------------------------------------------------------------
@@ -36,10 +36,10 @@ pub trait SyscallDriver: 'static {
     /// implementation is provided that rejects all Read-Only Allow calls.
     fn allow_readonly(
         &self,
-        buffer_number: u32,
+        buffer_num: u32,
         buffer: RoAllowBuffer,
     ) -> Result<RoAllowBuffer, (RoAllowBuffer, ErrorCode)> {
-        let _ = buffer_number; // Silences the unused variable warning.
+        let _ = buffer_num; // Silences the unused variable warning.
         Err((buffer, ErrorCode::NoSupport))
     }
 
@@ -48,10 +48,10 @@ pub trait SyscallDriver: 'static {
     /// implementation is provided that rejects all Read-Write Allow calls.
     fn allow_readwrite(
         &self,
-        buffer_number: u32,
+        buffer_num: u32,
         buffer: RwAllowBuffer,
     ) -> Result<RwAllowBuffer, (RwAllowBuffer, ErrorCode)> {
-        let _ = buffer_number; // Silences the unused variable warning.
+        let _ = buffer_num; // Silences the unused variable warning.
         Err((buffer, ErrorCode::NoSupport))
     }
 }

--- a/unittest/src/fake/syscalls/allow_ro_impl.rs
+++ b/unittest/src/fake/syscalls/allow_ro_impl.rs
@@ -4,20 +4,20 @@ use libtock_platform::{return_variant, ErrorCode, Register};
 use std::convert::TryInto;
 
 pub(super) unsafe fn allow_ro(
-    driver_number: Register,
-    buffer_number: Register,
+    driver_num: Register,
+    buffer_num: Register,
     address: Register,
     len: Register,
 ) -> [Register; 4] {
-    let driver_number = driver_number.try_into().expect("Too large driver number");
-    let buffer_number = buffer_number.try_into().expect("Too large buffer number");
+    let driver_num = driver_num.try_into().expect("Too large driver number");
+    let buffer_num = buffer_num.try_into().expect("Too large buffer number");
     let result = with_kernel_data(|option_kernel_data| {
         let kernel_data =
             option_kernel_data.expect("Read-Only Allow called but no fake::Kernel exists");
 
         kernel_data.syscall_log.push(SyscallLogEntry::AllowRo {
-            driver_number,
-            buffer_number,
+            driver_num,
+            buffer_num,
             len: len.into(),
         });
 
@@ -27,17 +27,17 @@ pub(super) unsafe fn allow_ro(
         match kernel_data.expected_syscalls.pop_front() {
             None => {}
             Some(ExpectedSyscall::AllowRo {
-                driver_number: expected_driver_number,
-                buffer_number: expected_buffer_number,
+                driver_num: expected_driver_num,
+                buffer_num: expected_buffer_num,
                 return_error,
             }) => {
                 assert_eq!(
-                    driver_number, expected_driver_number,
-                    "expected different driver_number"
+                    driver_num, expected_driver_num,
+                    "expected different driver_num"
                 );
                 assert_eq!(
-                    buffer_number, expected_buffer_number,
-                    "expected different buffer_number"
+                    buffer_num, expected_buffer_num,
+                    "expected different buffer_num"
                 );
                 if let Some(error_code) = return_error {
                     return Err(error_code);
@@ -46,7 +46,7 @@ pub(super) unsafe fn allow_ro(
             Some(expected_syscall) => expected_syscall.panic_wrong_call("Read-Only Allow"),
         };
 
-        let driver = match kernel_data.drivers.get(&driver_number) {
+        let driver = match kernel_data.drivers.get(&driver_num) {
             None => return Err(ErrorCode::NoDevice),
             Some(driver_data) => driver_data.driver.clone(),
         };
@@ -70,7 +70,7 @@ pub(super) unsafe fn allow_ro(
         }
     };
 
-    let (error_code, buffer_out) = match driver.allow_readonly(buffer_number, buffer) {
+    let (error_code, buffer_out) = match driver.allow_readonly(buffer_num, buffer) {
         Ok(buffer_out) => (None, buffer_out),
         Err((buffer_out, error_code)) => (Some(error_code), buffer_out),
     };

--- a/unittest/src/fake/syscalls/allow_ro_impl_tests.rs
+++ b/unittest/src/fake/syscalls/allow_ro_impl_tests.rs
@@ -32,8 +32,8 @@ fn expected_wrong() {
     .contains("but Read-Only Allow was called instead"));
 
     kernel.add_expected_syscall(ExpectedSyscall::AllowRo {
-        driver_number: 1,
-        buffer_number: 2,
+        driver_num: 1,
+        buffer_num: 2,
         return_error: None,
     });
     assert!(catch_unwind(|| unsafe {
@@ -42,11 +42,11 @@ fn expected_wrong() {
     .expect_err("failed to catch wrong driver number")
     .downcast_ref::<String>()
     .expect("wrong panic payload type")
-    .contains("expected different driver_number"));
+    .contains("expected different driver_num"));
 
     kernel.add_expected_syscall(ExpectedSyscall::AllowRo {
-        driver_number: 1,
-        buffer_number: 2,
+        driver_num: 1,
+        buffer_num: 2,
         return_error: None,
     });
     assert!(catch_unwind(|| unsafe {
@@ -55,7 +55,7 @@ fn expected_wrong() {
     .expect_err("failed to catch wrong buffer number")
     .downcast_ref::<String>()
     .expect("wrong panic payload type")
-    .contains("expected different buffer_number"));
+    .contains("expected different buffer_num"));
 }
 
 #[test]
@@ -99,8 +99,8 @@ fn syscall_log() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRo {
-            driver_number: 1,
-            buffer_number: 2,
+            driver_num: 1,
+            buffer_num: 2,
             len: 3,
         }]
     );

--- a/unittest/src/fake/syscalls/allow_rw_impl_tests.rs
+++ b/unittest/src/fake/syscalls/allow_rw_impl_tests.rs
@@ -32,8 +32,8 @@ fn expected_wrong() {
     .contains("but Read-Write Allow was called instead"));
 
     kernel.add_expected_syscall(ExpectedSyscall::AllowRw {
-        driver_number: 1,
-        buffer_number: 2,
+        driver_num: 1,
+        buffer_num: 2,
         return_error: None,
     });
     assert!(catch_unwind(|| unsafe {
@@ -42,11 +42,11 @@ fn expected_wrong() {
     .expect_err("failed to catch wrong driver number")
     .downcast_ref::<String>()
     .expect("wrong panic payload type")
-    .contains("expected different driver_number"));
+    .contains("expected different driver_num"));
 
     kernel.add_expected_syscall(ExpectedSyscall::AllowRw {
-        driver_number: 1,
-        buffer_number: 2,
+        driver_num: 1,
+        buffer_num: 2,
         return_error: None,
     });
     assert!(catch_unwind(|| unsafe {
@@ -55,7 +55,7 @@ fn expected_wrong() {
     .expect_err("failed to catch wrong buffer number")
     .downcast_ref::<String>()
     .expect("wrong panic payload type")
-    .contains("expected different buffer_number"));
+    .contains("expected different buffer_num"));
 }
 
 #[test]
@@ -99,8 +99,8 @@ fn syscall_log() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRw {
-            driver_number: 1,
-            buffer_number: 2,
+            driver_num: 1,
+            buffer_num: 2,
             len: 3,
         }]
     );

--- a/unittest/src/fake/syscalls/exit_impl.rs
+++ b/unittest/src/fake/syscalls/exit_impl.rs
@@ -1,9 +1,9 @@
 use core::convert::TryInto;
 
 pub(super) fn exit(r0: libtock_platform::Register, r1: libtock_platform::Register) -> ! {
-    let exit_number: u32 = r0.try_into().expect("Too large exit number");
+    let exit_num: u32 = r0.try_into().expect("Too large exit number");
     let completion_code: u32 = r1.try_into().expect("Too large completion code");
-    match exit_number {
+    match exit_num {
         libtock_platform::exit_id::TERMINATE => {
             println!("exit-terminate called with code {}", completion_code);
 
@@ -20,6 +20,6 @@ pub(super) fn exit(r0: libtock_platform::Register, r1: libtock_platform::Registe
 
             std::process::exit(1);
         }
-        _ => panic!("Unknown exit number {} invoked.", exit_number),
+        _ => panic!("Unknown exit number {} invoked.", exit_num),
     }
 }

--- a/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
@@ -20,8 +20,8 @@ fn allow_ro() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRo {
-            driver_number: 1,
-            buffer_number: 2,
+            driver_num: 1,
+            buffer_num: 2,
             len: 0,
         }]
     );
@@ -41,8 +41,8 @@ fn allow_rw() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::AllowRw {
-            driver_number: 1,
-            buffer_number: 2,
+            driver_num: 1,
+            buffer_num: 2,
             len: 0,
         }]
     );

--- a/unittest/src/fake/syscalls/subscribe_impl_tests.rs
+++ b/unittest/src/fake/syscalls/subscribe_impl_tests.rs
@@ -28,8 +28,8 @@ fn expected_wrong() {
         .contains("but Subscribe was called instead"));
 
     let expected_syscall = ExpectedSyscall::Subscribe {
-        driver_number: 1,
-        subscribe_number: 2,
+        driver_num: 1,
+        subscribe_num: 2,
         skip_with_error: None,
     };
 
@@ -90,8 +90,8 @@ fn no_kernel() {
 fn skip_with_error() {
     let kernel = fake::Kernel::new();
     kernel.add_expected_syscall(ExpectedSyscall::Subscribe {
-        driver_number: 1,
-        subscribe_number: 2,
+        driver_num: 1,
+        subscribe_num: 2,
         skip_with_error: Some(ErrorCode::NoAck),
     });
     unsafe extern "C" fn upcall_fn(_: u32, _: u32, _: u32, _: Register) {}
@@ -132,13 +132,13 @@ fn syscall4_subscribe() {
     assert_eq!(
         kernel.take_syscall_log(),
         [SyscallLogEntry::Subscribe {
-            driver_number: 1,
-            subscribe_number: 2,
+            driver_num: 1,
+            subscribe_num: 2,
         }]
     );
 }
 
-// Tests Subscribe with too large inputs (driver_number and subscribe_number)
+// Tests Subscribe with too large inputs (driver_num and subscribe_num)
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn too_large_inputs() {

--- a/unittest/src/fake/syscalls/yield_impl_tests.rs
+++ b/unittest/src/fake/syscalls/yield_impl_tests.rs
@@ -79,8 +79,8 @@ fn yield_no_wait_test() {
     // Upcall structures for using copy_args.
     let mut output_array = [0u32; 3];
     let upcall_id = UpcallId {
-        driver_number: 1,
-        subscribe_number: 2,
+        driver_num: 1,
+        subscribe_num: 2,
     };
     let upcall = Upcall {
         fn_pointer: Some(copy_args),
@@ -159,8 +159,8 @@ fn yield_wait_test() {
     // Upcall structures for using copy_args.
     let mut output_array = [0u32; 3];
     let upcall_id = UpcallId {
-        driver_number: 1,
-        subscribe_number: 2,
+        driver_num: 1,
+        subscribe_num: 2,
     };
     let upcall = Upcall {
         fn_pointer: Some(copy_args),

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -12,8 +12,8 @@ pub enum SyscallLogEntry {
     // Subscribe
     // -------------------------------------------------------------------------
     Subscribe {
-        driver_number: u32,
-        subscribe_number: u32,
+        driver_num: u32,
+        subscribe_num: u32,
     },
 
     // -------------------------------------------------------------------------
@@ -30,8 +30,8 @@ pub enum SyscallLogEntry {
     // Read-Only Allow
     // -------------------------------------------------------------------------
     AllowRo {
-        driver_number: u32,
-        buffer_number: u32,
+        driver_num: u32,
+        buffer_num: u32,
         len: usize,
     },
 
@@ -39,8 +39,8 @@ pub enum SyscallLogEntry {
     // Read-Write Allow
     // -------------------------------------------------------------------------
     AllowRw {
-        driver_number: u32,
-        buffer_number: u32,
+        driver_num: u32,
+        buffer_num: u32,
         len: usize,
     },
     // TODO: Add Memop.

--- a/unittest/src/upcall.rs
+++ b/unittest/src/upcall.rs
@@ -4,23 +4,23 @@
 /// Like the real kernel, this does nothing and returns success if there is no
 /// upcall or the upcall is a null upcall.
 pub fn schedule(
-    driver_number: u32,
-    subscribe_number: u32,
+    driver_num: u32,
+    subscribe_num: u32,
     args: (u32, u32, u32),
 ) -> Result<(), ScheduleError> {
     crate::kernel_data::with_kernel_data(|kernel_data| {
         let kernel_data = kernel_data.ok_or(ScheduleError::NoKernel)?;
         let driver_data = kernel_data
             .drivers
-            .get(&driver_number)
-            .ok_or(ScheduleError::NoDriver(driver_number))?;
-        if subscribe_number >= driver_data.num_upcalls {
+            .get(&driver_num)
+            .ok_or(ScheduleError::NoDriver(driver_num))?;
+        if subscribe_num >= driver_data.num_upcalls {
             return Err(ScheduleError::TooLargeSubscribeNumber {
                 num_upcalls: driver_data.num_upcalls,
-                requested: subscribe_number,
+                requested: subscribe_num,
             });
         }
-        let upcall = match driver_data.upcalls.get(&subscribe_number) {
+        let upcall = match driver_data.upcalls.get(&subscribe_num) {
             Some(&upcall) => upcall,
             None => return Ok(()),
         };
@@ -32,8 +32,8 @@ pub fn schedule(
         kernel_data.upcall_queue.push_back(UpcallQueueEntry {
             args,
             id: UpcallId {
-                driver_number,
-                subscribe_number,
+                driver_num,
+                subscribe_num,
             },
             upcall,
         });
@@ -108,8 +108,8 @@ pub(crate) struct UpcallQueueEntry {
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct UpcallId {
-    pub driver_number: u32,
-    pub subscribe_number: u32,
+    pub driver_num: u32,
+    pub subscribe_num: u32,
 }
 
 #[cfg(test)]
@@ -202,8 +202,8 @@ mod tests {
             assert_eq!(
                 upcall_queue_entry.id,
                 UpcallId {
-                    driver_number: 1,
-                    subscribe_number: 2
+                    driver_num: 1,
+                    subscribe_num: 2
                 }
             );
             assert!(upcall_queue_entry.upcall.fn_pointer == Some(upcall));
@@ -232,8 +232,8 @@ mod tests {
             assert_eq!(
                 front_queue_entry.id,
                 UpcallId {
-                    driver_number: 1,
-                    subscribe_number: 2
+                    driver_num: 1,
+                    subscribe_num: 2
                 }
             );
             assert!(front_queue_entry.upcall.fn_pointer == Some(upcall));
@@ -244,8 +244,8 @@ mod tests {
             assert_eq!(
                 back_queue_entry.id,
                 UpcallId {
-                    driver_number: 1,
-                    subscribe_number: 2
+                    driver_num: 1,
+                    subscribe_num: 2
                 }
             );
             assert!(back_queue_entry.upcall.fn_pointer == Some(upcall));


### PR DESCRIPTION
As noticed in #373, this repository uses a mix of `_number` and `_num` for allow/command/driver/exit/subscribe numbers. We decided to use `_num` everywhere for consistency. This PR replaces the `_number` suffixes with `_num`.

There are still many uses of `_id` in the code from before TRD104 standardized on using "number" for those values. This PR is already getting large, so I'll leave that for a separate PR.