### PR TITLE
platform: subscribe: add return code variants

### DIFF
--- a/platform/src/subscribe.rs
+++ b/platform/src/subscribe.rs
@@ -189,6 +189,33 @@ fn upcall_impls() {
     let cell_three = core::cell::Cell::new(None);
     cell_three.upcall(1, 2, 3);
     assert_eq!(cell_three.get(), Some((1, 2, 3)));
+
+    let cell_returncode_empty_success: core::cell::Cell<Option<Result<(), ErrorCode>>> =
+        core::cell::Cell::new(None);
+    cell_returncode_empty_success.upcall(0, 2, 3);
+    assert_eq!(cell_returncode_empty_success.get(), Some(Ok(())));
+    let cell_returncode_empty_fail: core::cell::Cell<Option<Result<(), ErrorCode>>> =
+        core::cell::Cell::new(None);
+    cell_returncode_empty_fail.upcall(1, 2, 3);
+    assert_eq!(cell_returncode_empty_fail.get(), Some(Err(ErrorCode::Fail)));
+
+    let cell_returncode_one_success: core::cell::Cell<Option<Result<(u32,), ErrorCode>>> =
+        core::cell::Cell::new(None);
+    cell_returncode_one_success.upcall(0, 2, 3);
+    assert_eq!(cell_returncode_one_success.get(), Some(Ok((2,))));
+    let cell_returncode_one_fail: core::cell::Cell<Option<Result<(u32,), ErrorCode>>> =
+        core::cell::Cell::new(None);
+    cell_returncode_one_fail.upcall(1, 2, 3);
+    assert_eq!(cell_returncode_one_fail.get(), Some(Err(ErrorCode::Fail)));
+
+    let cell_returncode_two_success: core::cell::Cell<Option<Result<(u32, u32), ErrorCode>>> =
+        core::cell::Cell::new(None);
+    cell_returncode_two_success.upcall(0, 2, 3);
+    assert_eq!(cell_returncode_two_success.get(), Some(Ok((2, 3))));
+    let cell_returncode_two_fail: core::cell::Cell<Option<Result<(u32, u32), ErrorCode>>> =
+        core::cell::Cell::new(None);
+    cell_returncode_two_fail.upcall(1, 2, 3);
+    assert_eq!(cell_returncode_two_fail.get(), Some(Err(ErrorCode::Fail)));
 }
 
 // -----------------------------------------------------------------------------

--- a/platform/src/subscribe.rs
+++ b/platform/src/subscribe.rs
@@ -1,4 +1,6 @@
+use crate::error_code::NotAnErrorCode;
 use crate::share::List;
+use crate::ErrorCode;
 use crate::Syscalls;
 
 // -----------------------------------------------------------------------------
@@ -120,6 +122,48 @@ impl Upcall<AnyId> for core::cell::Cell<Option<(u32, u32)>> {
 impl Upcall<AnyId> for core::cell::Cell<Option<(u32, u32, u32)>> {
     fn upcall(&self, arg0: u32, arg1: u32, arg2: u32) {
         self.set(Some((arg0, arg1, arg2)));
+    }
+}
+
+/// An `Upcall` implementation that interprets its first argument as a return
+/// code.
+impl Upcall<AnyId> for core::cell::Cell<Option<Result<(), ErrorCode>>> {
+    fn upcall(&self, arg0: u32, _: u32, _: u32) {
+        match arg0 {
+            0 => self.set(Some(Ok(()))),
+            a0 => {
+                let e: Result<ErrorCode, NotAnErrorCode> = a0.try_into();
+                self.set(Some(Err(e.unwrap_or(ErrorCode::Fail))));
+            }
+        }
+    }
+}
+
+/// An `Upcall` implementation that interprets its first argument as a return
+/// code and stores its second argument when called.
+impl Upcall<AnyId> for core::cell::Cell<Option<Result<(u32,), ErrorCode>>> {
+    fn upcall(&self, arg0: u32, arg1: u32, _: u32) {
+        match arg0 {
+            0 => self.set(Some(Ok((arg1,)))),
+            a0 => {
+                let e: Result<ErrorCode, NotAnErrorCode> = a0.try_into();
+                self.set(Some(Err(e.unwrap_or(ErrorCode::Fail))));
+            }
+        }
+    }
+}
+
+/// An `Upcall` implementation that interprets its first argument as a return
+/// code and stores its second argument when called.
+impl Upcall<AnyId> for core::cell::Cell<Option<Result<(u32, u32), ErrorCode>>> {
+    fn upcall(&self, arg0: u32, arg1: u32, arg2: u32) {
+        match arg0 {
+            0 => self.set(Some(Ok((arg1, arg2)))),
+            a0 => {
+                let e: Result<ErrorCode, NotAnErrorCode> = a0.try_into();
+                self.set(Some(Err(e.unwrap_or(ErrorCode::Fail))));
+            }
+        }
     }
 }
 

--- a/platform/src/subscribe.rs
+++ b/platform/src/subscribe.rs
@@ -1,4 +1,3 @@
-use crate::error_code::NotAnErrorCode;
 use crate::share::List;
 use crate::ErrorCode;
 use crate::Syscalls;
@@ -129,13 +128,10 @@ impl Upcall<AnyId> for core::cell::Cell<Option<(u32, u32, u32)>> {
 /// code.
 impl Upcall<AnyId> for core::cell::Cell<Option<Result<(), ErrorCode>>> {
     fn upcall(&self, arg0: u32, _: u32, _: u32) {
-        match arg0 {
-            0 => self.set(Some(Ok(()))),
-            a0 => {
-                let e: Result<ErrorCode, NotAnErrorCode> = a0.try_into();
-                self.set(Some(Err(e.unwrap_or(ErrorCode::Fail))));
-            }
-        }
+        self.set(Some(match arg0 {
+            0 => Ok(()),
+            _ => Err(arg0.try_into().unwrap_or(ErrorCode::Fail)),
+        }));
     }
 }
 
@@ -143,13 +139,10 @@ impl Upcall<AnyId> for core::cell::Cell<Option<Result<(), ErrorCode>>> {
 /// code and stores its second argument when called.
 impl Upcall<AnyId> for core::cell::Cell<Option<Result<(u32,), ErrorCode>>> {
     fn upcall(&self, arg0: u32, arg1: u32, _: u32) {
-        match arg0 {
-            0 => self.set(Some(Ok((arg1,)))),
-            a0 => {
-                let e: Result<ErrorCode, NotAnErrorCode> = a0.try_into();
-                self.set(Some(Err(e.unwrap_or(ErrorCode::Fail))));
-            }
-        }
+        self.set(Some(match arg0 {
+            0 => Ok((arg1,)),
+            _ => Err(arg0.try_into().unwrap_or(ErrorCode::Fail)),
+        }));
     }
 }
 
@@ -157,13 +150,10 @@ impl Upcall<AnyId> for core::cell::Cell<Option<Result<(u32,), ErrorCode>>> {
 /// code and stores its second argument when called.
 impl Upcall<AnyId> for core::cell::Cell<Option<Result<(u32, u32), ErrorCode>>> {
     fn upcall(&self, arg0: u32, arg1: u32, arg2: u32) {
-        match arg0 {
-            0 => self.set(Some(Ok((arg1, arg2)))),
-            a0 => {
-                let e: Result<ErrorCode, NotAnErrorCode> = a0.try_into();
-                self.set(Some(Err(e.unwrap_or(ErrorCode::Fail))));
-            }
-        }
+        self.set(Some(match arg0 {
+            0 => Ok((arg1, arg2)),
+            _ => Err(arg0.try_into().unwrap_or(ErrorCode::Fail)),
+        }));
     }
 }
 


### PR DESCRIPTION
One convention in Tock is that the first argument of an upcall is a return code. A return code is an `ErrorCode` but 0 means Success.

This makes it possible to write a subscribe callback like:

```rust
let called: Cell<Option<Result<(), ErrorCode>>> = Cell::new(None);
let called: Cell<Option<Result<(u32,), ErrorCode>>> = Cell::new(None);
let called: Cell<Option<Result<(u32, u32), ErrorCode>>> = Cell::new(None);
```

My implementation of converting a u32 to an errorcode is functional but not great, any ideas on what that should look like?