### PR TITLE
Tell search tools to search the `.cargo` and `.github` directories.

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,3 +1,9 @@
+# Cargo and GitHub Actions keep their configs in hidden directories. Some search
+# tools skip hidden directories by default. This overrides that, and makes them
+# search .cargo and .github.
+!.cargo/
+!.github/
+
 # Tell search tools to ignore the Tock submodule. Usually when someone wants to
 # search this repository they want to search libtock-rs' codebase, not the Tock
 # kernel.


### PR DESCRIPTION
`ripgrep` skips hidden directories by default. This overrides that, and tells it to include `.cargo/` and `.github/` in its search path.