### PR TITLE
led: seperate exist check and get num leds

### DIFF
--- a/apis/leds/src/lib.rs
+++ b/apis/leds/src/lib.rs
@@ -16,12 +16,8 @@ pub struct Leds<S: Syscalls>(S);
 
 impl<S: Syscalls> Leds<S> {
     /// Run a check against the leds capsule to ensure it is present.
-    ///
-    /// Returns `Ok(number_of_leds)` if the driver was present. This does not necessarily mean
-    /// that the driver is working, as it may still fail to allocate grant
-    /// memory.
-    pub fn count() -> Result<u32, ErrorCode> {
-        S::command(DRIVER_NUM, LEDS_COUNT, 0, 0).to_result()
+    pub fn check() -> Result<(), ErrorCode> {
+        S::command(DRIVER_NUM, LED_CHECK, 0, 0).to_result()
     }
 
     pub fn on(led: u32) -> Result<(), ErrorCode> {
@@ -35,6 +31,14 @@ impl<S: Syscalls> Leds<S> {
     pub fn toggle(led: u32) -> Result<(), ErrorCode> {
         S::command(DRIVER_NUM, LED_TOGGLE, led, 0).to_result()
     }
+
+    /// Returns `Ok(number_of_leds)`.This does not necessarily mean
+    /// that the driver is working, as it may still fail to allocate grant
+    /// memory.
+    pub fn count() -> Result<u32, ErrorCode> {
+        S::command(DRIVER_NUM, LEDS_COUNT, 0, 0).to_result()
+    }
+
 }
 
 #[cfg(test)]
@@ -47,7 +51,8 @@ mod tests;
 const DRIVER_NUM: u32 = 2;
 
 // Command IDs
-const LEDS_COUNT: u32 = 0;
+const LED_CHECK: u32 = 0;
 const LED_ON: u32 = 1;
 const LED_OFF: u32 = 2;
 const LED_TOGGLE: u32 = 3;
+const LEDS_COUNT: u32 = 4;


### PR DESCRIPTION
Added "check" function to led syscalls in order to seperate the functionality of exists
and getting the number of leds present on the board. Tock documentation says
command 0 must be the "exists" check and always return success; several
drivers use current command 0 as exists and count.

I have also submitted corresponding PRs for the tock led capsule and libtock-c
led code regarding issue #3375.