### PR TITLE
Update the Rust toolchain to `nightly-2023-08-22`.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 [toolchain]
 # See https://rust-lang.github.io/rustup-components-history/ for a list of
 # recently nightlies and what components are available for them.
-channel = "nightly-2022-06-10"
+channel = "nightly-2023-08-22"
 components = ["clippy", "miri", "rustfmt"]
 targets = ["thumbv6m-none-eabi",
            "thumbv7em-none-eabi",

--- a/unittest/Cargo.toml
+++ b/unittest/Cargo.toml
@@ -10,4 +10,4 @@ version = "0.1.0"
 
 [dependencies]
 libtock_platform = { path = "../platform" }
-thiserror = "1.0"
+thiserror = "1.0.44"


### PR DESCRIPTION
The semantics of int-to-pointer casts under strict provenance has changed. Ideally, we would update our `From<usize> for Register` implementation to use the `sptr` crate, but `sptr` does not currently have a suitable license. There is a [PR](https://github.com/Gankra/sptr/pull/14) to change that, but it hasn't gotten a response in 7 months, so I don't think we can use it. Instead, this copies the implementation of `core::ptr::invalid`.

This also bumps our `thiserror` dependency, which forces Cargo to pick a newer version of `proc-macro2` that is compatible with recently nightly toolchains.