### PR TITLE
fixed RAM memory layout for nano33ble

### DIFF
--- a/build_scripts/src/lib.rs
+++ b/build_scripts/src/lib.rs
@@ -22,7 +22,7 @@ const PLATFORMS: &[(&str, &str, &str, &str, &str)] = &[
     ("raspberry_pi_pico"  , "0x10040000", "256K"     , "0x20012000", "192K"   ),
     ("stm32f3discovery"   , "0x08020000", "0x0020000", "0x20004000", "48K"    ),
     ("stm32f412gdiscovery", "0x08030000", "256K"     , "0x20004000", "112K"   ),
-    ("nano33ble"          , "0x00050000", "704K"     , "0x20000000", "256K"   ),
+    ("nano33ble"          , "0x00050000", "704K"     , "0x20005000", "240K"   ),
 ];
 
 /// Helper function to configure cargo to use suitable linker scripts for


### PR DESCRIPTION
Hi!

I'm really sorry, last pull request: #537  was not completed as there is a little portion of RAM already in use.

Ram layout for applications in Arduino Nano33ble starts in 0x20005000

![Captura desde 2024-03-14 10-45-34](https://github.com/tock/libtock-rs/assets/10772286/8f8b80e8-9b3b-40c2-9b44-532d24c08689)

Now, the first application compiles and can be loadable in a nano33ble board.

Cheers