### PR TITLE
Remove our use of the `stack-sizes` tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,6 @@ endif
 .PHONY: setup
 setup: setup-qemu
 	cargo install elf2tab
-	cargo install stack-sizes
 	cargo miri setup
 	rustup target add --toolchain stable thumbv7em-none-eabi
 
@@ -126,10 +125,6 @@ test: examples test-stable
 	MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check" \
 		cargo miri test $(EXCLUDE_MIRI) --workspace
 	echo '[ SUCCESS ] libtock-rs tests pass'
-
-.PHONY: analyse-stack-sizes
-analyse-stack-sizes:
-	cargo stack-sizes $(release) --example $(EXAMPLE) $(features) -- -Z emit-stack-sizes
 
 .PHONY: apollo3
 apollo3:


### PR DESCRIPTION
As of version `0.5.0`, `stack-sizes` is [no longer a binary crate](https://github.com/japaric/stack-sizes/pull/14). This breaks our CI, which tries to install the latest version of the `stack-sizes` binary.

This PR removes all references to the tool from `libtock-rs`, so that CI can continue working.

`stack-sizes` appears to have been replaced by [`cargo-call-stack`](https://github.com/japaric/cargo-call-stack), which we may add support for in the future.