### PR TITLE
Remove bors-ng and switch to GitHub actions merge-queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,12 @@
 
 name: ci
 
-# We want to run CI on all pull requests. Additionally, Bors needs workflows to
-# run on the `staging` and `trying` branches.
+# We want to run CI on all pull requests. Additionally, GitHub actions merge
+# queue needs workflows to run on the `merge_queue` trigger to block merges on
+# them.
 on:
   pull_request:
-  push:
-    branches:
-      - staging
-      - trying
+  merge_group:
 
 jobs:
   ci:

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -2,8 +2,9 @@
 
 name: ci-mac-os
 
-# We run this workflow during pull request review, but not for Bors merges. We
-# can change this if the workflow is reasonably quick and reliable.
+# We run this workflow during pull request review, but not as a required status
+# for GitHub actions merge-queue merges. We can change this if the workflow is
+# reasonably quick and reliable.
 on: pull_request
 
 jobs:

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -3,14 +3,12 @@
 
 name: size-diff
 
-# We want to run this on all pull requests. Additionally, Bors needs workflows
-# to run on the `staging` and `trying` branches to block merges on them.
+# We want to run this on all pull requests. Additionally, GitHub actions merge
+# queue needs workflows to run on the `merge_queue` trigger to block merges on
+# them.
 on:
   pull_request:
-  push:
-    branches:
-      - staging
-      - trying
+  merge_group:
 
 jobs:
   size-diff:

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,0 @@
-status = [
-  "ci",
-  "size-diff",
-]


### PR DESCRIPTION
This removes the bors configuration and switches to the GitHub actions merge queue merge bot. It replicates the required status checks for bors to pass, and adds the appropriate GitHub merge group status checks. This PR needs to be followed up with the appropriate configuration applied in the repository settings.