### PR TITLE
build/make: set the page size

### DIFF
--- a/build_scripts/src/lib.rs
+++ b/build_scripts/src/lib.rs
@@ -175,6 +175,11 @@ pub fn auto_layout() {
     // Tell rustc which linker script to use and where to find it.
     println!("cargo:rustc-link-arg=-T{}", layout_path.display());
     println!("cargo:rustc-link-search={}", out_dir);
+
+    // Configure the alignment size for the linker. This prevents the linker
+    // from assuming very large pages (i.e. 65536 bytes) and unnecessarily
+    // inserting additional padding into the output ELF.
+    println!("cargo:rustc-link-arg=-zmax-page-size=4096");
 }
 
 // Retrieves an environment variable as a String. Returns None if the variable


### PR DESCRIPTION
Without setting this, lld seems to assume 0x10000 sized pages and tries to align the output segments to 0x10000. This often causes elfs with large padding regions before the first segment we actually want to load on the board.

See https://github.com/tock/elf2tab/pull/75 for further discussion.