### PR TITLE
readme: add MSRV

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ This script does the following steps for you:
 - create a TAB (tock application bundle)
 - if you have a J-Link compatible board connected: flash this TAB to your board (using tockloader)
 
+## Minimum Supported Rust Version (MSRV)
+
+`libtock-rs` requires Rust 1.59 or higher.
 
 ## License
 


### PR DESCRIPTION
This seems to be pretty standard with Rust crates. Given that we are 1.5 years from the release of 1.59, just documenting this is probably good enough without changes to the build infrastructure.

I don't actually know that we don't need a newer version, but #394 indicates we need 1.59.

Fixes #394.