### PR TITLE
runner: Adjust clap version to match used features

### DIFF
--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://www.github.com/tock/libtock-rs"
 version = "0.1.0"
 
 [dependencies]
-clap = { features = ["derive"], version = "3.0.10" }
+clap = { features = ["derive"], version = "3.2.6" }
 elf = "0.0.10"
 libc = "0.2.113"
 termion = "1.5.6"


### PR DESCRIPTION
This fixes builds which have a Cargo.lock with clap <3.2.