### PR TITLE
Use the `rust-version` field in Cargo.toml to set minimum Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0 OR MIT"
 name = "libtock"
 repository = "https://www.github.com/tock/libtock-rs"
 version = "0.1.0"
+# Minimum required Rust compiler version for libtock-rs.
+# Aug 2023: Set to support `Result::is_ok_and()`.
+rust-version = "1.70"
 
 [dependencies]
 libtock_adc = { path = "apis/adc"}


### PR DESCRIPTION
This encodes the minimum version so that the tooling will verify the user has a new enough Rust.

Set based on the needs from #498.

Fixes #394. Supersedes #499.