### PR TITLE
Update macos-10.15 to macos-latest

### DIFF
--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -8,7 +8,7 @@ on: pull_request
 
 jobs:
   ci-mac-os:
-    runs-on: macos-10.15
+    runs-on: macos-latest
 
     steps:
       # Clones a single commit from the libtock-rs repository. The commit cloned


### PR DESCRIPTION
## This PR Resolves
There is an issue with the macos runner in the CI because ```macos-10.15``` has been deprecated an now it takes a day until the check gets timeout.
I suggest using ```macos-latest``` in order to have always the latest LTS runner in the CI