### PR TITLE
Add console driver API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["tock"]
 members = [
     "apis/gpio",
     "apis/buttons",
+    "apis/console",
     "apis/leds",
     "apis/low_level_debug",
     "libtock2",

--- a/apis/console/Cargo.toml
+++ b/apis/console/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "libtock_console"
+version = "0.1.0"
+authors = [
+    "Tock Project Developers <tock-dev@googlegroups.com>",
+    "dcz <gihuac.dcz@porcupinefactory.org>",
+]
+license = "MIT/Apache-2.0"
+edition = "2021"
+repository = "https://www.github.com/tock/libtock-rs"
+description = "libtock console driver"
+
+[dependencies]
+libtock_platform = { path = "../../platform" }
+
+[dev-dependencies]
+libtock_unittest = { path = "../../unittest" }

--- a/apis/console/src/lib.rs
+++ b/apis/console/src/lib.rs
@@ -1,0 +1,113 @@
+#![no_std]
+
+use core::fmt;
+use core::marker::PhantomData;
+use libtock_platform as platform;
+use libtock_platform::allow_ro::AllowRo;
+use libtock_platform::share;
+use libtock_platform::subscribe::Subscribe;
+use libtock_platform::{DefaultConfig, ErrorCode, Syscalls};
+
+/// The console driver.
+///
+/// It allows libraries to pass strings to the kernel's console driver.
+///
+/// # Example
+/// ```ignore
+/// use libtock2::Console;
+///
+/// // Writes "foo", followed by a newline, to the console
+/// let mut writer = Console::writer();
+/// writeln!(writer, foo).unwrap();
+/// ```
+pub struct Console<
+    S: Syscalls,
+    C: platform::allow_ro::Config + platform::subscribe::Config = DefaultConfig,
+>(S, C);
+
+impl<S: Syscalls, C: platform::allow_ro::Config + platform::subscribe::Config> Console<S, C> {
+    /// Run a check against the console capsule to ensure it is present.
+    ///
+    /// Returns `true` if the driver was present. This does not necessarily mean
+    /// that the driver is working, as it may still fail to allocate grant
+    /// memory.
+    #[inline(always)]
+    pub fn driver_check() -> bool {
+        S::command(DRIVER_NUM, command::DRIVER_CHECK, 0, 0).is_success()
+    }
+
+    /// Writes bytes.
+    /// This is an alternative to `fmt::Write::write`
+    /// because this can actually return an error code.
+    pub fn write(s: &[u8]) -> Result<(), ErrorCode> {
+        let called = core::cell::Cell::new(Option::<(u32,)>::None);
+        share::scope::<
+            (
+                AllowRo<_, DRIVER_NUM, { allow_ro::WRITE }>,
+                Subscribe<_, DRIVER_NUM, { subscribe::WRITE }>,
+            ),
+            _,
+            _,
+        >(|handle| {
+            let (allow_ro, subscribe) = handle.split();
+
+            S::allow_ro::<C, DRIVER_NUM, { allow_ro::WRITE }>(allow_ro, s)?;
+
+            S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
+
+            S::command(DRIVER_NUM, command::WRITE, s.len() as u32, 0).to_result()?;
+
+            loop {
+                S::yield_wait();
+                if let Some((_,)) = called.get() {
+                    return Ok(());
+                }
+            }
+        })
+    }
+
+    pub fn writer() -> ConsoleWriter<S> {
+        ConsoleWriter {
+            syscalls: Default::default(),
+        }
+    }
+}
+
+pub struct ConsoleWriter<S: Syscalls> {
+    syscalls: PhantomData<S>,
+}
+
+impl<S: Syscalls> fmt::Write for ConsoleWriter<S> {
+    fn write_str(&mut self, s: &str) -> Result<(), fmt::Error> {
+        Console::<S>::write(s.as_bytes()).map_err(|_e| fmt::Error)
+    }
+}
+
+#[cfg(test)]
+mod tests;
+
+// -----------------------------------------------------------------------------
+// Driver number and command IDs
+// -----------------------------------------------------------------------------
+
+const DRIVER_NUM: u32 = 1;
+
+// Command IDs
+#[allow(unused)]
+mod command {
+    pub const DRIVER_CHECK: u32 = 0;
+    pub const WRITE: u32 = 1;
+    pub const READ: u32 = 2;
+    pub const ABORT: u32 = 3;
+}
+
+#[allow(unused)]
+mod subscribe {
+    use libtock_platform::subscribe;
+    pub const WRITE: u32 = 1;
+    pub const READ: u32 = 2;
+}
+
+mod allow_ro {
+    pub const WRITE: u32 = 1;
+}

--- a/apis/console/src/tests.rs
+++ b/apis/console/src/tests.rs
@@ -1,0 +1,71 @@
+use super::*;
+use core::fmt::Write;
+use libtock_platform::ErrorCode;
+use libtock_unittest::{command_return, fake, ExpectedSyscall};
+
+type Console = super::Console<fake::Syscalls>;
+
+#[test]
+fn no_driver() {
+    let _kernel = fake::Kernel::new();
+    assert!(!Console::driver_check());
+}
+
+#[test]
+fn driver_check() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+
+    assert!(Console::driver_check());
+    assert_eq!(driver.take_bytes(), &[]);
+}
+
+#[test]
+fn write_bytes() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+
+    Console::write(b"foo").unwrap();
+    Console::write(b"bar").unwrap();
+    assert_eq!(driver.take_bytes(), b"foobar",);
+}
+
+#[test]
+fn write_str() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+
+    write!(Console::writer(), "foo").unwrap();
+    assert_eq!(driver.take_bytes(), b"foo");
+}
+
+#[test]
+fn failed_print() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+    kernel.add_expected_syscall(ExpectedSyscall::AllowRo {
+        driver_num: DRIVER_NUM,
+        buffer_num: subscribe::WRITE,
+        return_error: None,
+    });
+    kernel.add_expected_syscall(ExpectedSyscall::Subscribe {
+        driver_num: DRIVER_NUM,
+        subscribe_num: subscribe::WRITE,
+        skip_with_error: None,
+    });
+    kernel.add_expected_syscall(ExpectedSyscall::Command {
+        driver_id: DRIVER_NUM,
+        command_id: command::WRITE,
+        argument0: 5,
+        argument1: 0,
+        override_return: Some(command_return::failure(ErrorCode::Fail)),
+    });
+
+    assert_eq!(Console::write(b"abcde"), Err(ErrorCode::Fail));
+    // The fake driver still receives the command even if a fake error is injected.
+    assert_eq!(driver.take_bytes(), b"abcde");
+}

--- a/libtock2/Cargo.toml
+++ b/libtock2/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 libtock_platform = { path = "../platform" }
 libtock_runtime = { path = "../runtime" }
 libtock_buttons = { path = "../apis/buttons" }
+libtock_console = { path = "../apis/console" }
 libtock_leds = { path = "../apis/leds" }
 libtock_low_level_debug = { path = "../apis/low_level_debug" }
 

--- a/libtock2/examples/console.rs
+++ b/libtock2/examples/console.rs
@@ -1,0 +1,15 @@
+//! An extremely simple libtock-rs example. Just prints out a message
+//! using the Console capsule, then terminates.
+
+#![no_main]
+#![no_std]
+use core::fmt::Write;
+use libtock2::console::Console;
+use libtock2::runtime::{set_main, stack_size};
+
+set_main! {main}
+stack_size! {0x100}
+
+fn main() {
+    writeln!(Console::writer(), "Hello world!").unwrap();
+}

--- a/libtock2/src/lib.rs
+++ b/libtock2/src/lib.rs
@@ -10,6 +10,10 @@ pub mod buttons {
     use libtock_buttons as buttons;
     pub type Buttons = buttons::Buttons<super::runtime::TockSyscalls>;
 }
+pub mod console {
+    use libtock_console as console;
+    pub type Console = console::Console<super::runtime::TockSyscalls>;
+}
 pub mod leds {
     use libtock_leds as leds;
     pub type Leds = leds::Leds<super::runtime::TockSyscalls>;

--- a/unittest/src/fake/console/mod.rs
+++ b/unittest/src/fake/console/mod.rs
@@ -1,0 +1,89 @@
+//! Fake implementation of the Console API, documented here:
+//! https://github.com/tock/tock/blob/master/doc/syscalls/00001_console.md
+//!
+//! Like the real API, `Console` stores each message written to it.
+//! The resulting byte stream can be retrieved via `take_bytes`
+//! for use in unit tests.
+
+use core::cell::Cell;
+use core::cmp;
+use libtock_platform::{CommandReturn, ErrorCode};
+
+use crate::upcall;
+use crate::RoAllowBuffer;
+
+pub struct Console {
+    messages: Cell<Vec<u8>>,
+    buffer: Cell<RoAllowBuffer>,
+}
+
+impl Console {
+    pub fn new() -> std::rc::Rc<Console> {
+        std::rc::Rc::new(Console {
+            messages: Default::default(),
+            buffer: Default::default(),
+        })
+    }
+
+    /// Returns the bytes that have been submitted so far,
+    /// and clears them.
+    pub fn take_bytes(&self) -> Vec<u8> {
+        self.messages.take()
+    }
+}
+
+impl crate::fake::SyscallDriver for Console {
+    fn id(&self) -> u32 {
+        DRIVER_NUM
+    }
+    fn num_upcalls(&self) -> u32 {
+        2
+    }
+
+    fn allow_readonly(
+        &self,
+        buffer_num: u32,
+        buffer: RoAllowBuffer,
+    ) -> Result<RoAllowBuffer, (RoAllowBuffer, ErrorCode)> {
+        if buffer_num == ALLOW_WRITE {
+            Ok(self.buffer.replace(buffer))
+        } else {
+            Err((buffer, ErrorCode::Invalid))
+        }
+    }
+
+    fn command(&self, command_num: u32, argument0: u32, _argument1: u32) -> CommandReturn {
+        match command_num {
+            DRIVER_CHECK => {}
+            WRITE => {
+                let mut bytes = self.messages.take();
+                let buffer = self.buffer.take();
+                let size = cmp::min(buffer.len(), argument0 as usize);
+                bytes.extend_from_slice(&(*buffer)[..size]);
+                self.buffer.set(buffer);
+                self.messages.set(bytes);
+                upcall::schedule(DRIVER_NUM, SUBSCRIBE_WRITE, (size as u32, 0, 0))
+                    .expect("Unable to schedule upcall {}");
+            }
+            _ => return crate::command_return::failure(ErrorCode::NoSupport),
+        }
+        crate::command_return::success()
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Implementation details below
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests;
+
+const DRIVER_NUM: u32 = 1;
+
+// Command numbers
+const DRIVER_CHECK: u32 = 0;
+const WRITE: u32 = 1;
+//const READ: u32 = 2;
+//const ABORT: u32 = 3;
+const SUBSCRIBE_WRITE: u32 = 1;
+const ALLOW_WRITE: u32 = 1;

--- a/unittest/src/fake/console/tests.rs
+++ b/unittest/src/fake/console/tests.rs
@@ -1,0 +1,44 @@
+use crate::fake;
+use crate::RoAllowBuffer;
+use libtock_platform::share;
+use libtock_platform::DefaultConfig;
+
+// Tests the command implementation.
+#[test]
+fn command() {
+    use fake::SyscallDriver;
+    let console = fake::Console::new();
+    assert!(console
+        .command(fake::console::DRIVER_CHECK, 1, 2)
+        .is_success());
+    assert!(console.allow_readonly(1, RoAllowBuffer::default()).is_ok());
+    assert!(console.allow_readonly(2, RoAllowBuffer::default()).is_err());
+}
+
+// Integration test that verifies Console works with fake::Kernel and
+// libtock_platform::Syscalls.
+#[test]
+fn kernel_integration() {
+    use libtock_platform::Syscalls;
+    let kernel = fake::Kernel::new();
+    let console = fake::Console::new();
+    kernel.add_driver(&console);
+    assert!(
+        fake::Syscalls::command(fake::console::DRIVER_NUM, fake::console::DRIVER_CHECK, 1, 2)
+            .is_success()
+    );
+    share::scope(|allow_ro| {
+        fake::Syscalls::allow_ro::<
+            DefaultConfig,
+            { fake::console::DRIVER_NUM },
+            { fake::console::ALLOW_WRITE },
+        >(allow_ro, b"abcd")
+        .unwrap();
+        assert!(
+            fake::Syscalls::command(fake::console::DRIVER_NUM, fake::console::WRITE, 3, 0)
+                .is_success()
+        );
+    });
+    assert_eq!(console.take_bytes(), b"abc");
+    assert_eq!(console.take_bytes(), b"");
+}

--- a/unittest/src/fake/mod.rs
+++ b/unittest/src/fake/mod.rs
@@ -10,6 +10,7 @@
 //! (e.g. `fake::Console`).
 
 mod buttons;
+mod console;
 mod gpio;
 mod kernel;
 mod leds;
@@ -18,6 +19,7 @@ mod syscall_driver;
 mod syscalls;
 
 pub use buttons::Buttons;
+pub use console::Console;
 pub use gpio::{Gpio, GpioMode, InterruptEdge, PullMode};
 pub use kernel::Kernel;
 pub use leds::Leds;


### PR DESCRIPTION
This is an implementation of the interface to the console driver.

It implements printing only, and the Write trait.

I'm not entirely sure about the Config traits for Allow and Subscribe.

I'm also not sure if the tests are structured correctly – e.g. integration testing would have to basically reimplement the same code as is already in the `write` API call, so I skipped that (but perhaps that's the point).

There's also a "hello world" example, so it would check off a few boxes from https://github.com/tock/libtock-rs/issues/322