### PR TITLE
Runner: flush stdout after each echo.

### DIFF
--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -28,9 +28,12 @@ pub fn process(cli: &Cli, mut child: Child) {
             }
             to_print.push(byte);
         }
-        stdout()
-            .write_all(&to_print)
+        let stdout = stdout();
+        let mut lock = stdout.lock();
+        lock.write_all(&to_print)
             .expect("Unable to echo child's stdout.");
+        let _ = lock.flush();
+        drop(lock);
         to_print.clear();
 
         let buffer_len = buffer.len();


### PR DESCRIPTION
Previously, if the Tock system printed a message that did not end with an EOL character, that message would not immediately appear on the terminal. This can be somewhat confusing. With this change, each message output by the Tock system appears on the terminal immeditately.