### PR TITLE
Update deprecated github action `artifact-upload`

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -39,7 +39,7 @@ jobs:
           make -j2 EXAMPLE=low_level_debug nrf52
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: libtock-rs examples
           path: target/tbf


### PR DESCRIPTION
v3 of `artifact-upload` is deprecated. This simply bumps to the recent version