### PR TITLE
Update to Tock 2.1.1.

### DIFF
--- a/syscalls_tests/src/subscribe_tests.rs
+++ b/syscalls_tests/src/subscribe_tests.rs
@@ -63,7 +63,7 @@ fn failed() {
     share::scope(|subscribe| {
         assert_eq!(
             fake::Syscalls::subscribe::<_, _, DefaultConfig, 1, 2>(subscribe, &done),
-            Err(ErrorCode::NoMem)
+            Err(ErrorCode::NoDevice)
         );
     });
 }

--- a/unittest/src/fake/syscalls/subscribe_impl.rs
+++ b/unittest/src/fake/syscalls/subscribe_impl.rs
@@ -74,10 +74,10 @@ pub(super) unsafe fn subscribe(
     }
 
     // Verify the given driver ID was present. If no driver with this ID is
-    // present, the kernel returns NOMEM.
+    // present, the kernel returns NODEVICE.
     let num_upcalls = match num_upcalls {
         Some(num_upcalls) => num_upcalls,
-        None => return failure_registers(ErrorCode::NoMem),
+        None => return failure_registers(ErrorCode::NoDevice),
     };
 
     // If a too-large subscribe number is passed, the kernel returns the Invalid

--- a/unittest/src/fake/syscalls/subscribe_impl_tests.rs
+++ b/unittest/src/fake/syscalls/subscribe_impl_tests.rs
@@ -69,7 +69,7 @@ fn missing_driver() {
         r3.into(),
     );
     assert_eq!(r0, return_variant::FAILURE_2_U32.into());
-    assert_eq!(r1, ErrorCode::NoMem as u32);
+    assert_eq!(r1, ErrorCode::NoDevice as u32);
     assert_eq!(r2, 0);
     assert_eq!(r3, 0);
 }


### PR DESCRIPTION
This updates the Tock submodule to the 2.1.1 release and adjusts the fake kernel's error codes to correspond with the corrections in https://github.com/tock/tock/pull/3300.