### PR TITLE
Use console panic handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "apis/leds",
     "apis/low_level_debug",
     "libtock2",
+    "panic_handlers/debug_panic",
     "panic_handlers/small_panic",
     "platform",
     "runner",

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ examples:
 # This is largely libtock_runtime and crates that depend on libtock_runtime.
 # Used when we need to build a crate for the host OS, as libtock_runtime only
 # supports running on Tock.
-EXCLUDE_RUNTIME := --exclude libtock2 --exclude libtock_runtime --exclude libtock_small_panic
+EXCLUDE_RUNTIME := --exclude libtock2 --exclude libtock_runtime \
+	--exclude libtock_debug_panic --exclude libtock_small_panic
 
 # Arguments to pass to cargo to exclude crates that cannot be tested by Miri. In
 # addition to excluding libtock_runtime, Miri also cannot test proc macro crates

--- a/libtock2/Cargo.toml
+++ b/libtock2/Cargo.toml
@@ -17,6 +17,4 @@ libtock_console = { path = "../apis/console" }
 libtock_leds = { path = "../apis/leds" }
 libtock_low_level_debug = { path = "../apis/low_level_debug" }
 
-# TODO: Implement a panic handler with more debugging functionality, then
-# replace libtock_small_panic with the debug-heavy panic handler here.
-libtock_small_panic = { path = "../panic_handlers/small_panic" }
+libtock_debug_panic = { path = "../panic_handlers/debug_panic" }

--- a/libtock2/src/lib.rs
+++ b/libtock2/src/lib.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
-extern crate libtock_small_panic;
+extern crate libtock_debug_panic;
 
 pub use libtock_platform as platform;
 pub use libtock_runtime as runtime;

--- a/panic_handlers/debug_panic/Cargo.toml
+++ b/panic_handlers/debug_panic/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "libtock_debug_panic"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+version = "0.1.0"
+description = """Debug panic handler for libtock. Prints panic info to console and terminates."""
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+repository = "https://www.github.com/tock/libtock-rs"
+
+[dependencies]
+libtock_console = { path = "../../apis/console" }
+libtock_low_level_debug = { path = "../../apis/low_level_debug" }
+libtock_platform = { path = "../../platform" }
+libtock_runtime = { path = "../../runtime" }

--- a/panic_handlers/debug_panic/src/lib.rs
+++ b/panic_handlers/debug_panic/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+use core::fmt::Write;
+use libtock_console::Console;
+use libtock_low_level_debug::{AlertCode, LowLevelDebug};
+use libtock_platform::{ErrorCode, Syscalls};
+use libtock_runtime::TockSyscalls;
+
+/// This handler requires some 0x400 bytes of stack
+
+#[panic_handler]
+fn panic_handler(info: &core::panic::PanicInfo) -> ! {
+    // Signal a panic using the LowLevelDebug capsule (if available).
+    LowLevelDebug::<TockSyscalls>::print_alert_code(AlertCode::Panic);
+
+    let mut writer = Console::<TockSyscalls>::writer();
+    // If this printing fails, we can't panic harder, and we can't print it either.
+    let _ = writeln!(writer, "{}", info);
+    // Exit with a non-zero exit code to indicate failure.
+    TockSyscalls::exit_terminate(ErrorCode::Fail as u32);
+}


### PR DESCRIPTION
This adds a panic handler printing panic information to the console if possible.
If not possible, it signals failure using the low level mechanism.

The console handler becomes the default.

Follows up on https://github.com/tock/libtock-rs/pull/395