### PR TITLE
Remove `rustup toolchain update stable` from CI, it is no longer needed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,15 +40,9 @@ jobs:
       # using the RUSTFLAGS environment variable because if we set RUSTFLAGS
       # cargo will ignore the rustflags config in .cargo/config, breaking
       # relocation.
-      #
-      # TODO: Remove the "rustup toolchain update stable" once the 20220227.1
-      # version of the Ubuntu 20.04 virtual environment is fully rolled out.
-      # The rollout status can be found here:
-      # https://github.com/actions/virtual-environments
       - name: Build and Test
         run: |
           sudo apt-get install ninja-build
-          rustup toolchain update stable
           cd "${GITHUB_WORKSPACE}"
           echo "[target.'cfg(all())']" >> .cargo/config
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config


### PR DESCRIPTION
GitHub Actions' environments now contain a sufficiently-new stable toolchain for `libtock-rs`. Remove the toolchain update step, as it is now a waste of time.