### PR TITLE
Bump the Rust MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [workspace.package]
 # This must be kept in sync with rust-toolchain.toml; please see that file for
 # more information.
-rust-version = "1.70"
+rust-version = "1.74"
 
 [dependencies]
 libtock_adc = { path = "apis/adc" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # you'd like to use. When you do so, update this to the first Rust version that
 # includes that feature. Whenever this value is updated, the rust-version field
 # in Cargo.toml must be updated as well.
-channel = "1.70"
+channel = "1.74"
 components = ["clippy", "rustfmt"]
 targets = ["thumbv6m-none-eabi",
            "thumbv7em-none-eabi",


### PR DESCRIPTION
We are starting to see failures with our current version of Rust [1] when building elf2tab.

We could look at pinning an older elf2tab, but that brings with it a range of issues. Instead let's bump our MSRV to a newer stable.

1: https://github.com/tock/libtock-rs/pull/533#issuecomment-1944945234