### PR TITLE
Simple size optimization flags for Cargo by default

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,5 +10,6 @@ rtv7em = "rthumbv7em"
 [target.'cfg(any(target_arch = "arm", target_arch = "riscv32"))']
 rustflags = [
     "-C", "relocation-model=static",
+    "-C", "link-arg=-icf=all",
 ]
 runner = ["cargo", "run", "-p", "runner", "--release"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ panic = "abort"
 debug = true
 lto = true
 panic = "abort"
+opt-level = "z"
+codegen-units = 1
 
 [workspace]
 exclude = ["tock"]


### PR DESCRIPTION
Very simply add three Cargo flags by default that seem to have a reasonable impact on code size in many examples, all used in the kernel as well:

1. `opt-level = "z"` is LLVM's `-Os`, i.e., optimize for size not speed, please. This seems to help in all but very small examples (under 1k)
2. `codegen-units = 1` restricts Cargo from splitting crates up during compilation and in general should improve LTO the cost is slower compile times. In practice, this doesn't seem to make a difference in this repo for now, so this is mostly a forward thinking precaution.
3. `"-C link-arg=-icf=all" combines identical compiled procedures. Seems to have marginal benefit.