### PR TITLE
Export GPIO API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,12 @@ libtock_alarm = { path = "apis/alarm" }
 libtock_buttons = { path = "apis/buttons" }
 libtock_console = { path = "apis/console" }
 libtock_debug_panic = { path = "panic_handlers/debug_panic" }
+libtock_gpio = { path = "apis/gpio" }
 libtock_leds = { path = "apis/leds" }
 libtock_low_level_debug = { path = "apis/low_level_debug" }
 libtock_platform = { path = "platform" }
 libtock_runtime = { path = "runtime" }
-libtock_temperature = { path = "apis/temperature"}
+libtock_temperature = { path = "apis/temperature" }
 
 [profile.dev]
 panic = "abort"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,14 @@ pub mod console {
     pub type Console = console::Console<super::runtime::TockSyscalls>;
     pub use console::ConsoleWriter;
 }
+pub mod gpio {
+    use libtock_gpio as gpio;
+    pub type Gpio = gpio::Gpio<super::runtime::TockSyscalls>;
+    pub use gpio::{
+        Error, GpioInterruptListener, GpioState, InputPin, OutputPin, PinInterruptEdge, Pull,
+        PullDown, PullNone, PullUp,
+    };
+}
 pub mod leds {
     use libtock_leds as leds;
     pub type Leds = leds::Leds<super::runtime::TockSyscalls>;


### PR DESCRIPTION
This pull requests exports the GPIO API, so that it can be used from applications that are not part of the `libtock-rs` crate.