### PR TITLE
Verify in CI that all `libtock-rs` crates build on stable.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,15 @@ jobs:
       # using the RUSTFLAGS environment variable because if we set RUSTFLAGS
       # cargo will ignore the rustflags config in .cargo/config, breaking
       # relocation.
+      #
+      # TODO: Remove the "rustup toolchain update stable" once the 20220227.1
+      # version of the Ubuntu 20.04 virtual environment is fully rolled out.
+      # The rollout status can be found here:
+      # https://github.com/actions/virtual-environments
       - name: Build and Test
         run: |
           sudo apt-get install ninja-build
+          rustup toolchain update stable
           cd "${GITHUB_WORKSPACE}"
           echo "[target.'cfg(all())']" >> .cargo/config
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config

--- a/Makefile
+++ b/Makefile
@@ -99,14 +99,16 @@ EXCLUDE_MIRI := $(EXCLUDE_RUNTIME) --exclude ufmt-macros
 EXCLUDE_STD := --exclude libtock_unittest --exclude print_sizes \
                --exclude runner --exclude syscalls_tests
 
-# Some of our crates should build with a stable toolchain. This verifies those
-# crates don't depend on unstable features by using cargo check. We specify a
-# different target directory so this doesn't flush the cargo cache of the
-# primary toolchain.
+# Currently, all of our crates should build with a stable toolchain. This
+# verifies our crates don't depend on unstable features by using cargo check. We
+# specify a different target directory so this doesn't flush the cargo cache of
+# the primary toolchain.
 .PHONY: test-stable
 test-stable:
 	CARGO_TARGET_DIR="target/stable-toolchain" cargo +stable check --workspace \
 		$(EXCLUDE_RUNTIME)
+	CARGO_TARGET_DIR="target/stable-toolchain" LIBTOCK_PLATFORM=nrf52 cargo \
+		+stable check $(EXCLUDE_STD) --target=thumbv7em-none-eabi --workspace
 
 .PHONY: test
 test: examples test-stable

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ setup: setup-qemu
 	cargo install elf2tab
 	cargo install stack-sizes
 	cargo miri setup
+	rustup target add --toolchain stable thumbv7em-none-eabi
 
 # Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
 # patches to better support boards that Tock supports.


### PR DESCRIPTION
This does not remove use of the nightly toolchain, because:

1. `cargo miri` requires nightly
2. I intend to use `#![feature(custom_test_frameworks)]` to build an integration test framework.
3. We will need `#![feature(default_alloc_error_handler)]` when we provide a global memory allocator (which will be an optional feature of `libtock-rs`).