### PR TITLE
Bump Rust to version 1.75

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [workspace.package]
 # This must be kept in sync with rust-toolchain.toml; please see that file for
 # more information.
-rust-version = "1.74"
+rust-version = "1.75"
 
 [dependencies]
 libtock_adc = { path = "apis/adc" }

--- a/nightly/rust-toolchain.toml
+++ b/nightly/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # This is the nightly Rust toolchain used by `make test`.
 [toolchain]
-channel = "nightly-2023-08-22"
+channel = "nightly-2024-04-19"
 components = ["miri", "rust-src"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # you'd like to use. When you do so, update this to the first Rust version that
 # includes that feature. Whenever this value is updated, the rust-version field
 # in Cargo.toml must be updated as well.
-channel = "1.74"
+channel = "1.75"
 components = ["clippy", "rustfmt"]
 targets = ["thumbv6m-none-eabi",
            "thumbv7em-none-eabi",


### PR DESCRIPTION
When trying to build embedded-hal-async we get this error

    error: package `embedded-hal-async v1.0.0` cannot be built because
    it requires rustc 1.75 or newer, while the currently active rustc
    version is 1.74.1

So let's upgrade to 1.75 to allow us to build embedded-hal-async.