### PR TITLE
Enable `small_panic` in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ libtock_platform = { path = "platform" }
 libtock_proximity = { path = "apis/sensors/proximity" }
 libtock_rng = { path = "apis/peripherals/rng" }
 libtock_runtime = { path = "runtime" }
+libtock_small_panic = { path = "panic_handlers/small_panic" }
 libtock_sound_pressure = { path = "apis/sensors/sound_pressure" }
 libtock_spi_controller = { path = "apis/peripherals/spi_controller" }
 libtock_temperature = { path = "apis/sensors/temperature" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![forbid(unsafe_code)]
 #![no_std]
 
+#[cfg(debug_assertions)]
 extern crate libtock_debug_panic;
+#[cfg(not(debug_assertions))]
+extern crate libtock_small_panic;
 
 pub use libtock_platform as platform;
 pub use libtock_runtime as runtime;


### PR DESCRIPTION
`panic_handler/small_panic` is significantly smaller than the current default `panic_handler/debug_panic` since it doesn't bother formatting a panic message, instead using the low-level-debugger and exiting.

However, it's not actually used anywhere (maybe downstream?)!

This PR uses `small_panic` in release mode and `debug_panic` in debug mode. There is a pretty substantial drop in code size for most examples.