### PR TITLE
ld: Check for alignment between FLASH_START and linker page size

### DIFF
--- a/build_scripts/libtock_layout.ld
+++ b/build_scripts/libtock_layout.ld
@@ -164,3 +164,23 @@ SECTIONS {
       *(.ARM.exidx .eh_frame)
     }
 }
+
+/* Check that the linker thinks our start of flash is page aligned. Now, the
+ * linker doesn't actually know the size of pages, and for our purposes we don't
+ * necessarily care that these are aligned, but the linker will generate
+ * segments which are aligned to what it thinks the page size is. This will
+ * cause the linker to insert segments _before_ `FLASH_START`, which is not what
+ * we intend. To ensure more valid-looking .elf files, we check that
+ * `FLASH_START` is aligned to what the linker thinks is the page size.
+ *
+ * If this check fails, it is likely the linker is using a page size of 0x10000
+ * (based on observations in Aug 2023). The linker argument `-z
+ * max-page-size=4096` changes this setting. We recommend adding
+ * `println!("cargo:rustc-link-arg=-zmax-page-size=4096");` to your build.rs
+ * file to fix this issue.
+ */
+ASSERT(FLASH_START % CONSTANT(MAXPAGESIZE)==0, "
+FLASH_START not page aligned according to the linker.
+This will cause issues with generated .elf segments.
+The linker is probably assuming too large of a page size.
+Add `println!('cargo:rustc-link-arg=-zmax-page-size=4096');` to build.rs to fix.")


### PR DESCRIPTION
This PR is on top of the make updates because that lets me test it. We only care about the latest commit: https://github.com/tock/libtock-rs/commit/79e25cf6f878a695a5b8dd9e32a479b6f3848fbc

The llvm linker seems to make sure the first segment is aligned to a flash page, and assumes the page size is 0x10000. This causes elfs with a segment before what we set as the start of flash:

```
readelf.py -lS target/cortex-m4.0x00048000.0x1000a000/console
There are 22 section headers, starting at offset 0x26f1c

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .start            PROGBITS        00048080 008080 000074 00  AX  0   0  1
  [ 2] .text             PROGBITS        000480f4 0080f4 0016c8 00  AX  0   0  2
  [ 3] .rodata           PROGBITS        000497bc 0097bc 0001ec 00   A  0   0  4
  [ 4] .stack            NOBITS          1000a000 00a000 000100 00  WA  0   0  1
  [ 5] .data             PROGBITS        1000a100 00a100 000000 00  WA  0   0  1
  [ 6] .bss              NOBITS          1000a100 00a100 000000 00  WA  0   0  1
  [ 7] .debug_loc        PROGBITS        00000000 00a100 0011c5 00      0   0  1
  [ 8] .debug_abbrev     PROGBITS        00000000 00b2c5 0003f3 00      0   0  1
  [ 9] .debug_info       PROGBITS        00000000 00b6b8 007c0d 00      0   0  1
  [10] .debug_aranges    PROGBITS        00000000 0132c5 000108 00      0   0  1
  [11] .debug_ranges     PROGBITS        00000000 0133cd 001278 00      0   0  1
  [12] .debug_str        PROGBITS        00000000 014645 009310 01  MS  0   0  1
  [13] .debug_pubnames   PROGBITS        00000000 01d955 004e3e 00      0   0  1
  [14] .debug_pubtypes   PROGBITS        00000000 022793 001021 00      0   0  1
  [15] .ARM.attributes   ARM_ATTRIBUTES  00000000 0237b4 000032 00      0   0  1
  [16] .debug_frame      PROGBITS        00000000 0237e8 000358 00      0   0  4
  [17] .debug_line       PROGBITS        00000000 023b40 0020c0 00      0   0  1
  [18] .comment          PROGBITS        00000000 025c00 000013 01  MS  0   0  1
  [19] .symtab           SYMTAB          00000000 025c14 0005c0 10     21  76  4
  [20] .shstrtab         STRTAB          00000000 0261d4 0000e1 00      0   0  1
  [21] .strtab           STRTAB          00000000 0262b5 000c65 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings)
  I (info), L (link order), G (group), T (TLS), E (exclude), x (unknown)
  O (extra OS processing required) o (OS specific), p (processor specific)

Elf file type is EXEC (Executable file)
Entry point is 0x480a1
There are 6 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  PHDR           0x000034 0x00040034 0x00040034 0x000c0 0x000c0 R   0x4
  LOAD           0x000000 0x00040000 0x00040000 0x000f4 0x000f4 R   0x10000  // <-- This is before where we said flash starts.
  LOAD           0x008080 0x00048080 0x00048080 0x0173c 0x0173c R E 0x10000
  LOAD           0x0097bc 0x000497bc 0x000497bc 0x001ec 0x001ec R   0x10000
  LOAD           0x00a000 0x1000a000 0x000499a8 0x00100 0x00100 RW  0x10000
  GNU_STACK      0x000000 0x00000000 0x00000000 0x00000 0x00000 RW  0x0

 Section to Segment mapping:
  Segment Sections...
   00
   01
   02     .start .text
   03     .rodata
   04     .stack
   05
```

These elfs are undesirable. This patch allows the linker to check if this case is going to happen.

The fix is adding 

```rust
println!("cargo:rustc-link-arg=-zmax-page-size=4096");
```
to build.rs.