### PR TITLE
Relocation check: set the failure completion code to FAIL

### DIFF
--- a/runtime/src/startup/asm_arm.s
+++ b/runtime/src/startup/asm_arm.s
@@ -50,6 +50,7 @@ start:
 	movs r2, #2  /* Alert code 2 (incorrect location */
 	svc 2        /* Execute `command` */
 	movs r0, #0  /* Operation: exit-terminate */
+	movs r1, #1  /* Completion code: FAIL */
 	svc 6        /* Execute `exit` */
 
 .Lset_brk:

--- a/runtime/src/startup/asm_riscv32.s
+++ b/runtime/src/startup/asm_riscv32.s
@@ -44,7 +44,7 @@ start:
 	li a4, 2  /* `command` class */
 	ecall
 	li a0, 0  /* exit-terminate */
-	/* TODO: Set a completion code, once completion codes are decided */
+	li a1, 1  /* Completion code: FAIL */
 	li a4, 6  /* `exit` class */
 	ecall
 


### PR DESCRIPTION
Now that completion codes have been specified (in [TRD 106](https://github.com/tock/tock/blob/master/doc/reference/trd106-completion-codes.md), we should return a a suitable error code if the relocation check fails. The only suitable error code I see is FAIL.