### PR TITLE
Initial memop syscall implementation + tests

### DIFF
--- a/platform/src/register.rs
+++ b/platform/src/register.rs
@@ -8,7 +8,7 @@ use core::mem::transmute;
 /// wraps, but instead use the conversion functions in this module.
 // Register is repr(transparent) so that an upcall's application data can be
 // soundly passed as a Register.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct Register(pub *mut ());
 
@@ -24,6 +24,12 @@ impl From<crate::ErrorCode> for Register {
 
 impl From<u32> for Register {
     fn from(value: u32) -> Register {
+        (value as usize).into()
+    }
+}
+
+impl From<i32> for Register {
+    fn from(value: i32) -> Register {
         (value as usize).into()
     }
 }
@@ -71,6 +77,13 @@ impl Register {
     /// the `TryFrom<Register> for u32` implementation instead.
     pub fn as_u32(self) -> u32 {
         self.0 as u32
+    }
+
+    /// Casts this register to a i32, truncating it if it is larger than
+    /// 32 bits. This conversion should be avoided in host-based test code; use
+    /// the `TryFrom<Register> for i32` implementation instead.
+    pub fn as_i32(self) -> i32 {
+        self.0 as i32
     }
 }
 

--- a/platform/src/syscalls.rs
+++ b/platform/src/syscalls.rs
@@ -77,7 +77,42 @@ pub trait Syscalls: RawSyscalls + Sized {
     /// `unallow_ro` does nothing.
     fn unallow_ro(driver_num: u32, buffer_num: u32);
 
-    // TODO: Add memop() methods.
+    // -------------------------------------------------------------------------
+    // Memop
+    // -------------------------------------------------------------------------
+
+    /// Changes the location of the program break to the specified address and
+    /// returns an error if it fails to do so.
+    ///
+    /// # Safety
+    /// Callers of this function must ensure that they do not pass an
+    /// address below any address that includes a currently reachable object.
+    unsafe fn memop_brk(addr: *const u8) -> Result<(), ErrorCode>;
+
+    /// Changes the location of the program break by the passed increment,
+    /// and returns the previous break address.
+    ///
+    /// # Safety
+    /// Callers of this function must ensure that they do not pass an
+    /// increment that would deallocate memory containing any currently
+    /// reachable object.
+    unsafe fn memop_sbrk(incr: i32) -> Result<*const u8, ErrorCode>;
+
+    /// Increments the program break by the passed increment,
+    /// and returns the previous break address.
+    fn memop_increment_brk(incr: u32) -> Result<*const u8, ErrorCode>;
+
+    /// Gets the address of the start of this application's RAM allocation.
+    fn memop_app_ram_start() -> Result<*const u8, ErrorCode>;
+
+    /// Tells the kernel where the start of the app stack is, to support
+    /// debugging.
+    fn memop_debug_stack_start(stack_top: *const u8) -> Result<(), ErrorCode>;
+
+    /// Tells the kernel the initial program break, to support debugging.
+    fn memop_debug_heap_start(initial_break: *const u8) -> Result<(), ErrorCode>;
+
+    // TODO: Add remaining memop() methods (3-9).
 
     // -------------------------------------------------------------------------
     // Exit

--- a/syscalls_tests/src/lib.rs
+++ b/syscalls_tests/src/lib.rs
@@ -24,7 +24,8 @@ mod exit_on_drop;
 
 // TODO: Add Exit.
 
-// TODO: Add Memop.
+#[cfg(test)]
+mod memop_tests;
 
 #[cfg(test)]
 mod subscribe_tests;

--- a/syscalls_tests/src/memop_tests.rs
+++ b/syscalls_tests/src/memop_tests.rs
@@ -1,0 +1,152 @@
+//! Tests for the Memop system call implementation in
+//! `libtock_platform::Syscalls`.
+
+use libtock_platform::{ErrorCode, Syscalls};
+use libtock_unittest::{fake, ExpectedSyscall, SyscallLogEntry};
+
+#[test]
+fn memop() {
+    let kernel = fake::Kernel::new();
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 1,
+        argument0: 3.into(),
+        return_error: Some(ErrorCode::NoMem),
+    });
+    assert_eq!(
+        unsafe { fake::Syscalls::memop_sbrk(3) },
+        Err(ErrorCode::NoMem)
+    );
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::Memop {
+            memop_num: 1,
+            argument0: 3.into(),
+        }]
+    );
+}
+
+#[test]
+fn brk_test() {
+    let kernel = fake::Kernel::new();
+    let fake_mem_buf = [0; 8];
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 0,
+        argument0: fake_mem_buf.as_ptr().into(),
+        return_error: None,
+    });
+    assert_eq!(
+        unsafe { fake::Syscalls::memop_brk(fake_mem_buf.as_ptr()) },
+        Ok(())
+    );
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::Memop {
+            memop_num: 0,
+            argument0: fake_mem_buf.as_ptr().into(),
+        }]
+    );
+}
+
+#[test]
+fn sbrk_test() {
+    let kernel = fake::Kernel::new();
+    let fake_mem_buf = [0; 8];
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 0,
+        argument0: fake_mem_buf.as_ptr().into(),
+        return_error: None,
+    });
+    assert_eq!(
+        unsafe { fake::Syscalls::memop_brk(fake_mem_buf.as_ptr()) },
+        Ok(())
+    );
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 1,
+        argument0: 4.into(),
+        return_error: None,
+    });
+    assert_eq!(
+        unsafe { fake::Syscalls::memop_sbrk(4) },
+        Ok((&fake_mem_buf[4]) as *const u8)
+    );
+}
+
+#[test]
+fn increment_brk_test() {
+    let kernel = fake::Kernel::new();
+    let fake_mem_buf = [0; 8];
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 0,
+        argument0: fake_mem_buf.as_ptr().into(),
+        return_error: None,
+    });
+    assert_eq!(
+        unsafe { fake::Syscalls::memop_brk(fake_mem_buf.as_ptr()) },
+        Ok(())
+    );
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 1,
+        argument0: 4.into(),
+        return_error: None,
+    });
+    assert_eq!(
+        fake::Syscalls::memop_increment_brk(4),
+        Ok((&fake_mem_buf[4]) as *const u8)
+    );
+}
+
+#[test]
+fn app_ram_start_test() {
+    let kernel = fake::Kernel::new();
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 2,
+        argument0: 0.into(),
+        return_error: None,
+    });
+    assert!(fake::Syscalls::memop_app_ram_start().is_ok());
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::Memop {
+            memop_num: 2,
+            argument0: 0.into(),
+        }]
+    );
+}
+
+#[test]
+fn debug_stack_start_test() {
+    let kernel = fake::Kernel::new();
+    let fake_stack = [0; 8];
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 10,
+        argument0: fake_stack.as_ptr().into(),
+        return_error: None,
+    });
+    assert!(fake::Syscalls::memop_debug_stack_start(fake_stack.as_ptr()).is_ok());
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::Memop {
+            memop_num: 10,
+            argument0: fake_stack.as_ptr().into(),
+        }]
+    );
+}
+
+#[test]
+fn debug_heap_start_test() {
+    let kernel = fake::Kernel::new();
+    let fake_heap = [0; 8];
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 11,
+        argument0: fake_heap.as_ptr().into(),
+        return_error: None,
+    });
+    assert!(fake::Syscalls::memop_debug_heap_start(fake_heap.as_ptr()).is_ok());
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [SyscallLogEntry::Memop {
+            memop_num: 11,
+            argument0: fake_heap.as_ptr().into(),
+        }]
+    );
+}

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -1,3 +1,5 @@
+use libtock_platform::Register;
+
 /// Unit tests can use `ExpectedSyscall` to alter `fake::Kernel`'s behavior for
 /// a particular system call. An example use case is error injection: unit tests
 /// can add a `ExpectedSyscall` to the fake kernel's queue to insert errors in
@@ -70,7 +72,18 @@ pub enum ExpectedSyscall {
         // invoked and the provided error will be returned instead.
         return_error: Option<libtock_platform::ErrorCode>,
     },
-    // TODO: Add Memop.
+
+    // -------------------------------------------------------------------------
+    // Memop
+    // -------------------------------------------------------------------------
+    Memop {
+        memop_num: u32,
+        argument0: Register, // Necessary for Miri ptr provenance tests of brk
+
+        // If set to Some(_), the driver's memop method will not be
+        // invoked and the provided error will be returned instead.
+        return_error: Option<libtock_platform::ErrorCode>,
+    },
     // TODO: Add Exit.
 }
 

--- a/unittest/src/fake/kernel.rs
+++ b/unittest/src/fake/kernel.rs
@@ -37,6 +37,7 @@ impl Kernel {
                 expected_syscalls: Default::default(),
                 syscall_log: Vec::new(),
                 upcall_queue: Default::default(),
+                memory_break: core::ptr::null(),
             }))
         });
         if let Some(old_kernel_data) = old_option {

--- a/unittest/src/fake/syscalls/memop_impl.rs
+++ b/unittest/src/fake/syscalls/memop_impl.rs
@@ -1,0 +1,92 @@
+//! `fake::Kernel`'s implementation of the Memop system call.
+
+use crate::kernel_data::with_kernel_data;
+use crate::{ExpectedSyscall, SyscallLogEntry};
+use libtock_platform::{return_variant, ErrorCode, Register};
+use std::convert::TryInto;
+
+pub(super) fn memop(memop_num: Register, argument0: Register) -> [Register; 2] {
+    let memop_num = memop_num.try_into().expect("Too large memop num");
+
+    let (return_error, memop_return, memop_r1) = with_kernel_data(|option_kernel_data| {
+        let kernel_data = option_kernel_data.expect("Memop called but no fake::Kernel exists");
+
+        kernel_data.syscall_log.push(SyscallLogEntry::Memop {
+            memop_num,
+            argument0,
+        });
+
+        // Check for an expected syscall entry. Sets return_error to None if
+        // the expected syscall queue is empty or if it expected this syscall
+        // but did not specify a return override. Panics if a different syscall
+        // was expected (either a non-Memop syscall, or a Memop call with
+        // different arguments).
+        let return_error = match kernel_data.expected_syscalls.pop_front() {
+            None => None,
+            Some(ExpectedSyscall::Memop {
+                memop_num: expected_memop_num,
+                argument0: expected_argument0,
+                return_error,
+            }) => {
+                assert_eq!(
+                    memop_num, expected_memop_num,
+                    "expected different memop_num"
+                );
+                assert_eq!(
+                    usize::from(argument0),
+                    usize::from(expected_argument0),
+                    "expected different argument0"
+                );
+                return_error
+            }
+            Some(expected_syscall) => expected_syscall.panic_wrong_call("Memop"),
+        };
+
+        // Emulate the memop call
+        // TODO: This emulation could be improved by adding data to kernel_data to allow us to
+        // better track what input arguments might be expected to return errors.
+        let (memop_return, memop_r1) = match memop_num {
+            0 => {
+                /* brk */
+                if Into::<*const u8>::into(argument0).is_null() {
+                    (return_variant::FAILURE, ErrorCode::Invalid.into())
+                } else {
+                    kernel_data.memory_break = argument0.into();
+                    (return_variant::SUCCESS, 0.into())
+                }
+            }
+            1 => {
+                /* sbrk */
+                let current_brk = kernel_data.memory_break;
+                let new_brk = current_brk.wrapping_byte_offset(argument0.as_i32() as isize);
+                kernel_data.memory_break = new_brk;
+                (return_variant::SUCCESS, kernel_data.memory_break.into())
+            }
+            2 => {
+                /* app_ram_start */
+                // just pick a random number to always return, for now
+                (return_variant::SUCCESS, 0x123400.into())
+            }
+            10 => {
+                /* debug_stack_start */
+                (return_variant::SUCCESS, 0.into())
+            }
+            11 => {
+                /* debug_heap_start */
+                (return_variant::SUCCESS, 0.into())
+            }
+            _ => {
+                panic!("Memop num not supported by test infrastructure");
+            }
+        };
+        (return_error, memop_return, memop_r1)
+    });
+
+    // Convert the return value into the representative register values.
+    // If there is an return_error, return a Failure along with that ErrorCode.
+    let (return_variant, r1) = return_error.map_or((memop_return, memop_r1), |override_errcode| {
+        (return_variant::FAILURE, override_errcode.into())
+    });
+    let r0: u32 = return_variant.into();
+    [r0.into(), r1]
+}

--- a/unittest/src/fake/syscalls/memop_impl_tests.rs
+++ b/unittest/src/fake/syscalls/memop_impl_tests.rs
@@ -1,0 +1,84 @@
+use super::memop_impl::*;
+use crate::{fake, ExpectedSyscall};
+use libtock_platform::{return_variant, ErrorCode, ReturnVariant};
+use std::convert::TryInto;
+use std::panic::catch_unwind;
+
+// Tests memop with expected syscalls that don't match this memop call.
+#[test]
+fn expected_wrong_memop() {
+    let kernel = fake::Kernel::new();
+    let expected_syscall = ExpectedSyscall::Memop {
+        memop_num: 1,
+        argument0: 1u32.into(),
+        return_error: None,
+    };
+
+    kernel.add_expected_syscall(expected_syscall);
+    assert!(catch_unwind(|| memop(0u32.into(), 1u32.into()))
+        .expect_err("failed to catch wrong memop_num")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("expected different memop_num"));
+
+    kernel.add_expected_syscall(expected_syscall);
+    assert!(catch_unwind(|| memop(1u32.into(), 0u32.into()))
+        .expect_err("failed to catch wrong memop argument0")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("expected different argument0"));
+}
+
+#[test]
+fn no_kernel() {
+    let result = catch_unwind(|| memop(1u32.into(), 1u32.into()));
+    assert!(result
+        .expect_err("failed to catch missing kernel")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("no fake::Kernel exists"));
+}
+
+#[test]
+fn return_error() {
+    let kernel = fake::Kernel::new();
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 1,
+        argument0: 4u32.into(),
+        return_error: Some(ErrorCode::NoMem),
+    });
+    let [r0, r1] = memop(1u32.into(), 4u32.into());
+    let r0: u32 = r0.try_into().expect("too large r0");
+    let r1: u32 = r1.try_into().expect("too large r1");
+    let return_variant: ReturnVariant = r0.into();
+    assert_eq!(return_variant, return_variant::FAILURE);
+    assert_eq!(r1, ErrorCode::NoMem as u32);
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn too_large_memop_num() {
+    let _kernel = fake::Kernel::new();
+    let result = catch_unwind(|| memop((u32::MAX as usize + 1).into(), 1u32.into()));
+    assert!(result
+        .expect_err("failed to catch too-large memop num")
+        .downcast_ref::<String>()
+        .expect("wrong panic payload type")
+        .contains("Too large memop num"));
+}
+
+#[test]
+fn memop_using_syscall1() {
+    let kernel = fake::Kernel::new();
+    kernel.add_expected_syscall(ExpectedSyscall::Memop {
+        memop_num: 2,
+        argument0: 0u32.into(),
+        return_error: None,
+    });
+    let [r0, r1] = memop(2u32.into(), 0u32.into());
+    let r0: u32 = r0.try_into().expect("too large r0");
+    let _r1: u32 = r1.try_into().expect("too large r1");
+    let return_variant: ReturnVariant = r0.into();
+    assert_eq!(return_variant, return_variant::SUCCESS);
+    // No assertion for return value, could be any value from real kernel.
+}

--- a/unittest/src/fake/syscalls/mod.rs
+++ b/unittest/src/fake/syscalls/mod.rs
@@ -2,6 +2,7 @@ mod allow_ro_impl;
 mod allow_rw_impl;
 mod command_impl;
 mod exit_impl;
+mod memop_impl;
 mod raw_syscalls_impl;
 mod subscribe_impl;
 mod yield_impl;
@@ -19,6 +20,8 @@ mod allow_rw_impl_tests;
 mod command_impl_tests;
 #[cfg(all(not(miri), test))]
 mod exit_impl_tests;
+#[cfg(test)]
+mod memop_impl_tests;
 #[cfg(test)]
 mod raw_syscalls_impl_tests;
 #[cfg(test)]

--- a/unittest/src/fake/syscalls/raw_syscalls_impl.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl.rs
@@ -25,9 +25,9 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
         }
     }
 
-    unsafe fn syscall1<const CLASS: usize>([Register(_r0)]: [Register; 1]) -> [Register; 2] {
+    unsafe fn syscall1<const CLASS: usize>([r0]: [Register; 1]) -> [Register; 2] {
         match CLASS {
-            syscall_class::MEMOP => unimplemented!("TODO: Add Memop"),
+            syscall_class::MEMOP => super::memop_impl::memop(r0, 0u32.into()),
             _ => panic!("Unknown syscall1 call. Class: {}", CLASS),
         }
     }
@@ -35,7 +35,7 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
     unsafe fn syscall2<const CLASS: usize>([r0, r1]: [Register; 2]) -> [Register; 2] {
         crate::fake::syscalls::assert_valid((r0, r1));
         match CLASS {
-            syscall_class::MEMOP => unimplemented!("TODO: Add Memop"),
+            syscall_class::MEMOP => super::memop_impl::memop(r0, r1),
             syscall_class::EXIT => super::exit_impl::exit(r0, r1),
             _ => panic!("Unknown syscall2 call. Class: {}", CLASS),
         }

--- a/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl_tests.rs
@@ -52,7 +52,27 @@ fn allow_rw() {
 
 // TODO: Implement Exit.
 
-// TODO: Implement Memop.
+#[test]
+fn memop() {
+    let kernel = fake::Kernel::new();
+    unsafe {
+        fake::Syscalls::syscall2::<{ syscall_class::MEMOP }>([1u32.into(), 2u32.into()]);
+        fake::Syscalls::syscall1::<{ syscall_class::MEMOP }>([2u32.into()]);
+    }
+    assert_eq!(
+        kernel.take_syscall_log(),
+        [
+            SyscallLogEntry::Memop {
+                memop_num: 1,
+                argument0: 2.into(),
+            },
+            SyscallLogEntry::Memop {
+                memop_num: 2,
+                argument0: 0.into(),
+            }
+        ]
+    );
+}
 
 // TODO: Implement Subscribe.
 

--- a/unittest/src/kernel_data.rs
+++ b/unittest/src/kernel_data.rs
@@ -23,6 +23,7 @@ pub(crate) struct KernelData {
     pub expected_syscalls: std::collections::VecDeque<crate::ExpectedSyscall>,
     pub syscall_log: Vec<crate::SyscallLogEntry>,
     pub upcall_queue: crate::upcall::UpcallQueue,
+    pub memory_break: *const u8,
 }
 
 // KERNEL_DATA is set to Some in `fake::Kernel::new` and set to None when the

--- a/unittest/src/syscall_log.rs
+++ b/unittest/src/syscall_log.rs
@@ -1,3 +1,5 @@
+use libtock_platform::Register;
+
 /// SyscallLogEntry represents a system call made during test execution.
 #[derive(Debug, Eq, PartialEq)]
 pub enum SyscallLogEntry {
@@ -43,6 +45,13 @@ pub enum SyscallLogEntry {
         buffer_num: u32,
         len: usize,
     },
-    // TODO: Add Memop.
+
+    // -------------------------------------------------------------------------
+    // Memop
+    // -------------------------------------------------------------------------
+    Memop {
+        memop_num: u32,
+        argument0: Register, // Necessary for Miri ptr provenance of brk()
+    },
     // TODO: Add Exit.
 }


### PR DESCRIPTION
This PR adds memop syscalls corresponding to memop 0, 1, 2, 10, and 11 to libtock-rs. Any instances where the underlying raw system calls were being used to call memop are migrated to the safe higher level syscall APIs as possible. This PR also adds a function to libtock-runtime for retrieving the value of _heap_start as set by the linker.

This PR also builds out some initial infrastructure for unit tests to include the memop syscall, and some tests of the system call implementation itself. This was definitely the trickier part of this PR. Because many of these memop APIs need to accept pointers for argument0, and because the unit tests include Miri's strict provenance tests, I modified the expected syscall type and the syscall log type to use the "Register" type for memop argument0, enabling tests to pass pointers to actual buffers without Miri complaining or without tests failing on 64 bit systems. Another tricky aspect of getting these tests right is that memop is the only system call which uses two different underlying raw system calls (syscall1 and syscall2 in this case). That makes the system call logging etc. a little weird -- I chose to still use a single type, and just follow a convention where I always pass 0 as the second argument when testing any memop calls that will use syscall1 under the hood, but I am open to suggestions for improvement there as well.

~~This PR has not yet been tested on hardware, but I wanted to go ahead and open this PR so I could get feedback on the unit test infrastructure. I will test on hardware shortly when I am back in the bay area.~~