### PR TITLE
fixed incorrect inference

### DIFF
--- a/apis/alarm/src/lib.rs
+++ b/apis/alarm/src/lib.rs
@@ -59,9 +59,6 @@ impl Convert for Milliseconds {
 
 impl<S: Syscalls, C: platform::subscribe::Config> Alarm<S, C> {
     /// Run a check against the console capsule to ensure it is present.
-    ///
-    /// Returns number of concurrent notifications supported,
-    /// 0 if unbounded.
     #[inline(always)]
     pub fn driver_check() -> Result<(), ErrorCode> {
         S::command(DRIVER_NUM, command::DRIVER_CHECK, 0, 0).to_result()

--- a/apis/alarm/src/lib.rs
+++ b/apis/alarm/src/lib.rs
@@ -63,7 +63,7 @@ impl<S: Syscalls, C: platform::subscribe::Config> Alarm<S, C> {
     /// Returns number of concurrent notifications supported,
     /// 0 if unbounded.
     #[inline(always)]
-    pub fn driver_check() -> Result<u32, ErrorCode> {
+    pub fn driver_check() -> Result<(), ErrorCode> {
         S::command(DRIVER_NUM, command::DRIVER_CHECK, 0, 0).to_result()
     }
 


### PR DESCRIPTION
closes #446
ran `make test` which concluded with  `[ SUCCESS ] libtock-rs tests pass`
