### PR TITLE
Update clobber to match ARM ARM

### DIFF
--- a/runtime/src/syscalls_impl_arm.rs
+++ b/runtime/src/syscalls_impl_arm.rs
@@ -6,6 +6,7 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::yield1
         // the use of `clobber_abi` allows us this to run on both Thumb-1 and Thumb-2
+        // see https://doc.rust-lang.org/nightly/reference/inline-assembly.html#abi-clobbers
         unsafe {
             asm!("svc 0",
                  inlateout("r0") r0 => _, // a1
@@ -17,7 +18,7 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
                  // r13 is the stack pointer and must be restored by the callee.
                  // r15 is the program counter.
 
-                 clobber_abi("C"), // a2, a3, a4, ip (r12), lr (r14)
+                 clobber_abi("aapcs"), // r[0-3], r12, r14, s[0-15], d[0-7], d[16-31]
             );
         }
     }
@@ -26,6 +27,7 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::yield2
         // the use of `clobber_abi` allows us this to run on both Thumb-1 and Thumb-2
+        // see https://doc.rust-lang.org/nightly/reference/inline-assembly.html#abi-clobbers
         unsafe {
             asm!("svc 0",
                  inlateout("r0") r0 => _, // a1
@@ -38,7 +40,7 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
                  // r13 is the stack pointer and must be restored by the callee.
                  // r15 is the program counter.
 
-                 clobber_abi("C"), // a3, a4, ip (r12), lr (r14)
+                 clobber_abi("aapcs"), // r[0-3], r12, r14, s[0-15], d[0-7], d[16-31]
             );
         }
     }


### PR DESCRIPTION
I just learned about this `asm!` feature, which prompted me to look at whether we were using it.

Not sure if some of the others were options when #381 was written, but strictly speaking arm cores are defined to follow the `AAPCS` on exception entry/exit. In practice, I _think_ `C` and `aapcs` (and the others here) are just aliases that do the same thing. Nonetheless, just in case, we should probably put the 'most correct' name here.

Relevant doc: https://doc.rust-lang.org/nightly/reference/inline-assembly.html#abi-clobbers
<img width="779" alt="image" src="https://user-images.githubusercontent.com/339422/183528580-1bbe394f-67af-4050-bc32-bbac9d2cf347.png">
