### PR TITLE
WIP: Implement block storage API basics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 
 [dependencies]
 libtock_alarm = { path = "apis/alarm" }
+libtock_block_storage = { path = "apis/block_storage" }
 libtock_buttons = { path = "apis/buttons" }
 libtock_console = { path = "apis/console" }
 libtock_debug_panic = { path = "panic_handlers/debug_panic" }
@@ -34,6 +35,7 @@ exclude = ["tock"]
 members = [
     "apis/alarm",
     "apis/gpio",
+    "apis/block_storage",
     "apis/buttons",
     "apis/console",
     "apis/leds",

--- a/apis/block_storage/Cargo.toml
+++ b/apis/block_storage/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "libtock_block_storage"
+version = "0.1.0"
+authors = [
+    "Tock Project Developers <tock-dev@googlegroups.com>",
+    "dcz <gihuac.dcz@porcupinefactory.org>",
+]
+license = "MIT/Apache-2.0"
+edition = "2021"
+repository = "https://www.github.com/tock/libtock-rs"
+description = "libtock block storage driver"
+
+[dependencies]
+libtock_platform = { path = "../../platform" }
+
+[dev-dependencies]
+libtock_unittest = { path = "../../unittest" }

--- a/apis/block_storage/src/lib.rs
+++ b/apis/block_storage/src/lib.rs
@@ -1,0 +1,200 @@
+#![no_std]
+/*! Synchronous block storage driver.
+
+Useful mainly for testing the syscall driver.
+*/
+// Written by dcz <gihuac.dcz@porcupinefactory.org>
+
+use libtock_platform as platform;
+use libtock_platform::share;
+use libtock_platform::subscribe::Subscribe;
+use libtock_platform::{DefaultConfig, ErrorCode, Syscalls};
+
+#[derive(Debug)]
+pub struct Geometry {
+    pub write_block_size: u32,
+    pub erase_block_size: u32,
+}
+
+impl Geometry {
+    pub fn get_erase_block_containing(&self, address: u64) -> u32 {
+        (address / self.erase_block_size as u64) as u32
+    }
+
+    pub fn get_write_block_containing(&self, address: u64) -> u32 {
+        (address / self.write_block_size as u64) as u32
+    }
+
+    pub fn get_address_of_write_block(&self, idx: u32) -> u64 {
+        idx as u64 * self.write_block_size as u64
+    }
+}
+
+/// The block storage driver.
+///
+/// It allows libraries to access a block storage device.
+///
+/// # Example
+/// ```ignore
+/// use libtock2::BlockStorage;
+///
+/// let Geometry::{write_block_size, erase_block_size}
+///     = BlockStorage::get_geometry();
+/// let mut buf = vec![0, write_block_size];
+/// // Reads block number 43 into `buf`
+/// BlockStorage::read(43, &mut buf).unwrap();
+/// ```
+pub struct BlockStorage<
+    S: Syscalls,
+    C: platform::allow_ro::Config
+        + platform::allow_rw::Config
+        + platform::subscribe::Config
+        = DefaultConfig
+>(S, C);
+
+impl<
+        S: Syscalls,
+        C: platform::allow_ro::Config + platform::allow_rw::Config + platform::subscribe::Config,
+    > BlockStorage<S, C>
+{
+    /// Run a check against the low-level capsule to ensure it is present.
+    ///
+    /// Returns `true` if the driver was present. This does not necessarily mean
+    /// that the driver is working, as it may still fail to allocate grant
+    /// memory.
+    #[inline(always)]
+    pub fn driver_check() -> bool {
+        S::command(DRIVER_NUM, command::DRIVER_CHECK, 0, 0).is_success()
+    }
+
+    pub fn get_geometry() -> Geometry {
+        let (write_block_size, erase_block_size) = S::command(DRIVER_NUM, command::GEOMETRY, 0, 0)
+            .get_success_2_u32()
+            .unwrap();
+        Geometry {
+            write_block_size,
+            erase_block_size,
+        }
+    }
+
+    pub fn get_size() -> u64 {
+        S::command(DRIVER_NUM, command::SIZE, 0, 0)
+            .get_success_u64()
+            .unwrap()
+    }
+
+    pub fn read(block_idx: u32, buf: &mut [u8]) -> Result<(), ErrorCode> {
+        let called = core::cell::Cell::new(Option::<(u32, u32)>::None);
+        share::scope::<
+            (
+                platform::AllowRw<_, DRIVER_NUM, { allow_rw::READ }>,
+                Subscribe<_, DRIVER_NUM, { subscribe::READ }>,
+            ),
+            _,
+            _,
+        >(|handle| {
+            let (allow_rw, subscribe) = handle.split();
+
+            S::allow_rw::<C, DRIVER_NUM, { allow_rw::READ }>(allow_rw, buf)?;
+
+            S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::READ }>(subscribe, &called)?;
+
+            S::command(DRIVER_NUM, command::READ, block_idx, 1).to_result()?;
+
+            loop {
+                S::yield_wait();
+                if let Some((is_error, errno)) = called.get() {
+                    return match is_error {
+                        0 => Ok(()),
+                        _ => Err(errno.try_into().unwrap_or(ErrorCode::Fail)),
+                    };
+                }
+            }
+        })
+    }
+
+    pub fn write(block_idx: u32, buf: &[u8]) -> Result<(), ErrorCode> {
+        let called = core::cell::Cell::new(Option::<(u32, u32)>::None);
+        share::scope::<
+            (
+                platform::AllowRo<_, DRIVER_NUM, { allow_ro::WRITE }>,
+                Subscribe<_, DRIVER_NUM, { subscribe::WRITE }>,
+            ),
+            _,
+            _,
+        >(|handle| {
+            let (allow_ro, subscribe) = handle.split();
+
+            S::allow_ro::<C, DRIVER_NUM, { allow_ro::WRITE }>(allow_ro, buf)?;
+
+            S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
+
+            S::command(DRIVER_NUM, command::WRITE, block_idx, 1).to_result()?;
+
+            loop {
+                S::yield_wait();
+                if let Some((is_error, errno)) = called.get() {
+                    return match is_error {
+                        0 => Ok(()),
+                        _ => Err(errno.try_into().unwrap_or(ErrorCode::Fail)),
+                    };
+                }
+            }
+        })
+    }
+
+    pub fn erase(block_idx: u32) -> Result<(), ErrorCode> {
+        let called = core::cell::Cell::new(Option::<(u32, u32)>::None);
+        share::scope::<Subscribe<_, DRIVER_NUM, { subscribe::ERASE }>, _, _>(|handle| {
+            S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::ERASE }>(handle, &called)?;
+
+            S::command(DRIVER_NUM, command::ERASE, block_idx, 1).to_result()?;
+
+            loop {
+                S::yield_wait();
+                if let Some((is_error, errno)) = called.get() {
+                    return match is_error {
+                        0 => Ok(()),
+                        _ => Err(errno.try_into().unwrap_or(ErrorCode::Fail)),
+                    };
+                }
+            }
+        })
+    }
+}
+
+//#[cfg(test)]
+//mod tests;
+
+// -----------------------------------------------------------------------------
+// Driver number and command IDs
+// -----------------------------------------------------------------------------
+
+const DRIVER_NUM: u32 = 0x50004;
+
+// Command IDs
+#[allow(unused)]
+mod command {
+    pub const DRIVER_CHECK: u32 = 0;
+    pub const SIZE: u32 = 1;
+    pub const GEOMETRY: u32 = 2;
+    pub const READ_RANGE: u32 = 3;
+    pub const READ: u32 = 4;
+    pub const ERASE: u32 = 5;
+    pub const WRITE: u32 = 6;
+}
+
+#[allow(unused)]
+mod subscribe {
+    pub const READ: u32 = 0;
+    pub const ERASE: u32 = 1;
+    pub const WRITE: u32 = 2;
+}
+
+mod allow_ro {
+    pub const WRITE: u32 = 0;
+}
+
+mod allow_rw {
+    pub const READ: u32 = 0;
+}

--- a/apis/block_storage/src/tests.rs
+++ b/apis/block_storage/src/tests.rs
@@ -1,0 +1,71 @@
+use super::*;
+use core::fmt::Write;
+use libtock_platform::ErrorCode;
+use libtock_unittest::{command_return, fake, ExpectedSyscall};
+
+type Console = super::Console<fake::Syscalls>;
+
+#[test]
+fn no_driver() {
+    let _kernel = fake::Kernel::new();
+    assert!(!Console::driver_check());
+}
+
+#[test]
+fn driver_check() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+
+    assert!(Console::driver_check());
+    assert_eq!(driver.take_bytes(), &[]);
+}
+
+#[test]
+fn write_bytes_all() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+
+    Console::write_all("foo".as_bytes()).unwrap();
+    Console::write_all("bar".as_bytes()).unwrap();
+    assert_eq!(driver.take_bytes(), "foobar".as_bytes(),);
+}
+
+#[test]
+fn write_str() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+
+    write!(Console::writer(), "foo").unwrap();
+    assert_eq!(driver.take_bytes(), "foo".as_bytes());
+}
+
+#[test]
+fn failed_print() {
+    let kernel = fake::Kernel::new();
+    let driver = fake::Console::new();
+    kernel.add_driver(&driver);
+    kernel.add_expected_syscall(ExpectedSyscall::AllowRo {
+        driver_num: DRIVER_NUM,
+        buffer_num: 1,
+        return_error: None,
+    });
+    kernel.add_expected_syscall(ExpectedSyscall::Subscribe {
+        driver_num: DRIVER_NUM,
+        subscribe_num: 1,
+        skip_with_error: None,
+    });
+    kernel.add_expected_syscall(ExpectedSyscall::Command {
+        driver_id: DRIVER_NUM,
+        command_id: command::WRITE,
+        argument0: 5,
+        argument1: 0,
+        override_return: Some(command_return::failure(ErrorCode::Fail)),
+    });
+
+    assert_eq!(Console::write(b"abcde"), Err(ErrorCode::Fail));
+    // The fake driver still receives the command even if a fake error is injected.
+    assert_eq!(driver.take_bytes(), b"abcde");
+}

--- a/examples/block_storage.rs
+++ b/examples/block_storage.rs
@@ -1,0 +1,50 @@
+//! A simple block_storage example.
+//! Prints device geometry, then assumes its write block size is under 256 bytes,
+//! and erases a block.
+
+#![no_main]
+#![no_std]
+use core::fmt::Write;
+use libtock::block_storage::BlockStorage;
+use libtock::console::Console;
+use libtock::runtime::{set_main, stack_size};
+
+set_main! {main}
+stack_size! {0x1800}
+
+fn main() {
+    let mut w = Console::writer();
+    if BlockStorage::driver_check() {
+        let g = BlockStorage::get_geometry();
+        writeln!(&mut w, "Write block size: {} bytes", g.write_block_size).unwrap();
+        writeln!(
+            Console::writer(),
+            "Erase block size: {} bytes",
+            g.erase_block_size
+        )
+        .unwrap();
+        let mut buf = [0; 256];
+        if g.write_block_size as usize > buf.len() {
+            writeln!(
+                Console::writer(),
+                "Block size bigger than preallocated buffer, writes will be inaccurate."
+            )
+            .unwrap();
+        }
+        let wb = 43;
+        let a = g.get_address_of_write_block(wb);
+        let eb = g.get_erase_block_containing(a);
+        BlockStorage::read(wb, &mut buf).unwrap();
+        writeln!(&mut w, "First bytes of sector 43: {:?}", &buf[..10]).unwrap();
+        BlockStorage::erase(eb).unwrap();
+        BlockStorage::read(wb, &mut buf).unwrap();
+        writeln!(&mut w, "Erased sector to: {:?}", &buf[..10]).unwrap();
+        buf = [0; 256];
+        buf[2] = 137;
+        BlockStorage::write(wb, &mut buf).unwrap();
+        BlockStorage::read(wb, &mut buf).unwrap();
+        writeln!(&mut w, "Written sector: {:?}", &buf[..10]).unwrap();
+    } else {
+        writeln!(Console::writer(), "No block device detected").unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,11 @@ pub mod alarm {
     pub type Alarm = alarm::Alarm<super::runtime::TockSyscalls>;
     pub use alarm::{Convert, Hz, Milliseconds, Ticks};
 }
+pub mod block_storage {
+    use libtock_block_storage as block_storage;
+    pub type BlockStorage = block_storage::BlockStorage<super::runtime::TockSyscalls>;
+    pub use block_storage::Geometry;
+}
 pub mod buttons {
     use libtock_buttons as buttons;
     pub type Buttons = buttons::Buttons<super::runtime::TockSyscalls>;


### PR DESCRIPTION
This is a synchronous API for the proposed [block storage syscall](https://github.com/tock/tock/pull/3162). It's enough to test it.

TODO:
- write tests

Tested on the SMA Q3 as described in https://github.com/tock/tock/pull/3162