### PR TITLE
Fix address calculation

### DIFF
--- a/runtime/src/startup/asm_arm.s
+++ b/runtime/src/startup/asm_arm.s
@@ -40,7 +40,7 @@ start:
 	mov r4, pc        /* r4 = address of .start + 4 (Thumb bit unset) */
 	mov r5, r0        /* Save rt_header; we use r0 for syscalls */
 	ldr r0, [r5, #0]  /* r0 = rt_header.start */
-	adds r0, #3       /* r0 = rt_header.start + 4 - 1 (for Thumb bit) */
+	adds r0, #3       /* r0 = rt_header.start + 4 (Thumb bit already accounted for in rt_header.start value) */
 	cmp r0, r4        /* Skip error handling if pc correct */
 	beq .Lset_brk     
 	/* If the beq on the previous line did not jump, then the binary is not at


### PR DESCRIPTION
The Thumb bit is already present in rt_header.start value when linking with GNU ld, as well as rust-lld.

Excerpt with rust-lld:

```
[root@5b7ac846a2fc libtock-rs]# arm-none-eabi-objdump -x target/thumbv7em-none-eabi/release/examples/cortex-m4.leds.elf 

target/thumbv7em-none-eabi/release/examples/cortex-m4.leds.elf:     file format elf32-littlearm
target/thumbv7em-none-eabi/release/examples/cortex-m4.leds.elf
architecture: armv7e-m, flags 0x00000112:
EXEC_P, HAS_SYMS, D_PAGED
start address 0x00030069

[symbols]

00030068 g     F .start 00000000 start
[...]
```