### PR TITLE
Bump Rust to version 1.77

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.1.0"
 [workspace.package]
 # This must be kept in sync with rust-toolchain.toml; please see that file for
 # more information.
-rust-version = "1.75"
+rust-version = "1.77"
 
 [features]
 rust_embedded = [

--- a/doc/PlatformDesignStory.md
+++ b/doc/PlatformDesignStory.md
@@ -429,7 +429,7 @@ macro_rules! test_component {
     [$link:ident, $name:ident: $comp:ty = $init:expr] => {
         let $name = std::boxed::Box::leak(std::boxed::Box::new($init)) as &$comp;
         std::thread_local!(static GLOBAL: std::cell::Cell<Option<&'static $comp>>
-                           = std::cell::Cell::new(None));
+                           = const {std::cell::Cell::new(None)})
         GLOBAL.with(|g| g.set(Some($name)));
         struct $link;
         impl<T> libtock_platform::FreeCallback<T> for $link

--- a/platform/src/share/tests.rs
+++ b/platform/src/share/tests.rs
@@ -1,6 +1,6 @@
 use crate::share::{scope, Handle, List};
 
-std::thread_local! {static INSTANCE_COUNT: core::cell::Cell<u64> = core::cell::Cell::new(0)}
+std::thread_local! {static INSTANCE_COUNT: core::cell::Cell<u64> = const {core::cell::Cell::new(0)}}
 
 // InstanceCounter increments INSTANCE_COUNT when it is constructed and
 // decrements INSTANCE_COUNT when it is dropped.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,9 +5,11 @@
 # you'd like to use. When you do so, update this to the first Rust version that
 # includes that feature. Whenever this value is updated, the rust-version field
 # in Cargo.toml must be updated as well.
-channel = "1.75"
+channel = "1.77"
 components = ["clippy", "rustfmt"]
-targets = ["thumbv6m-none-eabi",
-           "thumbv7em-none-eabi",
-           "riscv32imac-unknown-none-elf",
-           "riscv32imc-unknown-none-elf"]
+targets = [
+    "thumbv6m-none-eabi",
+    "thumbv7em-none-eabi",
+    "riscv32imac-unknown-none-elf",
+    "riscv32imc-unknown-none-elf",
+]

--- a/syscalls_tests/src/allow_ro.rs
+++ b/syscalls_tests/src/allow_ro.rs
@@ -33,7 +33,7 @@ impl fake::SyscallDriver for TestDriver {
 struct TestConfig;
 
 // CALLED is set to true when returned_nonzero_buffer is called.
-thread_local! {static CALLED: Cell<bool> = Cell::new(false); }
+thread_local! {static CALLED: Cell<bool> = const {Cell::new(false)} }
 
 impl allow_ro::Config for TestConfig {
     fn returned_nonzero_buffer(driver_num: u32, buffer_num: u32) {

--- a/syscalls_tests/src/allow_rw.rs
+++ b/syscalls_tests/src/allow_rw.rs
@@ -33,7 +33,7 @@ impl fake::SyscallDriver for TestDriver {
 struct TestConfig;
 
 // CALLED is set to true when returned_nonzero_buffer is called.
-thread_local! {static CALLED: Cell<bool> = Cell::new(false); }
+thread_local! {static CALLED: Cell<bool> = const {Cell::new(false)} }
 
 impl allow_rw::Config for TestConfig {
     fn returned_nonzero_buffer(driver_num: u32, buffer_num: u32) {

--- a/syscalls_tests/src/subscribe_tests.rs
+++ b/syscalls_tests/src/subscribe_tests.rs
@@ -2,7 +2,7 @@ use libtock_platform::{
     share, subscribe, CommandReturn, DefaultConfig, ErrorCode, Syscalls, YieldNoWaitReturn,
 };
 use libtock_unittest::{command_return, fake, DriverInfo, DriverShareRef, SyscallLogEntry};
-use std::rc::Rc;
+use std::{cell::Cell, rc::Rc};
 
 // Fake driver that accepts an upcall.
 #[derive(Default)]
@@ -28,7 +28,7 @@ impl fake::SyscallDriver for MockDriver {
 fn config() {
     // Thread local used by TestConfig to indicate that returned_nonnull_upcall
     // has been called.
-    std::thread_local! {static CALLED: core::cell::Cell<Option<(u32, u32)>> = Default::default(); }
+    std::thread_local! {static CALLED: core::cell::Cell<Option<(u32, u32)>> = const {Cell::new(None)} }
     struct TestConfig;
     impl subscribe::Config for TestConfig {
         fn returned_nonnull_upcall(driver_num: u32, subscribe_num: u32) {

--- a/unittest/src/kernel_data.rs
+++ b/unittest/src/kernel_data.rs
@@ -28,7 +28,7 @@ pub(crate) struct KernelData {
 
 // KERNEL_DATA is set to Some in `fake::Kernel::new` and set to None when the
 // `fake::Kernel` is dropped.
-thread_local!(pub(crate) static KERNEL_DATA: RefCell<Option<KernelData>> = RefCell::new(None));
+thread_local!(pub(crate) static KERNEL_DATA: RefCell<Option<KernelData>> = const { RefCell::new(None) });
 
 // Convenience function to get mutable access to KERNEL_DATA.
 pub(crate) fn with_kernel_data<F: FnOnce(Option<&mut KernelData>) -> R, R>(f: F) -> R {


### PR DESCRIPTION
When trying to build rowan we get this error

    error: package `rowan v0.15.16` cannot be built because
    it requires rustc 1.77.0 or newer, while the currently active rustc
    version is 1.75.0

So let's upgrade to 1.77 to allow us to build rowan.