### PR TITLE
workflows/artifacts: use stable rustc to install elf2tab

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -12,7 +12,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cargo install elf2tab
+          rustup install stable
+          cargo +stable install elf2tab
 
       - name: Build LEDs
         run: |


### PR DESCRIPTION
This applies the same hack of tock/libtock-rs#486 to work around our current rust-toolchain being too old to build elf2tab.