### PR TITLE
`async` compatible Allow RW design

### DIFF
--- a/platform/src/syscalls.rs
+++ b/platform/src/syscalls.rs
@@ -57,6 +57,19 @@ pub trait Syscalls: RawSyscalls + Sized {
         buffer: &'share mut [u8],
     ) -> Result<(), ErrorCode>;
 
+    /// Shares a read-write buffer with the kernel.
+    fn allow_rw_buffer<
+        'share,
+        CONFIG: allow_rw::Config,
+        const DRIVER_NUM: u32,
+        const BUFFER_NUM: u32,
+        const BUFFER_SIZE: usize,
+    >(
+        allow_rw_buffer: core::pin::Pin<
+            &'share mut allow_rw::AllowRwBuffer<Self, DRIVER_NUM, BUFFER_NUM, BUFFER_SIZE>,
+        >,
+    ) -> Result<(), ErrorCode>;
+
     /// Revokes the kernel's access to the buffer with the given ID, overwriting
     /// it with a zero buffer. If no buffer is shared with the given ID,
     /// `unallow_rw` does nothing.


### PR DESCRIPTION
This pull request adds the initial design idea for an `async`-compatible allow mechanism. This includes:

- `AllowRwBuffer` structure to be used in asynchronous function
- extension of the `Syscalls` trait to use the new allow interface
- minimal unittesting to ensure correctness