### PR TITLE
Fix Driver ID Naming to Hexadecimal Format

### DIFF
--- a/apis/interface/buttons/src/lib.rs
+++ b/apis/interface/buttons/src/lib.rs
@@ -135,7 +135,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 3;
+const DRIVER_NUM: u32 = 0x3;
 
 // Command IDs
 const BUTTONS_COUNT: u32 = 0;

--- a/apis/interface/console/src/lib.rs
+++ b/apis/interface/console/src/lib.rs
@@ -137,7 +137,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 1;
+const DRIVER_NUM: u32 = 0x1;
 
 // Command IDs
 #[allow(unused)]

--- a/apis/interface/leds/src/lib.rs
+++ b/apis/interface/leds/src/lib.rs
@@ -44,7 +44,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 2;
+const DRIVER_NUM: u32 = 0x2;
 
 // Command IDs
 const LEDS_COUNT: u32 = 0;

--- a/apis/kernel/low_level_debug/src/lib.rs
+++ b/apis/kernel/low_level_debug/src/lib.rs
@@ -73,7 +73,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 8;
+const DRIVER_NUM: u32 = 0x8;
 
 // Command IDs
 const EXISTS: u32 = 0;

--- a/apis/peripherals/alarm/src/lib.rs
+++ b/apis/peripherals/alarm/src/lib.rs
@@ -110,7 +110,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 0;
+const DRIVER_NUM: u32 = 0x0;
 
 // Command IDs
 #[allow(unused)]

--- a/apis/peripherals/gpio/src/lib.rs
+++ b/apis/peripherals/gpio/src/lib.rs
@@ -254,7 +254,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 4;
+const DRIVER_NUM: u32 = 0x4;
 
 // Command IDs
 const EXISTS: u32 = 0;

--- a/unittest/src/fake/alarm/mod.rs
+++ b/unittest/src/fake/alarm/mod.rs
@@ -62,7 +62,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 0;
+const DRIVER_NUM: u32 = 0x0;
 
 // Command IDs
 #[allow(unused)]

--- a/unittest/src/fake/buttons/mod.rs
+++ b/unittest/src/fake/buttons/mod.rs
@@ -118,7 +118,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 3;
+const DRIVER_NUM: u32 = 0x3;
 
 // Command IDs
 const BUTTONS_COUNT: u32 = 0;

--- a/unittest/src/fake/console/mod.rs
+++ b/unittest/src/fake/console/mod.rs
@@ -118,7 +118,7 @@ impl crate::fake::SyscallDriver for Console {
 #[cfg(test)]
 mod tests;
 
-const DRIVER_NUM: u32 = 1;
+const DRIVER_NUM: u32 = 0x1;
 
 // Command numbers
 const EXISTS: u32 = 0;

--- a/unittest/src/fake/gpio/mod.rs
+++ b/unittest/src/fake/gpio/mod.rs
@@ -253,7 +253,7 @@ mod tests;
 // Driver number and command IDs
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 4;
+const DRIVER_NUM: u32 = 0x4;
 
 // Command IDs
 const EXISTS: u32 = 0;

--- a/unittest/src/fake/leds/mod.rs
+++ b/unittest/src/fake/leds/mod.rs
@@ -70,7 +70,7 @@ mod tests;
 // Implementation details below
 // -----------------------------------------------------------------------------
 
-const DRIVER_NUM: u32 = 2;
+const DRIVER_NUM: u32 = 0x2;
 
 // Command numbers
 const EXISTS: u32 = 0;

--- a/unittest/src/fake/low_level_debug/mod.rs
+++ b/unittest/src/fake/low_level_debug/mod.rs
@@ -69,7 +69,7 @@ impl core::fmt::Display for Message {
 #[cfg(test)]
 mod tests;
 
-const DRIVER_NUM: u32 = 8;
+const DRIVER_NUM: u32 = 0x8;
 
 // Command numbers
 const EXISTS: u32 = 0;


### PR DESCRIPTION
This pull request corrects the driver ID naming. Previously, driver IDs were inconsistently represented using a mix of decimal and hexadecimal formats, leading to potential confusion and errors.

Changes:
- Replaced all occurrences of driver IDs with their hexadecimal equivalents.