### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -39,7 +39,7 @@ jobs:
           make -j2 EXAMPLE=low_level_debug nrf52
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: libtock-rs examples
           path: target/tbf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       # scripts, but we do not recursively checkout submodules as we need Tock's
       # makefile to set up the qemu submodule itself.
       - name: Clone repository
-        uses: actions/checkout@v2.3.0
+        uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -15,7 +15,7 @@ jobs:
       # Clones a single commit from the libtock-rs repository. The commit cloned
       # is a merge commit between the PR's target branch and the PR's source.
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and Test
         run: |

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -25,7 +25,7 @@ jobs:
       # We'll later add another commit (the pre-merge target branch) to the
       # repository.
       - name: Clone repository
-        uses: actions/checkout@v2.3.0
+        uses: actions/checkout@v3
 
       # The main diff script. Stores the sizes of the example binaries for both
       # the merge commit and the target branch. We display the diff in a


### PR DESCRIPTION
Similarly to https://github.com/tock/tock/pull/3591, this PR updates the versions of dependencies used in GitHub Actions to avoid the removal of Node v12 on Monday.

Two of the workflows are fixed on `ubuntu-20.04` for stability, although I think GitHub will also remove Node v12 from these runners too. There's no harm in updating them either way if they still work.