### PR TITLE
Enable strict provenance in Miri.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,7 @@ test: examples test-stable
 		--target=thumbv7em-none-eabi --workspace
 	LIBTOCK_PLATFORM=hifive1 cargo clippy $(EXCLUDE_STD) \
 		--target=riscv32imac-unknown-none-elf --workspace
-	cargo miri test $(EXCLUDE_MIRI) --workspace
-	MIRIFLAGS="-Zmiri-symbolic-alignment-check -Zmiri-tag-raw-pointers" \
+	MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check" \
 		cargo miri test $(EXCLUDE_MIRI) --workspace
 	echo '[ SUCCESS ] libtock-rs tests pass'
 


### PR DESCRIPTION
This merges the two miri commands together, as strict provenance is strictly more restrictive than all other configurations.

See https://github.com/rust-lang/miri/pull/2045 for some more background on `-Zmiri-strict-provenance`.

Closes #400 