### PR TITLE
RFC: Use stable Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,8 @@ endif
 .PHONY: setup
 setup: setup-qemu
 	rustup install stable
-	cargo +stable install elf2tab
-	cargo miri setup
-	rustup target add --toolchain stable thumbv7em-none-eabi
+	cargo install elf2tab
+	cargo +nightly miri setup
 
 # Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
 # patches to better support boards that Tock supports.
@@ -108,19 +107,8 @@ EXCLUDE_STD := --exclude libtock_unittest --exclude print_sizes \
                --exclude runner --exclude syscalls_tests \
                --exclude libtock_build_scripts
 
-# Currently, all of our crates should build with a stable toolchain. This
-# verifies our crates don't depend on unstable features by using cargo check. We
-# specify a different target directory so this doesn't flush the cargo cache of
-# the primary toolchain.
-.PHONY: test-stable
-test-stable:
-	cargo +stable check --target-dir=target/stable --workspace \
-		$(EXCLUDE_RUNTIME)
-	LIBTOCK_PLATFORM=nrf52 cargo +stable check $(EXCLUDE_STD) \
-		--target=thumbv7em-none-eabi --target-dir=target/stable --workspace
-
 .PHONY: test
-test: examples test-stable
+test: examples
 	cargo test $(EXCLUDE_RUNTIME) --workspace
 	LIBTOCK_PLATFORM=nrf52 cargo fmt --all -- --check
 	cargo clippy --all-targets $(EXCLUDE_RUNTIME) --workspace
@@ -129,7 +117,7 @@ test: examples test-stable
 	LIBTOCK_PLATFORM=hifive1 cargo clippy $(EXCLUDE_STD) \
 		--target=riscv32imac-unknown-none-elf --workspace
 	MIRIFLAGS="-Zmiri-strict-provenance -Zmiri-symbolic-alignment-check" \
-		cargo miri test $(EXCLUDE_MIRI) --workspace
+		cargo +nightly miri test $(EXCLUDE_MIRI) --workspace
 	echo '[ SUCCESS ] libtock-rs tests pass'
 
 # Helper functions to define make targets to build for specific (flash, ram,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,7 +1,7 @@
 [toolchain]
 # See https://rust-lang.github.io/rustup-components-history/ for a list of
 # recently nightlies and what components are available for them.
-channel = "nightly-2022-06-10"
+channel = "nightly-2023-08-22"
 components = ["clippy", "miri", "rustfmt"]
 targets = ["thumbv6m-none-eabi",
            "thumbv7em-none-eabi",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,8 +1,6 @@
 [toolchain]
-# See https://rust-lang.github.io/rustup-components-history/ for a list of
-# recently nightlies and what components are available for them.
-channel = "nightly-2023-08-22"
-components = ["clippy", "miri", "rustfmt"]
+channel = "stable"
+components = ["clippy", "rustfmt"]
 targets = ["thumbv6m-none-eabi",
            "thumbv7em-none-eabi",
            "riscv32imac-unknown-none-elf",

--- a/unittest/Cargo.toml
+++ b/unittest/Cargo.toml
@@ -10,4 +10,4 @@ version = "0.1.0"
 
 [dependencies]
 libtock_platform = { path = "../platform" }
-thiserror = "1.0"
+thiserror = "1.0.44"


### PR DESCRIPTION
Opening this on top of #511 as an idea to switch to using stable rust. Since we don't have to chase specific nightly versions, it seems like a good idea to just use stable rust with a minimum version for specific features we want.

But, this toolchain selection seems very confusing because again rust seems like it doesn't _really_ support cross-compiling. What we want are very separate ways to specify the toolchain for building for embedded targets from ways to specify the toolchain for running host-side tests. It remains perplexing to me that rust still doesn't really seem to take this seriously.

Specifically, I don't know how to tell cargo "use nightly, but use a nightly with miri available". Maybe it does this automatically since we are running a miri command? I don't know.