### PR TITLE
Apply the unused-qualifications lint.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -6,19 +6,6 @@ rrv32imc = "rriscv32imc"
 rthumbv7em = "run --release --target=thumbv7em-none-eabi --example"
 rtv7em = "rthumbv7em"
 
-# Note about rustflags: Because we specify rustflags in a [target.<cfg>] entry
-# (which we use to apply relocation flags to embedded builds but not host
-# builds), all rustc flags must be specified in a [target.<cfg>] entry. If we
-# specify rustflags through another mechanism, such as [build.rustflags], then
-# one of the rustflags definitions will overwrite the other, rather than
-# combining the flags.
-
-# Enable some disabled-by-default lints across the entire workspace.
-[target.'cfg(all())']
-rustflags = [
-    "-W", "unused_qualifications",
-]
-
 # Common settings for all embedded targets
 [target.'cfg(any(target_arch = "arm", target_arch = "riscv32"))']
 rustflags = [

--- a/.cargo/config
+++ b/.cargo/config
@@ -6,6 +6,19 @@ rrv32imc = "rriscv32imc"
 rthumbv7em = "run --release --target=thumbv7em-none-eabi --example"
 rtv7em = "rthumbv7em"
 
+# Note about rustflags: Because we specify rustflags in a [target.<cfg>] entry
+# (which we use to apply relocation flags to embedded builds but not host
+# builds), all rustc flags must be specified in a [target.<cfg>] entry. If we
+# specify rustflags through another mechanism, such as [build.rustflags], then
+# one of the rustflags definitions will overwrite the other, rather than
+# combining the flags.
+
+# Enable some disabled-by-default lints across the entire workspace.
+[target.'cfg(all())']
+rustflags = [
+    "-W", "unused_qualifications",
+]
+
 # Common settings for all embedded targets
 [target.'cfg(any(target_arch = "arm", target_arch = "riscv32"))']
 rustflags = [

--- a/apis/alarm/src/lib.rs
+++ b/apis/alarm/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+use core::cell::Cell;
 use libtock_platform as platform;
 use libtock_platform::share;
 use libtock_platform::{DefaultConfig, ErrorCode, Syscalls};
@@ -76,7 +77,7 @@ impl<S: Syscalls, C: platform::subscribe::Config> Alarm<S, C> {
         let freq = Self::get_frequency()?;
         let ticks = time.to_ticks(freq);
 
-        let called = core::cell::Cell::new(Option::<(u32, u32)>::None);
+        let called: Cell<Option<(u32, u32)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::CALLBACK }>(subscribe, &called)?;
 

--- a/apis/console/src/lib.rs
+++ b/apis/console/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+use core::cell::Cell;
 use core::fmt;
 use core::marker::PhantomData;
 use libtock_platform as platform;
@@ -38,7 +39,7 @@ impl<S: Syscalls, C: Config> Console<S, C> {
     /// This is an alternative to `fmt::Write::write`
     /// because this can actually return an error code.
     pub fn write(s: &[u8]) -> Result<(), ErrorCode> {
-        let called = core::cell::Cell::new(Option::<(u32,)>::None);
+        let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope::<
             (
                 AllowRo<_, DRIVER_NUM, { allow_ro::WRITE }>,
@@ -69,7 +70,7 @@ impl<S: Syscalls, C: Config> Console<S, C> {
     /// No special guarantees about when the read stops.
     /// Returns count of bytes written to `buf`.
     pub fn read(buf: &mut [u8]) -> (usize, Result<(), ErrorCode>) {
-        let called = core::cell::Cell::new(Option::<(u32, u32)>::None);
+        let called: Cell<Option<(u32, u32)>> = Cell::new(None);
         let mut bytes_received = 0;
         let r = share::scope::<
             (

--- a/platform/src/command_return.rs
+++ b/platform/src/command_return.rs
@@ -244,7 +244,7 @@ impl CommandReturn {
         let ec: ErrorCode = if return_variant == E::RETURN_VARIANT {
             // Safety: E::RETURN_VARIANT must be a failure variant, and
             // failure variants must contain a valid ErrorCode in r1.
-            unsafe { core::mem::transmute(r1) }
+            unsafe { transmute(r1) }
         } else {
             r2 = 0;
             r3 = 0;

--- a/platform/src/register.rs
+++ b/platform/src/register.rs
@@ -88,7 +88,7 @@ impl<T> From<Register> for *const T {
 /// Converts a `Register` to a `u32`. Returns an error if the `Register`'s value
 /// is larger than `u32::MAX`. This is intended for use in host-based tests; in
 /// Tock process binary code, use Register::as_u32 instead.
-impl core::convert::TryFrom<Register> for u32 {
+impl TryFrom<Register> for u32 {
     type Error = core::num::TryFromIntError;
 
     fn try_from(register: Register) -> Result<u32, core::num::TryFromIntError> {

--- a/unittest/src/share_data.rs
+++ b/unittest/src/share_data.rs
@@ -120,7 +120,7 @@ mod tests {
 
         // Call schedule with no registered upcall.
         assert_eq!(mock_driver.share_ref.schedule_upcall(2, (3, 4, 5)), Ok(()));
-        crate::kernel_data::with_kernel_data(|kernel_data| {
+        with_kernel_data(|kernel_data| {
             let kernel_data = kernel_data.unwrap();
 
             // There was no upcall to schedule, so the queue should still be
@@ -140,7 +140,7 @@ mod tests {
         // is a null upcall.
         assert_eq!(mock_driver.share_ref.schedule_upcall(2, (3, 4, 5)), Ok(()));
         unsafe extern "C" fn upcall(_: u32, _: u32, _: u32, _: libtock_platform::Register) {}
-        crate::kernel_data::with_kernel_data(|kernel_data| {
+        with_kernel_data(|kernel_data| {
             let kernel_data = kernel_data.unwrap();
 
             // Verify the upcall was not queued.
@@ -157,7 +157,7 @@ mod tests {
         });
         // Call schedule again. This should schedule the upcall.
         assert_eq!(mock_driver.share_ref.schedule_upcall(2, (3, 4, 5)), Ok(()));
-        crate::kernel_data::with_kernel_data(|kernel_data| {
+        with_kernel_data(|kernel_data| {
             let kernel_data = kernel_data.unwrap();
 
             // Verify the upcall was queued.
@@ -190,7 +190,7 @@ mod tests {
             mock_driver.share_ref.schedule_upcall(2, (30, 40, 50)),
             Ok(())
         );
-        crate::kernel_data::with_kernel_data(|kernel_data| {
+        with_kernel_data(|kernel_data| {
             let kernel_data = kernel_data.unwrap();
 
             // Very the upcall was queued.

--- a/unittest/src/upcall.rs
+++ b/unittest/src/upcall.rs
@@ -41,7 +41,7 @@ impl Upcall {
 // need a long queue in test cases, so that is acceptable. There are alternative
 // data structures that avoid that slowdown, but they are more complex and
 // likely slower in the common case.
-pub(crate) type UpcallQueue = std::collections::VecDeque<crate::upcall::UpcallQueueEntry>;
+pub(crate) type UpcallQueue = std::collections::VecDeque<UpcallQueueEntry>;
 
 // An entry in the fake kernel's upcall queue.
 pub(crate) struct UpcallQueueEntry {


### PR DESCRIPTION
**This PR is a request for comments, please see below**

The [`unused-qualifications`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-qualifications) lint is included in rustc, but disabled by default. This enables the lint, and fixes locations that trigger it.

However, I'm not sure that all of the changes I made were an improvement. Several of our tests contained the following pattern:

```rust
let called = Cell::new(Option::<(u32,)>::None);
```

This pattern triggers the lint, indicating the `Option::<(u32,)>::` is optional. In other words, we can write:

```rust
let called = Cell::new(None);
```

and Rust will infer the `Option`'s generic parameters. However, the inferred parameters are not obvious, and we intentionally specified the types to help human readers. Therefore, I instead changed the pattern to:

```rust
let called: Cell<Option<(u32,)>> = Cell::new(None);
```

but I'm not sure that's an improvement.

**Question:** Do we want to make the above replacement, or leave the code as-is?