### PR TITLE
Support Embedded Graphics using the `screen` system call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,4 @@ jobs:
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config.toml
           make -j2 setup
           make -j2 test
+          make demos

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /nightly/target
 /target
 /demos/*/target
+/demos/*/*/target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
     "apis/storage/key_value",
     "demos/st7789",
     "demos/st7789-slint",
+    "libraries/embedded_graphics_libtock",
     "panic_handlers/debug_panic",
     "panic_handlers/small_panic",
     "platform",

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ examples: toolchain
 # Used when we need to build a crate for the host OS, as libtock_runtime only
 # supports running on Tock.
 EXCLUDE_RUNTIME := --exclude libtock --exclude libtock_runtime \
-	--exclude libtock_debug_panic --exclude libtock_small_panic
+	--exclude libtock_debug_panic --exclude libtock_small_panic --exclude embedded_graphics_libtock
 
 # Arguments to pass to cargo to exclude demo crates.
 EXCLUDE_RUNTIME := $(EXCLUDE_RUNTIME) --exclude st7789 --exclude st7789-slint

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,11 @@ $(eval $(call platform_build,msp432,thumbv7em-none-eabi))
 $(eval $(call platform_build,clue_nrf52840,thumbv7em-none-eabi))
 $(eval $(call platform_flash,clue_nrf52840,thumbv7em-none-eabi))
 
+.PHONY: demos
+demos:
+	$(MAKE) -C demos/embedded_graphics/spin
+	$(MAKE) -C demos/embedded_graphics/buttons
+
 # clean cannot safely be invoked concurrently with other actions, so we don't
 # need to depend on toolchain. We also manually remove the nightly toolchain's
 # target directory, in case the user doesn't want to install the nightly

--- a/demos/embedded_graphics/buttons/Cargo.toml
+++ b/demos/embedded_graphics/buttons/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "buttons"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+repository = "https://www.github.com/tock/libtock-rs"
+rust-version = "1.87"
+description = "libtock-rs button app with embedded graphics"
+
+[dependencies]
+embedded-graphics = "0.8.1"
+libm = "0.2.15"
+
+libtock = { path = "../../../", version = "0.1.0" }
+libtock_platform = { path = "../../../platform" }
+embedded_graphics_libtock = { path = "../../../libraries/embedded_graphics_libtock", version = "0.1.0" }
+
+[build-dependencies]
+libtock_build_scripts = { path = "../../../build_scripts" }
+
+[workspace]

--- a/demos/embedded_graphics/buttons/Makefile
+++ b/demos/embedded_graphics/buttons/Makefile
@@ -1,0 +1,20 @@
+# Makefile for the demo app.
+
+# Crate name of the demo app
+DEMO := buttons
+
+all: tab
+
+include ../../../Targets.mk
+
+$(ELF_TARGETS):
+	LIBTOCK_LINKER_FLASH=$(F) LIBTOCK_LINKER_RAM=$(R) cargo build --target=$(T) --release
+	@mkdir -p target/$(A).$(F).$(R)/
+	@cp target/$(T)/release/$(DEMO) target/$(A).$(F).$(R)/
+	$(eval ELF_LIST += target/$(A).$(F).$(R)/$(DEMO),$(A).$(F).$(R))
+
+# This target (`make tab`) is not parallel-safe
+.PHONY: tab
+tab: $(ELF_TARGETS)
+	@mkdir -p target/tab
+	elf2tab --kernel-major 2 --kernel-minor 1 -n $(DEMO) -o target/tab/$(DEMO).tab --stack 1024 --minimum-footer-size 256 $(ELF_LIST)

--- a/demos/embedded_graphics/buttons/README.md
+++ b/demos/embedded_graphics/buttons/README.md
@@ -1,0 +1,5 @@
+Buttons Demo Using Embedded Graphics
+====================================
+
+Draws buttons as circles on the screen. When a button is pressed the
+corresponding circle is filled in.

--- a/demos/embedded_graphics/buttons/build.rs
+++ b/demos/embedded_graphics/buttons/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    libtock_build_scripts::auto_layout();
+}

--- a/demos/embedded_graphics/buttons/src/main.rs
+++ b/demos/embedded_graphics/buttons/src/main.rs
@@ -1,0 +1,120 @@
+#![no_main]
+#![no_std]
+use core::cell::Cell;
+use core::fmt::Write;
+use libtock::buttons::{ButtonListener, ButtonState, Buttons};
+use libtock::console::Console;
+use libtock::runtime::{set_main, stack_size, TockSyscalls};
+use libtock_platform::share;
+use libtock_platform::ErrorCode;
+use libtock_platform::Syscalls;
+
+use embedded_graphics_libtock::tock_screen::TockMonochromeScreen;
+
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::Point;
+use embedded_graphics::prelude::Primitive;
+use embedded_graphics::primitives::{Circle, PrimitiveStyle};
+use embedded_graphics::Drawable;
+
+set_main! {main}
+stack_size! {4000}
+
+fn run() -> Result<(), ErrorCode> {
+    let mut screen = TockMonochromeScreen::new();
+
+    let width = screen.get_width();
+    let height = screen.get_height();
+
+    let button_count = Buttons::count()?;
+    writeln!(Console::writer(), "[BUTTONS] Count: {}", button_count).unwrap();
+
+    // Calculate where the buttons should be drawn.
+    let button_padding_px = (button_count - 1) * 2;
+    let max_x = (width - button_padding_px) / button_count;
+    let max_y = height - 2;
+    let diameter = core::cmp::min(max_x, max_y);
+    let buttons_width = (diameter * button_count) + button_padding_px;
+    let padding_left_px = (width - buttons_width) / 2;
+    let y = (height / 2) - (diameter / 2);
+
+    // Draw the initial button outlines.
+    for i in 0..button_count {
+        let x = padding_left_px + ((diameter + 2) * i);
+
+        let _ = Circle::new(Point::new(x as i32, y as i32), diameter)
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .draw(&mut screen);
+    }
+    let _ = screen.flush();
+
+    // Now wait for button presses. Record what happened in the upcall.
+    let buttons: [Cell<ButtonState>; 10] = [const { Cell::new(ButtonState::Released) }; 10];
+    let changed: Cell<bool> = Cell::new(false);
+
+    let listener = ButtonListener(|button, state| {
+        // If the button state changed, record it.
+        if buttons[button as usize].get() != state {
+            buttons[button as usize].set(state);
+            changed.set(true);
+        }
+    });
+    share::scope(|subscribe| {
+        // Subscribe to the button callback.
+        Buttons::register_listener(&listener, subscribe).unwrap();
+
+        // Enable interrupts for each button press.
+        for i in 0..button_count {
+            Buttons::enable_interrupts(i).unwrap();
+        }
+
+        // Wait for buttons to be pressed.
+        loop {
+            TockSyscalls::yield_wait();
+
+            // If a button state changed, re-draw the buttons.
+            if changed.get() {
+                changed.set(false);
+
+                let mut screen = TockMonochromeScreen::new();
+
+                // Draw Circles
+                for i in 0..button_count {
+                    let x = padding_left_px + ((diameter + 2) * i);
+
+                    // Draw outer circle
+                    let _ = Circle::new(Point::new(x as i32, y as i32), diameter)
+                        .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+                        .draw(&mut screen);
+
+                    match buttons[i as usize].get() {
+                        ButtonState::Pressed => {
+                            let _ =
+                                Circle::new(Point::new(x as i32 + 1, y as i32 + 1), diameter - 2)
+                                    .into_styled(PrimitiveStyle::with_fill(BinaryColor::On))
+                                    .draw(&mut screen);
+                        }
+                        ButtonState::Released => {
+                            let _ =
+                                Circle::new(Point::new(x as i32 + 1, y as i32 + 1), diameter - 2)
+                                    .into_styled(PrimitiveStyle::with_fill(BinaryColor::Off))
+                                    .draw(&mut screen);
+                        }
+                    }
+                }
+                let _ = screen.flush();
+            }
+        }
+    });
+
+    Ok(())
+}
+
+fn main() {
+    match run() {
+        Ok(()) => {}
+        Err(_e) => {
+            writeln!(Console::writer(), "[BUTTONS] Err could not run app").unwrap();
+        }
+    }
+}

--- a/demos/embedded_graphics/buttons/src/main.rs
+++ b/demos/embedded_graphics/buttons/src/main.rs
@@ -9,7 +9,7 @@ use libtock_platform::share;
 use libtock_platform::ErrorCode;
 use libtock_platform::Syscalls;
 
-use embedded_graphics_libtock::tock_screen::TockMonochromeScreen;
+use embedded_graphics_libtock::tock_screen::TockMonochrome8BitPage128x64Screen;
 
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::Point;
@@ -21,7 +21,7 @@ set_main! {main}
 stack_size! {4000}
 
 fn run() -> Result<(), ErrorCode> {
-    let mut screen = TockMonochromeScreen::new();
+    let mut screen = TockMonochrome8BitPage128x64Screen::new();
 
     let width = screen.get_width();
     let height = screen.get_height();
@@ -76,7 +76,7 @@ fn run() -> Result<(), ErrorCode> {
             if changed.get() {
                 changed.set(false);
 
-                let mut screen = TockMonochromeScreen::new();
+                let mut screen = TockMonochrome8BitPage128x64Screen::new();
 
                 // Draw Circles
                 for i in 0..button_count {

--- a/demos/embedded_graphics/spin/Cargo.toml
+++ b/demos/embedded_graphics/spin/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "spin"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2021"
+repository = "https://www.github.com/tock/libtock-rs"
+rust-version = "1.87"
+description = "libtock-rs spin app with embedded graphics"
+
+[dependencies]
+embedded-graphics = "0.8.1"
+libm = "0.2.15"
+
+libtock = { path = "../../../", version = "0.1.0" }
+embedded_graphics_libtock = { path = "../../../libraries/embedded_graphics_libtock", version = "0.1.0" }
+
+[build-dependencies]
+libtock_build_scripts = { path = "../../../build_scripts" }
+
+[workspace]

--- a/demos/embedded_graphics/spin/Makefile
+++ b/demos/embedded_graphics/spin/Makefile
@@ -1,0 +1,20 @@
+# Makefile for the demo app.
+
+# Crate name of the demo app
+DEMO := spin
+
+all: tab
+
+include ../../../Targets.mk
+
+$(ELF_TARGETS):
+	LIBTOCK_LINKER_FLASH=$(F) LIBTOCK_LINKER_RAM=$(R) cargo build --target=$(T) --release
+	@mkdir -p target/$(A).$(F).$(R)/
+	@cp target/$(T)/release/$(DEMO) target/$(A).$(F).$(R)/
+	$(eval ELF_LIST += target/$(A).$(F).$(R)/$(DEMO),$(A).$(F).$(R))
+
+# This target (`make tab`) is not parallel-safe
+.PHONY: tab
+tab: $(ELF_TARGETS)
+	@mkdir -p target/tab
+	elf2tab --kernel-major 2 --kernel-minor 1 -n $(DEMO) -o target/tab/$(DEMO).tab --stack 1024 --minimum-footer-size 256 $(ELF_LIST)

--- a/demos/embedded_graphics/spin/README.md
+++ b/demos/embedded_graphics/spin/README.md
@@ -1,0 +1,5 @@
+Spin Demo Using Embedded Graphics
+=================================
+
+This demo spins a line on a screen. It was tested using the SSD1306 screen on
+the nRF52840dk.

--- a/demos/embedded_graphics/spin/build.rs
+++ b/demos/embedded_graphics/spin/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    libtock_build_scripts::auto_layout();
+}

--- a/demos/embedded_graphics/spin/src/main.rs
+++ b/demos/embedded_graphics/spin/src/main.rs
@@ -1,0 +1,53 @@
+#![no_main]
+#![no_std]
+use libtock::alarm::Alarm;
+use libtock::alarm::Milliseconds;
+use libtock::runtime::{set_main, stack_size};
+
+use embedded_graphics_libtock::tock_screen::TockMonochromeScreen;
+
+use embedded_graphics::draw_target::DrawTarget;
+use embedded_graphics::pixelcolor::BinaryColor;
+use embedded_graphics::prelude::Point;
+use embedded_graphics::prelude::Primitive;
+use embedded_graphics::primitives::{Line, PrimitiveStyle};
+use embedded_graphics::Drawable;
+
+set_main! {main}
+stack_size! {4000}
+
+fn main() {
+    let mut screen = TockMonochromeScreen::new();
+
+    let width = screen.get_width() as i32;
+    let height = screen.get_height() as i32;
+
+    let center_x = width / 2;
+    let center_y = height / 2;
+    let radius = if width < height {
+        center_x - 1
+    } else {
+        center_y - 1
+    };
+
+    let mut rot: usize = 0;
+
+    loop {
+        let _ = screen.clear(BinaryColor::Off);
+
+        let angle = (rot as f32 / 100.0) * (2.0 * core::f32::consts::PI);
+
+        let x = (center_x as f32 + (radius as f32 * libm::cosf(angle))) as i32;
+        let y = (center_y as f32 + (radius as f32 * libm::sinf(angle))) as i32;
+
+        let _ = Line::new(Point::new(center_x, center_y), Point::new(x, y))
+            .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+            .draw(&mut screen);
+
+        let _ = screen.flush();
+
+        Alarm::sleep_for(Milliseconds(200)).unwrap();
+
+        rot = (rot + 1) % 100;
+    }
+}

--- a/demos/embedded_graphics/spin/src/main.rs
+++ b/demos/embedded_graphics/spin/src/main.rs
@@ -4,7 +4,7 @@ use libtock::alarm::Alarm;
 use libtock::alarm::Milliseconds;
 use libtock::runtime::{set_main, stack_size};
 
-use embedded_graphics_libtock::tock_screen::TockMonochromeScreen;
+use embedded_graphics_libtock::tock_screen::TockMonochrome8BitPage128x64Screen;
 
 use embedded_graphics::draw_target::DrawTarget;
 use embedded_graphics::pixelcolor::BinaryColor;
@@ -17,7 +17,7 @@ set_main! {main}
 stack_size! {4000}
 
 fn main() {
-    let mut screen = TockMonochromeScreen::new();
+    let mut screen = TockMonochrome8BitPage128x64Screen::new();
 
     let width = screen.get_width() as i32;
     let height = screen.get_height() as i32;

--- a/libraries/embedded_graphics_libtock/Cargo.toml
+++ b/libraries/embedded_graphics_libtock/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "embedded_graphics_libtock"
+version = "0.1.0"
+authors = ["Tock Project Developers <tock-dev@googlegroups.com>"]
+license = "Apache-2.0 OR MIT"
+edition = "2018"
+repository = "https://www.github.com/tock/libtock-rs"
+rust-version.workspace = true
+description = "libtock-rs port of embedded graphics"
+
+[dependencies]
+embedded-graphics = "0.8.1"
+
+libtock = { path = "../../" }
+libtock_platform = { path = "../../platform" }

--- a/libraries/embedded_graphics_libtock/README.md
+++ b/libraries/embedded_graphics_libtock/README.md
@@ -1,0 +1,8 @@
+Embedded Graphics - Libtock
+===========================
+
+This crate connects the
+[Embedded Graphics library](https://crates.io/crates/embedded-graphics) to
+libtock-rs. Specifically, this implements the
+[DrawTarget trait](https://docs.rs/embedded-graphics/latest/embedded_graphics/draw_target/trait.DrawTarget.html)
+using the Tock `screen` systemcall.

--- a/libraries/embedded_graphics_libtock/src/lib.rs
+++ b/libraries/embedded_graphics_libtock/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod tock_screen;

--- a/libraries/embedded_graphics_libtock/src/lib.rs
+++ b/libraries/embedded_graphics_libtock/src/lib.rs
@@ -1,3 +1,32 @@
+//! Interface library for using Embedded Graphics with libtock-rs
+//!
+//! This library implements `embedded_graphics::draw_target::DrawTarget` from
+//! the [Embedded Graphics](https://crates.io/crates/embedded-graphics) graphics
+//! library using the screen system call driver in Tock.
+//!
+//! ## Example Usage
+//!
+//! Using Embedded Graphics to draw a circle on the screen might look like:DrawTarget
+//!
+//! ```rust
+//! use embedded_graphics_libtock::tock_screen::TockMonochrome8BitPage128x64Screen;
+//!
+//! use embedded_graphics::pixelcolor::BinaryColor;
+//! use embedded_graphics::prelude::Point;
+//! use embedded_graphics::primitives::{Circle, PrimitiveStyle};
+//!
+//! let mut screen = TockMonochrome8BitPage128x64Screen::new();
+//!
+//! let x = 50;
+//! let y = 50;
+//! let diameter = 40;
+//! let _ = Circle::new(Point::new(x as i32, y as i32), diameter)
+//!     .into_styled(PrimitiveStyle::with_stroke(BinaryColor::On, 1))
+//!     .draw(&mut screen);
+//! }
+//! let _ = screen.flush();
+//! ```
+
 #![no_std]
 
 pub mod tock_screen;

--- a/libraries/embedded_graphics_libtock/src/tock_screen.rs
+++ b/libraries/embedded_graphics_libtock/src/tock_screen.rs
@@ -1,7 +1,14 @@
+//! Implementations of `DrawTarget` using the screen system call.
+
 use libtock::display::Screen;
 use libtock_platform::ErrorCode;
 
-pub struct TockMonochromeScreen {
+/// An implementation of a `DrawTarget` for monochromatic, 128x64 pixel screens
+/// where the pixels in each byte are vertical on the screen.
+///
+/// This corresponds to the `Mono_8BitPage` pixel format documented
+/// [here](https://github.com/tock/tock/blob/master/doc/syscalls/90001_screen.md#command-number-25).
+pub struct TockMonochrome8BitPage128x64Screen {
     /// The framebuffer for the max supported screen size (128x64). Each pixel
     /// is a bit.
     framebuffer: [u8; (128 * 64) / 8],
@@ -9,15 +16,20 @@ pub struct TockMonochromeScreen {
     height: u32,
 }
 
-impl Default for TockMonochromeScreen {
+impl Default for TockMonochrome8BitPage128x64Screen {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl TockMonochromeScreen {
+impl TockMonochrome8BitPage128x64Screen {
     pub fn new() -> Self {
         let (width, height) = Screen::get_resolution().unwrap_or((0, 0));
+
+        // Because this is a specific type of screen with a specific pixel
+        // format, we tell the kernel that is the pixel format we expect.
+        let mono_8_bit_page = 6;
+        let _ = Screen::set_pixel_format(mono_8_bit_page);
 
         Self {
             framebuffer: [0; 1024],
@@ -42,7 +54,7 @@ impl TockMonochromeScreen {
     }
 }
 
-impl embedded_graphics::draw_target::DrawTarget for TockMonochromeScreen {
+impl embedded_graphics::draw_target::DrawTarget for TockMonochrome8BitPage128x64Screen {
     type Color = embedded_graphics::pixelcolor::BinaryColor;
     type Error = core::convert::Infallible;
 
@@ -78,7 +90,7 @@ impl embedded_graphics::draw_target::DrawTarget for TockMonochromeScreen {
     }
 }
 
-impl embedded_graphics::geometry::OriginDimensions for TockMonochromeScreen {
+impl embedded_graphics::geometry::OriginDimensions for TockMonochrome8BitPage128x64Screen {
     fn size(&self) -> embedded_graphics::geometry::Size {
         embedded_graphics::geometry::Size::new(128, 64)
     }

--- a/libraries/embedded_graphics_libtock/src/tock_screen.rs
+++ b/libraries/embedded_graphics_libtock/src/tock_screen.rs
@@ -1,0 +1,79 @@
+use libtock::display::Screen;
+use libtock_platform::ErrorCode;
+
+pub struct TockMonochromeScreen {
+    /// The framebuffer for the max supported screen size (128x64). Each pixel
+    /// is a bit.
+    framebuffer: [u8; (128 * 64) / 8],
+    width: u32,
+    height: u32,
+}
+
+impl TockMonochromeScreen {
+    pub fn new() -> Self {
+        let (width, height) = Screen::get_resolution().unwrap_or((0, 0));
+
+        Self {
+            framebuffer: [0; 1024],
+            width,
+            height,
+        }
+    }
+
+    pub fn get_width(&self) -> u32 {
+        self.width
+    }
+
+    pub fn get_height(&self) -> u32 {
+        self.height
+    }
+
+    /// Updates the screen from the framebuffer.
+    pub fn flush(&self) -> Result<(), ErrorCode> {
+        Screen::set_write_frame(0, 0, self.width, self.height)?;
+        Screen::write(&self.framebuffer)?;
+        Ok(())
+    }
+}
+
+impl embedded_graphics::draw_target::DrawTarget for TockMonochromeScreen {
+    type Color = embedded_graphics::pixelcolor::BinaryColor;
+    type Error = core::convert::Infallible;
+
+    fn draw_iter<I>(&mut self, pixels: I) -> Result<(), Self::Error>
+    where
+        I: IntoIterator<Item = embedded_graphics::Pixel<Self::Color>>,
+    {
+        for embedded_graphics::Pixel(coord, color) in pixels.into_iter() {
+            if coord.x >= 0
+                && coord.x < self.width as i32
+                && coord.y >= 0
+                && coord.y < self.height as i32
+            {
+                const X_FACTOR: usize = 1;
+                const Y_FACTOR: usize = 8;
+                const X_COLS: usize = 128;
+
+                let x = coord.x as usize;
+                let y = coord.y as usize;
+
+                let byte_index = (x / X_FACTOR) + ((y / Y_FACTOR) * X_COLS);
+                let bit_index = y % Y_FACTOR;
+
+                if color.is_on() {
+                    self.framebuffer[byte_index] |= 1 << bit_index;
+                } else {
+                    self.framebuffer[byte_index] &= !(1 << bit_index);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl embedded_graphics::geometry::OriginDimensions for TockMonochromeScreen {
+    fn size(&self) -> embedded_graphics::geometry::Size {
+        embedded_graphics::geometry::Size::new(128, 64)
+    }
+}

--- a/libraries/embedded_graphics_libtock/src/tock_screen.rs
+++ b/libraries/embedded_graphics_libtock/src/tock_screen.rs
@@ -9,6 +9,12 @@ pub struct TockMonochromeScreen {
     height: u32,
 }
 
+impl Default for TockMonochromeScreen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TockMonochromeScreen {
     pub fn new() -> Self {
         let (width, height) = Screen::get_resolution().unwrap_or((0, 0));


### PR DESCRIPTION
This uses #568.

It provides basic support for using the embedded graphics library with the Tock screen syscall.

I was able to port the spin demo from libtock-c and verify that it works on the nrf52840dk with the attached monochromatic screen.