### PR TITLE
Use const operand for ARM syscall implementation

### DIFF
--- a/runtime/src/syscalls_impl_arm.rs
+++ b/runtime/src/syscalls_impl_arm.rs
@@ -1,5 +1,5 @@
 use core::arch::asm;
-use libtock_platform::{syscall_class, RawSyscalls, Register};
+use libtock_platform::{RawSyscalls, Register};
 
 unsafe impl RawSyscalls for crate::TockSyscalls {
     unsafe fn yield1([Register(r0)]: [Register; 1]) {
@@ -43,94 +43,58 @@ unsafe impl RawSyscalls for crate::TockSyscalls {
         }
     }
 
-    unsafe fn syscall1<const CLASS: usize>([Register(mut r0)]: [Register; 1]) -> [Register; 2] {
+    unsafe fn syscall1<const SYSCALL_CLASS_NUMBER: usize>(
+        [Register(mut r0)]: [Register; 1],
+    ) -> [Register; 2] {
         let r1;
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::syscall1
         #[allow(clippy::pointers_in_nomem_asm_block)]
         unsafe {
-            // Syscall class 5 is Memop, the only syscall class that syscall1
-            // supports.
-            asm!("svc 5",
-                 inlateout("r0") r0,
-                 lateout("r1") r1,
-                 options(preserves_flags, nostack, nomem),
+            asm!(
+                "svc {SYSCALL_CLASS_NUMBER}",
+                inlateout("r0") r0,
+                lateout("r1") r1,
+                options(preserves_flags, nostack, nomem),
+                SYSCALL_CLASS_NUMBER = const SYSCALL_CLASS_NUMBER,
             );
         }
         [Register(r0), Register(r1)]
     }
 
-    unsafe fn syscall2<const CLASS: usize>(
+    unsafe fn syscall2<const SYSCALL_CLASS_NUMBER: usize>(
         [Register(mut r0), Register(mut r1)]: [Register; 2],
     ) -> [Register; 2] {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::syscall2
+        #[allow(clippy::pointers_in_nomem_asm_block)]
         unsafe {
-            // TODO: Replace this match statement with a `const` operand when
-            // asm_const [1] is stabilized, or redesign RawSyscalls to not need
-            // this match statement.
-            //
-            // [1] https://github.com/rust-lang/rust/issues/93332
-            #[allow(clippy::pointers_in_nomem_asm_block)]
-            match CLASS {
-                syscall_class::MEMOP => asm!("svc 5",
-                     inlateout("r0") r0,
-                     inlateout("r1") r1,
-                     options(preserves_flags, nostack, nomem)
-                ),
-                syscall_class::EXIT => asm!("svc 6",
-                     inlateout("r0") r0,
-                     inlateout("r1") r1,
-                     options(preserves_flags, nostack, nomem)
-                ),
-                _ => unreachable!(),
-            }
+            asm!(
+                "svc {SYSCALL_CLASS_NUMBER}",
+                 inlateout("r0") r0,
+                 inlateout("r1") r1,
+                 options(preserves_flags, nostack, nomem),
+                 SYSCALL_CLASS_NUMBER = const SYSCALL_CLASS_NUMBER,
+            );
         }
         [Register(r0), Register(r1)]
     }
 
-    unsafe fn syscall4<const CLASS: usize>(
+    unsafe fn syscall4<const SYSCALL_CLASS_NUMBER: usize>(
         [Register(mut r0), Register(mut r1), Register(mut r2), Register(mut r3)]: [Register; 4],
     ) -> [Register; 4] {
         // Safety: This matches the invariants required by the documentation on
         // RawSyscalls::syscall4
         unsafe {
-            // TODO: Replace this match statement with a `const` operand when
-            // asm_const [1] is stabilized, or redesign RawSyscalls to not need
-            // this match statement.
-            //
-            // [1] https://github.com/rust-lang/rust/issues/93332
-            match CLASS {
-                syscall_class::SUBSCRIBE => asm!("svc 1",
-                     inlateout("r0") r0,
-                     inlateout("r1") r1,
-                     inlateout("r2") r2,
-                     inlateout("r3") r3,
-                     options(preserves_flags, nostack),
-                ),
-                syscall_class::COMMAND => asm!("svc 2",
-                     inlateout("r0") r0,
-                     inlateout("r1") r1,
-                     inlateout("r2") r2,
-                     inlateout("r3") r3,
-                     options(preserves_flags, nostack),
-                ),
-                syscall_class::ALLOW_RW => asm!("svc 3",
-                     inlateout("r0") r0,
-                     inlateout("r1") r1,
-                     inlateout("r2") r2,
-                     inlateout("r3") r3,
-                     options(preserves_flags, nostack),
-                ),
-                syscall_class::ALLOW_RO => asm!("svc 4",
-                     inlateout("r0") r0,
-                     inlateout("r1") r1,
-                     inlateout("r2") r2,
-                     inlateout("r3") r3,
-                     options(preserves_flags, nostack),
-                ),
-                _ => unreachable!(),
-            }
+            asm!(
+                "svc {SYSCALL_CLASS_NUMBER}",
+                inlateout("r0") r0,
+                inlateout("r1") r1,
+                inlateout("r2") r2,
+                inlateout("r3") r3,
+                options(preserves_flags, nostack),
+                SYSCALL_CLASS_NUMBER = const SYSCALL_CLASS_NUMBER,
+            );
         }
         [Register(r0), Register(r1), Register(r2), Register(r3)]
     }


### PR DESCRIPTION
`asm_const` feature has been stabilized in Rust 1.82. Using const operands for inline assembly eliminates a lot of the duplicated code in the ARM syscall implementation.

This commit has been tested by running a simple application that periodically blinks and writes a message on Raspberry Pi Pico.