### PR TITLE
apis: update breaking driver existence check changes

### DIFF
--- a/apis/adc/src/lib.rs
+++ b/apis/adc/src/lib.rs
@@ -11,11 +11,11 @@ impl<S: Syscalls> Adc<S> {
     /// Returns Ok() if the driver was present.This does not necessarily mean
     /// that the driver is working.
     pub fn exists() -> Result<(), ErrorCode> {
-        // Note! The "exists" command should return directly return `Result<(),
-        // ErrorCode>` (i.e. with no `.and()` call), but the current ADC driver
-        // in the kernel returns the number of ADC channels instead of just
-        // success. This will be fixed in a future release of Tock, but for now
-        // we workaround this issue.
+        // TODO(Tock 3.0): The "exists" command should return directly return
+        // `Result<(), ErrorCode>` (i.e. with no `.and()` call), but the
+        // current ADC driver in the kernel returns the number of ADC channels
+        // instead of just success. This will be fixed in a future release of
+        // Tock, but for now we workaround this issue.
         //
         // https://github.com/tock/tock/issues/3375
         S::command(DRIVER_NUM, EXISTS, 0, 0)

--- a/apis/adc/src/tests.rs
+++ b/apis/adc/src/tests.rs
@@ -11,7 +11,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::Adc::new();
     kernel.add_driver(&driver);

--- a/apis/air_quality/src/tests.rs
+++ b/apis/air_quality/src/tests.rs
@@ -12,7 +12,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::AirQuality::new();
     kernel.add_driver(&driver);

--- a/apis/alarm/src/lib.rs
+++ b/apis/alarm/src/lib.rs
@@ -60,8 +60,8 @@ impl Convert for Milliseconds {
 impl<S: Syscalls, C: platform::subscribe::Config> Alarm<S, C> {
     /// Run a check against the console capsule to ensure it is present.
     #[inline(always)]
-    pub fn driver_check() -> Result<(), ErrorCode> {
-        S::command(DRIVER_NUM, command::DRIVER_CHECK, 0, 0).to_result()
+    pub fn exists() -> Result<(), ErrorCode> {
+        S::command(DRIVER_NUM, command::EXISTS, 0, 0).to_result()
     }
 
     pub fn get_frequency() -> Result<Hz, ErrorCode> {
@@ -104,7 +104,7 @@ const DRIVER_NUM: u32 = 0;
 // Command IDs
 #[allow(unused)]
 mod command {
-    pub const DRIVER_CHECK: u32 = 0;
+    pub const EXISTS: u32 = 0;
     pub const FREQUENCY: u32 = 1;
     pub const TIME: u32 = 2;
     pub const STOP: u32 = 3;

--- a/apis/ambient_light/src/tests.rs
+++ b/apis/ambient_light/src/tests.rs
@@ -13,7 +13,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::AmbientLight::new();
     kernel.add_driver(&driver);

--- a/apis/buzzer/src/tests.rs
+++ b/apis/buzzer/src/tests.rs
@@ -11,7 +11,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::Buzzer::new();
     kernel.add_driver(&driver);

--- a/apis/console/src/lib.rs
+++ b/apis/console/src/lib.rs
@@ -31,8 +31,8 @@ impl<S: Syscalls, C: Config> Console<S, C> {
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
     #[inline(always)]
-    pub fn driver_check() -> bool {
-        S::command(DRIVER_NUM, command::DRIVER_CHECK, 0, 0).is_success()
+    pub fn exists() -> bool {
+        S::command(DRIVER_NUM, command::EXISTS, 0, 0).is_success()
     }
 
     /// Writes bytes.
@@ -142,7 +142,7 @@ const DRIVER_NUM: u32 = 1;
 // Command IDs
 #[allow(unused)]
 mod command {
-    pub const DRIVER_CHECK: u32 = 0;
+    pub const EXISTS: u32 = 0;
     pub const WRITE: u32 = 1;
     pub const READ: u32 = 2;
     pub const ABORT: u32 = 3;

--- a/apis/console/src/tests.rs
+++ b/apis/console/src/tests.rs
@@ -8,16 +8,16 @@ type Console = super::Console<fake::Syscalls>;
 #[test]
 fn no_driver() {
     let _kernel = fake::Kernel::new();
-    assert!(!Console::driver_check());
+    assert!(!Console::exists());
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::Console::new();
     kernel.add_driver(&driver);
 
-    assert!(Console::driver_check());
+    assert!(Console::exists());
     assert_eq!(driver.take_bytes(), &[]);
 }
 

--- a/apis/gpio/src/lib.rs
+++ b/apis/gpio/src/lib.rs
@@ -56,11 +56,13 @@ impl Pull for PullNone {
 pub struct Gpio<S: Syscalls>(S);
 
 impl<S: Syscalls> Gpio<S> {
-    /// Run a check against the gpio capsule to ensure it is present.
-    ///
-    /// Returns true` if the driver was present. This does not necessarily mean
+    /// Returns Ok() if the driver was present.This does not necessarily mean
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
+    pub fn exists() -> Result<(), ErrorCode> {
+        S::command(DRIVER_NUM, EXISTS, 0, 0).to_result()
+    }
+
     pub fn count() -> Result<u32, ErrorCode> {
         S::command(DRIVER_NUM, GPIO_COUNT, 0, 0).to_result()
     }
@@ -239,7 +241,7 @@ mod tests;
 const DRIVER_NUM: u32 = 4;
 
 // Command IDs
-const GPIO_COUNT: u32 = 0;
+const EXISTS: u32 = 0;
 
 const GPIO_ENABLE_OUTPUT: u32 = 1;
 const GPIO_SET: u32 = 2;
@@ -253,3 +255,5 @@ const GPIO_ENABLE_INTERRUPTS: u32 = 7;
 const GPIO_DISABLE_INTERRUPTS: u32 = 8;
 
 const GPIO_DISABLE: u32 = 9;
+
+const GPIO_COUNT: u32 = 10;

--- a/apis/leds/src/tests.rs
+++ b/apis/leds/src/tests.rs
@@ -10,7 +10,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::Leds::<10>::new();
     kernel.add_driver(&driver);

--- a/apis/low_level_debug/src/lib.rs
+++ b/apis/low_level_debug/src/lib.rs
@@ -25,8 +25,8 @@ impl<S: Syscalls> LowLevelDebug<S> {
     /// that the driver is working, as it may still fail to allocate grant
     /// memory.
     #[inline(always)]
-    pub fn driver_check() -> bool {
-        S::command(DRIVER_NUM, DRIVER_CHECK, 0, 0).is_success()
+    pub fn exists() -> bool {
+        S::command(DRIVER_NUM, EXISTS, 0, 0).is_success()
     }
 
     /// Print one of the predefined alerts in [`AlertCode`].
@@ -76,7 +76,7 @@ mod tests;
 const DRIVER_NUM: u32 = 8;
 
 // Command IDs
-const DRIVER_CHECK: u32 = 0;
+const EXISTS: u32 = 0;
 const PRINT_ALERT_CODE: u32 = 1;
 const PRINT_1: u32 = 2;
 const PRINT_2: u32 = 3;

--- a/apis/low_level_debug/src/tests.rs
+++ b/apis/low_level_debug/src/tests.rs
@@ -7,16 +7,16 @@ type LowLevelDebug = super::LowLevelDebug<fake::Syscalls>;
 #[test]
 fn no_driver() {
     let _kernel = fake::Kernel::new();
-    assert!(!LowLevelDebug::driver_check());
+    assert!(!LowLevelDebug::exists());
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::LowLevelDebug::new();
     kernel.add_driver(&driver);
 
-    assert!(LowLevelDebug::driver_check());
+    assert!(LowLevelDebug::exists());
     assert_eq!(driver.take_messages(), []);
 }
 

--- a/apis/ninedof/src/tests.rs
+++ b/apis/ninedof/src/tests.rs
@@ -13,7 +13,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::NineDof::new();
     kernel.add_driver(&driver);

--- a/apis/proximity/src/tests.rs
+++ b/apis/proximity/src/tests.rs
@@ -11,7 +11,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::Proximity::new();
     kernel.add_driver(&driver);

--- a/apis/sound_pressure/src/tests.rs
+++ b/apis/sound_pressure/src/tests.rs
@@ -11,7 +11,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::SoundPressure::new();
     kernel.add_driver(&driver);

--- a/apis/temperature/src/tests.rs
+++ b/apis/temperature/src/tests.rs
@@ -11,7 +11,7 @@ fn no_driver() {
 }
 
 #[test]
-fn driver_check() {
+fn exists() {
     let kernel = fake::Kernel::new();
     let driver = fake::Temperature::new();
     kernel.add_driver(&driver);

--- a/unittest/src/fake/alarm/mod.rs
+++ b/unittest/src/fake/alarm/mod.rs
@@ -67,7 +67,7 @@ const DRIVER_NUM: u32 = 0;
 // Command IDs
 #[allow(unused)]
 pub mod command {
-    pub const DRIVER_CHECK: u32 = 0;
+    pub const EXISTS: u32 = 0;
     pub const FREQUENCY: u32 = 1;
     pub const TIME: u32 = 2;
     pub const STOP: u32 = 3;

--- a/unittest/src/fake/console/mod.rs
+++ b/unittest/src/fake/console/mod.rs
@@ -79,7 +79,7 @@ impl crate::fake::SyscallDriver for Console {
 
     fn command(&self, command_num: u32, argument0: u32, _argument1: u32) -> CommandReturn {
         match command_num {
-            DRIVER_CHECK => {}
+            EXISTS => {}
             WRITE => {
                 let mut bytes = self.messages.take();
                 let buffer = self.buffer.take();
@@ -121,7 +121,7 @@ mod tests;
 const DRIVER_NUM: u32 = 1;
 
 // Command numbers
-const DRIVER_CHECK: u32 = 0;
+const EXISTS: u32 = 0;
 const WRITE: u32 = 1;
 const READ: u32 = 2;
 //const ABORT: u32 = 3;

--- a/unittest/src/fake/console/tests.rs
+++ b/unittest/src/fake/console/tests.rs
@@ -8,9 +8,7 @@ use libtock_platform::DefaultConfig;
 fn command() {
     use fake::SyscallDriver;
     let console = fake::Console::new();
-    assert!(console
-        .command(fake::console::DRIVER_CHECK, 1, 2)
-        .is_success());
+    assert!(console.command(fake::console::EXISTS, 1, 2).is_success());
     assert!(console.allow_readonly(1, RoAllowBuffer::default()).is_ok());
     assert!(console.allow_readonly(2, RoAllowBuffer::default()).is_err());
 
@@ -29,7 +27,7 @@ fn kernel_integration() {
     let console = fake::Console::new();
     kernel.add_driver(&console);
     assert!(
-        fake::Syscalls::command(fake::console::DRIVER_NUM, fake::console::DRIVER_CHECK, 1, 2)
+        fake::Syscalls::command(fake::console::DRIVER_NUM, fake::console::EXISTS, 1, 2)
             .is_success()
     );
     share::scope(|allow_ro| {

--- a/unittest/src/fake/gpio/mod.rs
+++ b/unittest/src/fake/gpio/mod.rs
@@ -146,7 +146,9 @@ impl<const NUM_GPIOS: usize> crate::fake::SyscallDriver for Gpio<NUM_GPIOS> {
     }
 
     fn command(&self, command_number: u32, argument0: u32, argument1: u32) -> CommandReturn {
-        if command_number == GPIO_COUNT {
+        if command_number == EXISTS {
+            crate::command_return::success()
+        } else if command_number == GPIO_COUNT {
             crate::command_return::success_u32(NUM_GPIOS as u32)
         } else if argument0 < NUM_GPIOS as u32 {
             if self.gpios[argument0 as usize].get().is_some() {
@@ -254,7 +256,7 @@ mod tests;
 const DRIVER_NUM: u32 = 4;
 
 // Command IDs
-const GPIO_COUNT: u32 = 0;
+const EXISTS: u32 = 0;
 
 const GPIO_ENABLE_OUTPUT: u32 = 1;
 const GPIO_SET: u32 = 2;
@@ -268,3 +270,5 @@ const GPIO_ENABLE_INTERRUPTS: u32 = 7;
 const GPIO_DISABLE_INTERRUPTS: u32 = 8;
 
 const GPIO_DISABLE: u32 = 9;
+
+const GPIO_COUNT: u32 = 10;

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -33,7 +33,7 @@ impl<const LEDS_COUNT: usize> crate::fake::SyscallDriver for Leds<LEDS_COUNT> {
 
     fn command(&self, command_num: u32, argument0: u32, _argument1: u32) -> CommandReturn {
         match command_num {
-            DRIVER_CHECK => crate::command_return::success_u32(LEDS_COUNT as u32),
+            EXISTS => crate::command_return::success_u32(LEDS_COUNT as u32),
             LED_ON => {
                 if argument0 < LEDS_COUNT as u32 {
                     self.leds[argument0 as usize].set(true);
@@ -73,7 +73,7 @@ mod tests;
 const DRIVER_NUM: u32 = 2;
 
 // Command numbers
-const DRIVER_CHECK: u32 = 0;
+const EXISTS: u32 = 0;
 const LED_ON: u32 = 1;
 const LED_OFF: u32 = 2;
 const LED_TOGGLE: u32 = 3;

--- a/unittest/src/fake/leds/tests.rs
+++ b/unittest/src/fake/leds/tests.rs
@@ -7,7 +7,7 @@ use libtock_platform::ErrorCode;
 fn command() {
     use fake::SyscallDriver;
     let leds = Leds::<10>::new();
-    let value = leds.command(DRIVER_CHECK, 1, 2);
+    let value = leds.command(EXISTS, 1, 2);
     assert_eq!(value.get_success_u32(), Some(10));
     assert_eq!(
         leds.command(LED_ON, 11, 0).get_failure(),
@@ -32,7 +32,7 @@ fn kernel_integration() {
     let kernel = fake::Kernel::new();
     let leds = Leds::<10>::new();
     kernel.add_driver(&leds);
-    let value = fake::Syscalls::command(DRIVER_NUM, DRIVER_CHECK, 1, 2);
+    let value = fake::Syscalls::command(DRIVER_NUM, EXISTS, 1, 2);
     assert!(value.is_success_u32());
     assert_eq!(value.get_success_u32(), Some(10));
     assert_eq!(

--- a/unittest/src/fake/low_level_debug/mod.rs
+++ b/unittest/src/fake/low_level_debug/mod.rs
@@ -33,7 +33,7 @@ impl crate::fake::SyscallDriver for LowLevelDebug {
 
     fn command(&self, command_num: u32, argument0: u32, argument1: u32) -> CommandReturn {
         match command_num {
-            DRIVER_CHECK => {}
+            EXISTS => {}
             PRINT_ALERT_CODE => self.handle_message(Message::AlertCode(argument0)),
             PRINT_1 => self.handle_message(Message::Print1(argument0)),
             PRINT_2 => self.handle_message(Message::Print2(argument0, argument1)),
@@ -72,7 +72,7 @@ mod tests;
 const DRIVER_NUM: u32 = 8;
 
 // Command numbers
-const DRIVER_CHECK: u32 = 0;
+const EXISTS: u32 = 0;
 const PRINT_ALERT_CODE: u32 = 1;
 const PRINT_1: u32 = 2;
 const PRINT_2: u32 = 3;

--- a/unittest/src/fake/low_level_debug/tests.rs
+++ b/unittest/src/fake/low_level_debug/tests.rs
@@ -6,7 +6,7 @@ use fake::low_level_debug::*;
 fn command() {
     use fake::SyscallDriver;
     let low_level_debug = LowLevelDebug::new();
-    assert!(low_level_debug.command(DRIVER_CHECK, 1, 2).is_success());
+    assert!(low_level_debug.command(EXISTS, 1, 2).is_success());
     assert!(low_level_debug.command(PRINT_ALERT_CODE, 3, 4).is_success());
     assert_eq!(low_level_debug.take_messages(), [Message::AlertCode(3)]);
     assert!(low_level_debug.command(PRINT_1, 5, 6).is_success());
@@ -25,7 +25,7 @@ fn kernel_integration() {
     let kernel = fake::Kernel::new();
     let low_level_debug = LowLevelDebug::new();
     kernel.add_driver(&low_level_debug);
-    assert!(fake::Syscalls::command(DRIVER_NUM, DRIVER_CHECK, 1, 2).is_success());
+    assert!(fake::Syscalls::command(DRIVER_NUM, EXISTS, 1, 2).is_success());
     assert!(fake::Syscalls::command(DRIVER_NUM, PRINT_ALERT_CODE, 3, 4).is_success());
     assert_eq!(low_level_debug.take_messages(), [Message::AlertCode(3)]);
     assert!(fake::Syscalls::command(DRIVER_NUM, PRINT_1, 5, 6).is_success());


### PR DESCRIPTION
Bring libtock-rs into consistency with the changes in [this PR](https://github.com/tock/tock/pull/3613/).

Only `apis/gpio/src/lib.rs` needed to be changed. The rest is a grepped driver_check -> exists.