### PR TITLE
runtime: set heap start and stack top at app startup

### DIFF
--- a/runtime/src/startup/asm_arm.s
+++ b/runtime/src/startup/asm_arm.s
@@ -58,6 +58,16 @@ start:
 	ldr r1, [r5, #4]  /* rt_header`s initial process break */
 	svc 5             /* call `memop` */
 
+	/* memop(): set heap starting location from rt_header's value */
+	movs r0, #10      /* operation: specify heap start address */
+	/* r1 already set correctly from previous svc call */
+	svc 5             /* call `memop` */
+
+	/* memop(): set top of stack from rt_header's value */
+	movs r0, #11      /* operation: specify stack top address */
+	ldr r1, [r5, #8]  /* rt_header`s top of stack value */
+	svc 5             /* call `memop` */
+
 	/* Set the stack pointer */
 	ldr r0, [r5, #8]  /* r0 = rt_header._stack_top */
 	mov sp, r0

--- a/runtime/src/startup/asm_riscv32.s
+++ b/runtime/src/startup/asm_riscv32.s
@@ -55,6 +55,17 @@ start:
 	li a4, 5      /* `memop` class */
 	ecall
 
+	/* memop(): set heap starting location from rt_header's value */
+	li a0, 11     /* operation: specify heap start address */
+	/* a1 and a4 already set correctly from above ecall */
+	ecall
+
+	/* memop(): set top of stack from rt_header's value */
+	li a0, 10     /* operation: specify stack top address */
+	lw a1, 8(a5)  /* rt_header's top of stack value */
+	/* a4 already set correctly from above ecall */
+	ecall
+
 	/* Set the stack pointer */
 	lw sp, 8(a5)  /* sp = rt_header._stack_top */
 

--- a/runtime/src/startup/start_prototype.rs
+++ b/runtime/src/startup/start_prototype.rs
@@ -53,10 +53,14 @@ extern "C" fn start_prototype(
         }
     }
 
-    // Set the app break.
     // TODO: Replace with Syscalls::memop_brk() when that is implemented.
     unsafe {
+        // Set the app break.
         TockSyscalls::syscall2::<syscall_class::MEMOP>([0 as *mut (), rt_header.initial_break]);
+        // Set heap starting address
+        TockSyscalls::syscall2::<syscall_class::MEMOP>([11 as *mut (), rt_header.initial_break]);
+        // Set top of stack address
+        TockSyscalls::syscall2::<syscall_class::MEMOP>([10 as *mut (), rt_header.stack_top]);
     }
 
     // Set the stack pointer.


### PR DESCRIPTION
Add `memop` ecalls during application start up to set the heap starting address and stack top address with the kernel. This does not take that much extra time, but can be very valuable to the kernel if it is tracking process debug information. These calls were also in 1.x version of libtock-rs, so it seems appropriate to replicate them here as well.
