### PR TITLE
Fix crate resolution inside macro

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -21,7 +21,7 @@
 #![no_std]
 #![warn(unsafe_op_in_unsafe_fn)]
 
-mod startup;
+pub mod startup;
 
 /// TockSyscalls implements `libtock_platform::Syscalls`.
 pub struct TockSyscalls;


### PR DESCRIPTION
With this fix, other crates can use libtock2 without worrying about its deps.

Otherwise, the macro `set_main! {main}` breaks when used from another crate.

Example: https://gitlab.com/dcz_self/seistock

- adjust path to libtock,
- remove contents of the main function and imports (not upstreamed yet),
- run `just build`