### PR TITLE
Clear the Thumb bit on `.start`'s address to be compatible with both `ld` and `lld`.

### DIFF
--- a/runtime/libtock_layout.ld
+++ b/runtime/libtock_layout.ld
@@ -61,7 +61,7 @@ SECTIONS {
          * elf2tab does not parse the ELF file correctly for unknown reasons.
          */
         rt_header = .;
-        LONG(start);
+        LONG(start & 0xFFFFFFFE);        /* .start w/ Thumb bit unset */
         LONG(ADDR(.bss) + SIZEOF(.bss)); /* Initial process break */
         LONG(_stack_top);
         LONG(SIZEOF(.data));

--- a/runtime/src/startup/asm_arm.s
+++ b/runtime/src/startup/asm_arm.s
@@ -40,7 +40,7 @@ start:
 	mov r4, pc        /* r4 = address of .start + 4 (Thumb bit unset) */
 	mov r5, r0        /* Save rt_header; we use r0 for syscalls */
 	ldr r0, [r5, #0]  /* r0 = rt_header.start */
-	adds r0, #3       /* r0 = rt_header.start + 4 - 1 (for Thumb bit) */
+	adds r0, #4       /* r0 = rt_header.start + 4 */
 	cmp r0, r4        /* Skip error handling if pc correct */
 	beq .Lset_brk     
 	/* If the beq on the previous line did not jump, then the binary is not at


### PR DESCRIPTION
This is an alternative fix for the issue that https://github.com/tock/libtock-rs/pull/392 fixes. The underlying issue is that `rust-lld` (based on LLVM's LLD) and GCC's `ld` handle the Thumb bit differently. `rust-lld` sets the Thumb bit for symbol addresses, and `ld` does not, resulting in different `rt_header.start` values.

This PR resolves that issue by clearing the Thumb bit in the linker script when setting `rt_header.start`, and modifying the ARM startup assembly to no longer expect the Thumb bit to be set. Now, `libtock_runtime` should correctly start with either linker. This *should* be a no-op on RISC-V (where `.start` is always aligned to a multiple of 4 address), and was tested by hand on RISC-V using QEMU.