### PR TITLE
Update rust-toolchain to nightly of 2023-07-30

### DIFF
--- a/apis/adc/src/lib.rs
+++ b/apis/adc/src/lib.rs
@@ -42,7 +42,7 @@ impl<S: Syscalls> Adc<S> {
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
             Self::read_single_sample()?;
-            while sample.get() == None {
+            while sample.get().is_none() {
                 S::yield_wait();
             }
 

--- a/apis/air_quality/src/lib.rs
+++ b/apis/air_quality/src/lib.rs
@@ -80,7 +80,7 @@ impl<S: Syscalls> AirQuality<S> {
             match read_type {
                 CO2 => {
                     Self::read_co2()?;
-                    while data_cell.get() == None {
+                    while data_cell.get().is_none() {
                         S::yield_wait();
                     }
 
@@ -91,7 +91,7 @@ impl<S: Syscalls> AirQuality<S> {
                 }
                 Tvoc => {
                     Self::read_tvoc()?;
-                    while data_cell.get() == None {
+                    while data_cell.get().is_none() {
                         S::yield_wait();
                     }
 

--- a/apis/ambient_light/src/lib.rs
+++ b/apis/ambient_light/src/lib.rs
@@ -44,7 +44,7 @@ impl<S: Syscalls> AmbientLight<S> {
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
             Self::read_intensity()?;
-            while intensity_cell.get() == None {
+            while intensity_cell.get().is_none() {
                 S::yield_wait();
             }
 

--- a/apis/buzzer/src/lib.rs
+++ b/apis/buzzer/src/lib.rs
@@ -45,7 +45,7 @@ impl<S: Syscalls> Buzzer<S> {
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
             Self::tone(freq, duration)?;
-            while buzzer_cell.get() == None {
+            while buzzer_cell.get().is_none() {
                 S::yield_wait();
             }
             match buzzer_cell.get() {

--- a/apis/ninedof/src/lib.rs
+++ b/apis/ninedof/src/lib.rs
@@ -63,7 +63,7 @@ impl<S: Syscalls> NineDof<S> {
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
             Self::read_accelerometer()?;
-            while data_cell.get() == None {
+            while data_cell.get().is_none() {
                 S::yield_wait();
             }
             match data_cell.get() {
@@ -84,7 +84,7 @@ impl<S: Syscalls> NineDof<S> {
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
             Self::read_magnetometer()?;
-            while data_cell.get() == None {
+            while data_cell.get().is_none() {
                 S::yield_wait();
             }
             match data_cell.get() {
@@ -105,7 +105,7 @@ impl<S: Syscalls> NineDof<S> {
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
             Self::read_gyro()?;
-            while data_cell.get() == None {
+            while data_cell.get().is_none() {
                 S::yield_wait();
             }
             match data_cell.get() {

--- a/apis/proximity/src/lib.rs
+++ b/apis/proximity/src/lib.rs
@@ -77,7 +77,7 @@ impl<S: Syscalls> Proximity<S> {
         share::scope(|subscribe| {
             if let Ok(()) = Self::register_listener(&listener, subscribe) {
                 if let Ok(()) = Self::read_on_interrupt(lower, upper) {
-                    while listener.get() == None {
+                    while listener.get().is_none() {
                         S::yield_wait();
                     }
                 }

--- a/apis/sound_pressure/src/lib.rs
+++ b/apis/sound_pressure/src/lib.rs
@@ -54,7 +54,7 @@ impl<S: Syscalls> SoundPressure<S> {
         share::scope(|subscribe| {
             Self::register_listener(&listener, subscribe)?;
             Self::read()?;
-            while pressure_cell.get() == None {
+            while pressure_cell.get().is_none() {
                 S::yield_wait();
             }
             match pressure_cell.get() {

--- a/apis/temperature/src/lib.rs
+++ b/apis/temperature/src/lib.rs
@@ -45,7 +45,7 @@ impl<S: Syscalls> Temperature<S> {
         share::scope(|subscribe| {
             if let Ok(()) = Self::register_listener(&listener, subscribe) {
                 if let Ok(()) = Self::read_temperature() {
-                    while temperature_cell.get() == None {
+                    while temperature_cell.get().is_none() {
                         S::yield_wait();
                     }
                 }

--- a/platform/src/error_code_tests.rs
+++ b/platform/src/error_code_tests.rs
@@ -8,7 +8,7 @@ use crate::{error_code::NotAnErrorCode, ErrorCode};
 #[test]
 fn error_code_range() {
     for value in 1..=1024u32 {
-        unsafe { *(&value as *const u32 as *const ErrorCode) };
+        let _ = unsafe { *(&value as *const u32 as *const ErrorCode) };
     }
 }
 

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), no_std)]
 #![warn(unsafe_op_in_unsafe_fn)]
+#![feature(strict_provenance)]
 
 pub mod allow_ro;
 pub mod allow_rw;

--- a/platform/src/register.rs
+++ b/platform/src/register.rs
@@ -16,19 +16,19 @@ pub struct Register(pub *mut ());
 
 impl From<crate::ErrorCode> for Register {
     fn from(value: crate::ErrorCode) -> Register {
-        Register(value as u16 as *mut ())
+        Register(core::ptr::null::<()>().with_addr(value as u16 as usize) as *mut ())
     }
 }
 
 impl From<u32> for Register {
     fn from(value: u32) -> Register {
-        Register(value as *mut ())
+        Register(core::ptr::null::<()>().with_addr(value as usize) as *mut ())
     }
 }
 
 impl From<usize> for Register {
     fn from(value: usize) -> Register {
-        Register(value as *mut ())
+        Register(core::ptr::null::<()>().with_addr(value) as *mut ())
     }
 }
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 [toolchain]
 # See https://rust-lang.github.io/rustup-components-history/ for a list of
 # recently nightlies and what components are available for them.
-channel = "nightly-2022-06-10"
+channel = "nightly-2023-07-30"
 components = ["clippy", "miri", "rustfmt"]
 targets = ["thumbv7em-none-eabi",
            "riscv32imac-unknown-none-elf",

--- a/unittest/src/fake/air_quality/mod.rs
+++ b/unittest/src/fake/air_quality/mod.rs
@@ -38,7 +38,7 @@ impl AirQuality {
     pub fn set_value(&self, value: u32) {
         if self.busy.get() {
             self.share_ref
-                .schedule_upcall(0, (value as u32, 0, 0))
+                .schedule_upcall(0, (value, 0, 0))
                 .expect("Unable to schedule upcall");
             self.busy.set(false);
         }

--- a/unittest/src/fake/ambient_light/mod.rs
+++ b/unittest/src/fake/ambient_light/mod.rs
@@ -33,7 +33,7 @@ impl AmbientLight {
     pub fn set_value(&self, value: u32) {
         if self.busy.get() {
             self.share_ref
-                .schedule_upcall(0, (value as u32, 0, 0))
+                .schedule_upcall(0, (value, 0, 0))
                 .expect("Unable to schedule upcall");
             self.busy.set(false);
         }

--- a/unittest/src/fake/gpio/mod.rs
+++ b/unittest/src/fake/gpio/mod.rs
@@ -87,8 +87,8 @@ impl<const NUM_GPIOS: usize> Gpio<NUM_GPIOS> {
     }
 
     pub fn set_missing_gpio(&self, gpio: usize) {
-        if (gpio as usize) < self.gpios.len() {
-            self.gpios[gpio as usize].set(None);
+        if gpio < self.gpios.len() {
+            self.gpios[gpio].set(None);
         }
     }
 

--- a/unittest/src/fake/sound_pressure/mod.rs
+++ b/unittest/src/fake/sound_pressure/mod.rs
@@ -62,7 +62,7 @@ impl crate::fake::SyscallDriver for SoundPressure {
                 }
                 self.busy.set(true);
                 if let Some(val) = self.upcall_on_command.take() {
-                    self.set_value(val as u8);
+                    self.set_value(val);
                 }
                 crate::command_return::success()
             }


### PR DESCRIPTION
This version and the time to update is chosen somewhat arbitrarily, as libtock-rs fails to build elf2tab on its current Rust toolchain (2022-06-10).