### PR TITLE
Fix Raspberry Pi Pico board and layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,14 +204,14 @@ flash-nrf52840:
 	LIBTOCK_PLATFORM=nrf52840 cargo run --example $(EXAMPLE) $(features) \
 		--target=thumbv7em-none-eabi $(release) -- --deploy=tockloader
 
-.PHONY: raspberrypi_pico
-raspberrypi_pico:
-	LIBTOCK_PLATFORM=raspberrypi_pico cargo run --example $(EXAMPLE) $(features) \
+.PHONY: raspberry_pi_pico
+raspberry_pi_pico:
+	LIBTOCK_PLATFORM=raspberry_pi_pico cargo run --example $(EXAMPLE) $(features) \
 		--target=thumbv6m-none-eabi $(release)
-	mkdir -p target/tbf/raspberrypi_pico
+	mkdir -p target/tbf/raspberry_pi_pico
 	cp target/thumbv6m-none-eabi/release/examples/$(EXAMPLE).tab \
 		target/thumbv6m-none-eabi/release/examples/$(EXAMPLE).tbf \
-		target/tbf/raspberrypi_pico
+		target/tbf/raspberry_pi_pico
 
 .PHONY: nano_rp2040_connect
 nano_rp2040_connect:

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 
 fn get_platform_architecture(platform: &str) -> Option<&'static str> {
     match platform {
-        "raspberrypi_pico" | "nano_rp2040_connect" => Some("cortex-m0"),
+        "raspberry_pi_pico" | "nano_rp2040_connect" => Some("cortex-m0"),
         "apollo3"
         | "clue_nrf52840"
         | "hail"

--- a/runtime/layouts/raspberry_pi_pico.ld
+++ b/runtime/layouts/raspberry_pi_pico.ld
@@ -1,8 +1,8 @@
 /* Layout for the Raspberry Pi Pico board, used by the examples in this repository. */
 
 MEMORY {
-  FLASH (X) : ORIGIN = 0x10020000, LENGTH = 256K
-  RAM (W) : ORIGIN = 0x20004000, LENGTH = 248K
+  FLASH (X) : ORIGIN = 0x10040000, LENGTH = 256K
+  RAM (W) : ORIGIN = 0x20011800, LENGTH = 194K
 }
 
 TBF_HEADER_SIZE = 0x60;


### PR DESCRIPTION
This pull request fixes the Raspberry Pi Pico's board name and layout.

This was tested using a Raspberry Pi Pico.

It would be great if we could merge this until the Rust Nation presentation.
