### PR TITLE
doc: overview: remove outdated list

### DIFF
--- a/doc/Overview.md
+++ b/doc/Overview.md
@@ -59,12 +59,4 @@ panic handler for binaries that depend on it). The following crates provide a
 
 ## Driver crates
 
-Driver crates provide interfaces to specific Tock APIs:
-
-| Crate                   | Tock API        |
-|-------------------------|-----------------|
-|`libtock_console`        |[Console]        |
-|`libtock_low_level_debug`|[Low-Level Debug]|
-
-[Console]: https://github.com/tock/tock/blob/master/doc/syscalls/00001_console.md
-[Low-Level Debug]: https://github.com/tock/tock/blob/master/doc/syscalls/00008_low_level_debug.md
+Driver crates provide interfaces to specific Tock APIs in the `/apis` directory.


### PR DESCRIPTION
We could try to add all of the drivers to the table, but that will probably never stay up-to-date, so perhaps it's better to just remove the table and point readers in the right direction.

I don't feel strongly about this, perhaps it's better for someone to write a script to populate this table.