### PR TITLE
Makefile: use /usr/bin/env bash in favor of /bin/bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Make uses /bin/sh by default, which is a different shell on different OSes.
 # Specify Bash instead so we don't have to test against a variety of shells.
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # By default, let's print out some help
 .PHONY: usage


### PR DESCRIPTION
Not all systems have a /bin/bash (e.g., NixOS). Using either /usr/bin/env to look for an appropriate shell binary in the PATH, or using /bin/sh directly is more reliable and portable.

Fixes #504.