### PR TITLE
make: enable make tab on stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ endif
 
 ifndef DEBUG
 release=--release
+artifact_dir=release
+else
+artifact_dir=debug
 endif
 
 # Rustup currently lacks the locking needed for concurrent use:
@@ -187,7 +190,9 @@ $(call fixed-target, F=0x10020000 R=0x20004000 T=thumbv6m-none-eabi A=cortex-m0)
 $(call fixed-target, F=0x10028000 R=0x2000c000 T=thumbv6m-none-eabi A=cortex-m0)
 
 $(ELF_TARGETS): toolchain
-	LIBTOCK_LINKER_FLASH=$(F) LIBTOCK_LINKER_RAM=$(R) cargo build --example $(EXAMPLE) $(features) --target=$(T) $(release) --out-dir target/$(A).$(F).$(R) -Z unstable-options
+	LIBTOCK_LINKER_FLASH=$(F) LIBTOCK_LINKER_RAM=$(R) cargo build --example $(EXAMPLE) $(features) --target=$(T) $(release)
+	@mkdir -p target/$(A).$(F).$(R)/
+	@cp target/$(T)/$(artifact_dir)/examples/$(EXAMPLE) target/$(A).$(F).$(R)/
 	$(eval ELF_LIST += target/$(A).$(F).$(R)/$(EXAMPLE),$(A).$(F).$(R))
 
 .PHONY: tab


### PR DESCRIPTION
This removes `--out-dir <dir> -Z unstable-options` so that `make tab` works with the stable toolchain.

Unfortunately without --out-dir we cannot run `make tab` with parallel builds. But given this has been an issue for about 7 months, no one uses this command anyway.