### PR TITLE
Update the nightly toolchain to 2022-06-10.

### DIFF
--- a/apis/buttons/src/lib.rs
+++ b/apis/buttons/src/lib.rs
@@ -28,7 +28,7 @@ use libtock_platform::{
 
 pub struct Buttons<S: Syscalls>(S);
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ButtonState {
     Pressed,
     Released,

--- a/apis/gpio/src/lib.rs
+++ b/apis/gpio/src/lib.rs
@@ -17,7 +17,7 @@ use libtock_platform::{
 ///
 /// ```
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum GpioState {
     Low = 0,
     High = 1,

--- a/platform/src/share/tests.rs
+++ b/platform/src/share/tests.rs
@@ -39,6 +39,7 @@ fn list_lifetime() {
 // This test will only compile if the correct trait impls exist for tuples.
 #[test]
 fn tuple_impls() {
+    #[allow(clippy::let_unit_value)]
     scope(|list: Handle<()>| {
         let _empty: () = list.split();
     });

--- a/platform/src/syscalls_impl.rs
+++ b/platform/src/syscalls_impl.rs
@@ -134,7 +134,7 @@ impl<S: RawSyscalls> Syscalls for S {
             Ok(())
         }
 
-        let upcall_fcn = (kernel_upcall::<S, IDS, U> as usize).into();
+        let upcall_fcn = (kernel_upcall::<S, IDS, U> as *const ()).into();
         let upcall_data = (upcall as *const U).into();
         // Safety: upcall's type guarantees it is a reference to a U that will
         // remain valid for at least the 'scope lifetime. _subscribe is a

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -3,7 +3,7 @@ mod output_processor;
 mod qemu;
 mod tockloader;
 
-use clap::{ArgEnum, Parser};
+use clap::{Parser, ValueEnum};
 use std::env::{var, VarError};
 use std::path::PathBuf;
 
@@ -13,18 +13,19 @@ use std::path::PathBuf;
 pub struct Cli {
     /// Where to deploy the process binary. If not specified, runner will only
     /// make a TBF file and not attempt to run it.
-    #[clap(arg_enum, long, short)]
+    #[clap(action, long, short, value_enum)]
     deploy: Option<Deploy>,
 
     /// The executable to convert into Tock Binary Format and run.
+    #[clap(action)]
     elf: PathBuf,
 
     /// Whether to output verbose debugging information to the console.
-    #[clap(long, short)]
+    #[clap(long, short, action)]
     verbose: bool,
 }
 
-#[derive(ArgEnum, Clone, Copy, Debug)]
+#[derive(ValueEnum, Clone, Copy, Debug)]
 pub enum Deploy {
     Qemu,
     Tockloader,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 [toolchain]
 # See https://rust-lang.github.io/rustup-components-history/ for a list of
 # recently nightlies and what components are available for them.
-channel = "nightly-2022-01-20"
+channel = "nightly-2022-06-10"
 components = ["clippy", "miri", "rustfmt"]
 targets = ["thumbv7em-none-eabi",
            "riscv32imac-unknown-none-elf",

--- a/unittest/src/allow_db.rs
+++ b/unittest/src/allow_db.rs
@@ -145,7 +145,7 @@ impl AllowDb {
     }
 }
 
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
 #[error("allow buffers overlap")]
 pub struct OverlapError;
 

--- a/unittest/src/exit_test/mod.rs
+++ b/unittest/src/exit_test/mod.rs
@@ -69,7 +69,7 @@ pub fn exit_test<F: FnOnce() + UnwindSafe>(test_name: &str, fcn: F) -> ExitCall 
 
 /// Indicates what type of Exit call was performed, and what completion code was
 /// provided.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExitCall {
     Terminate(u32),
     Restart(u32),
@@ -112,7 +112,7 @@ impl std::str::FromStr for ExitCall {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[doc(hidden)]
 pub struct ParseExitError;
 
@@ -126,7 +126,7 @@ const SIGNAL_VAR: &str = "LIBTOCK_UNITTEST_EXIT_TEST";
 // followed by the Display string for a ExitMessage.
 const EXIT_STRING: &str = "LIBTOCK_UNITTEST_EXIT_TEST_RESULT: ";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 enum ExitMessage {
     ExitCall(ExitCall),
     WrongCase,

--- a/unittest/src/fake/buttons/mod.rs
+++ b/unittest/src/fake/buttons/mod.rs
@@ -12,7 +12,7 @@ use libtock_platform::{CommandReturn, ErrorCode};
 
 use crate::upcall;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct ButtonState {
     pub pressed: bool,
     pub interrupt_enabled: bool,

--- a/unittest/src/fake/gpio/mod.rs
+++ b/unittest/src/fake/gpio/mod.rs
@@ -13,14 +13,14 @@ use std::convert::TryFrom;
 
 use crate::upcall;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum GpioMode {
     Output,
     Input(PullMode),
     Disable,
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum PullMode {
     PullNone = 0,
     PullUp = 1,
@@ -40,7 +40,7 @@ impl TryFrom<u32> for PullMode {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum InterruptEdge {
     Either,
     Rising,
@@ -60,7 +60,7 @@ impl TryFrom<u32> for InterruptEdge {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct GpioState {
     pub value: bool,
     pub mode: GpioMode,

--- a/unittest/src/fake/low_level_debug/mod.rs
+++ b/unittest/src/fake/low_level_debug/mod.rs
@@ -45,7 +45,7 @@ impl crate::fake::SyscallDriver for LowLevelDebug {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Message {
     AlertCode(u32),
     Print1(u32),

--- a/unittest/src/fake/syscalls/subscribe_impl.rs
+++ b/unittest/src/fake/syscalls/subscribe_impl.rs
@@ -97,7 +97,7 @@ pub(super) unsafe fn subscribe(
             // guarantees that an unsafe extern fn(u32, u32, u32, Register) can
             // be transmuted into an Option<unsafe extern fn(u32, u32, u32,
             // Register)>.
-            upcall_fn => unsafe { core::mem::transmute(upcall_fn) },
+            _ => unsafe { core::mem::transmute(upcall_fn) },
         },
         data,
     };

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -1,5 +1,5 @@
 /// SyscallLogEntry represents a system call made during test execution.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum SyscallLogEntry {
     // -------------------------------------------------------------------------
     // Yield

--- a/unittest/src/upcall.rs
+++ b/unittest/src/upcall.rs
@@ -41,7 +41,7 @@ pub fn schedule(
     })
 }
 
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ScheduleError {
     #[error("Driver number {0} does not exist.")]
     NoDriver(u32),


### PR DESCRIPTION
This contains 3 categories of changes to avoid warnings and failures:

1. `clippy` now warns if you derive `PartialEq` without also deriving `Eq`. All of the types that triggered this warning can implement `Eq`, so I added `Eq` derives.
2. Miri no longer allows integer-to-function-pointer casts. I tweaked the subscribe implementations to avoid casting through `usize`.
3. `clippy` added a warning for expressions of the form `let var: () = expr();`, but we did that intentionally as part of a compile test. I disabled that warning for the relevant test case.