### PR TITLE
api: adc: exists needs to handle number of channels

### DIFF
--- a/apis/adc/src/lib.rs
+++ b/apis/adc/src/lib.rs
@@ -10,7 +10,12 @@ pub struct Adc<S: Syscalls>(S);
 impl<S: Syscalls> Adc<S> {
     /// Returns Ok() if the driver was present.This does not necessarily mean
     /// that the driver is working.
-    pub fn exists() -> Result<(), ErrorCode> {
+    //
+    // Note! The "exists" command should return `Result<(), ErrorCode>`, but the
+    // current ADC driver in the kernel returns the number of ADC channels
+    // instead of just success. This will be fixed in a future release of Tock,
+    // but for now we workaround this issue.
+    pub fn exists() -> Result<u32, ErrorCode> {
         S::command(DRIVER_NUM, EXISTS, 0, 0).to_result()
     }
 

--- a/apis/adc/src/lib.rs
+++ b/apis/adc/src/lib.rs
@@ -10,15 +10,17 @@ pub struct Adc<S: Syscalls>(S);
 impl<S: Syscalls> Adc<S> {
     /// Returns Ok() if the driver was present.This does not necessarily mean
     /// that the driver is working.
-    //
-    // Note! The "exists" command should return `Result<(), ErrorCode>`, but the
-    // current ADC driver in the kernel returns the number of ADC channels
-    // instead of just success. This will be fixed in a future release of Tock,
-    // but for now we workaround this issue.
-    //
-    // https://github.com/tock/tock/issues/3375
-    pub fn exists() -> Result<u32, ErrorCode> {
-        S::command(DRIVER_NUM, EXISTS, 0, 0).to_result()
+    pub fn exists() -> Result<(), ErrorCode> {
+        // Note! The "exists" command should return directly return `Result<(),
+        // ErrorCode>` (i.e. with no `.and()` call), but the current ADC driver
+        // in the kernel returns the number of ADC channels instead of just
+        // success. This will be fixed in a future release of Tock, but for now
+        // we workaround this issue.
+        //
+        // https://github.com/tock/tock/issues/3375
+        S::command(DRIVER_NUM, EXISTS, 0, 0)
+            .to_result::<u32, ErrorCode>()
+            .and(Ok(()))
     }
 
     // Initiate a sample reading

--- a/apis/adc/src/lib.rs
+++ b/apis/adc/src/lib.rs
@@ -15,6 +15,8 @@ impl<S: Syscalls> Adc<S> {
     // current ADC driver in the kernel returns the number of ADC channels
     // instead of just success. This will be fixed in a future release of Tock,
     // but for now we workaround this issue.
+    //
+    // https://github.com/tock/tock/issues/3375
     pub fn exists() -> Result<u32, ErrorCode> {
         S::command(DRIVER_NUM, EXISTS, 0, 0).to_result()
     }

--- a/unittest/src/fake/adc/mod.rs
+++ b/unittest/src/fake/adc/mod.rs
@@ -53,7 +53,7 @@ impl crate::fake::SyscallDriver for Adc {
 
     fn command(&self, command_id: u32, _argument0: u32, _argument1: u32) -> CommandReturn {
         match command_id {
-            EXISTS => crate::command_return::success(),
+            EXISTS => crate::command_return::success_u32(1),
 
             SINGLE_SAMPLE => {
                 if self.busy.get() {

--- a/unittest/src/fake/adc/tests.rs
+++ b/unittest/src/fake/adc/tests.rs
@@ -7,7 +7,7 @@ use libtock_platform::{share, DefaultConfig, YieldNoWaitReturn};
 fn command() {
     let adc = Adc::new();
 
-    assert!(adc.command(EXISTS, 1, 2).is_success());
+    assert!(adc.command(EXISTS, 1, 2).is_success_u32());
 
     assert!(adc.command(SINGLE_SAMPLE, 0, 0).is_success());
 
@@ -33,7 +33,7 @@ fn kernel_integration() {
     let kernel = fake::Kernel::new();
     let adc = Adc::new();
     kernel.add_driver(&adc);
-    assert!(fake::Syscalls::command(DRIVER_NUM, EXISTS, 1, 2).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, EXISTS, 1, 2).is_success_u32());
     assert!(fake::Syscalls::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 0).is_success());
     assert_eq!(
         fake::Syscalls::command(DRIVER_NUM, SINGLE_SAMPLE, 0, 0).get_failure(),


### PR DESCRIPTION
This is a bug in the kernel which will be fixed in future releases but for now we enable the ADC example to work.