### PR TITLE
demos: st7789: make standalone apps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,6 @@ members = [
     "apis/sensors/proximity",
     "apis/sensors/temperature",
     "apis/storage/key_value",
-    "demos/st7789",
-    "demos/st7789-slint",
     "libraries/embedded_graphics_libtock",
     "panic_handlers/debug_panic",
     "panic_handlers/small_panic",

--- a/demos/st7789-slint/Cargo.toml
+++ b/demos/st7789-slint/Cargo.toml
@@ -2,7 +2,7 @@
 name = "st7789-slint"
 version = "0.1.0"
 edition = "2021"
-rust-version.workspace = true
+rust-version = "1.87"
 authors = ["Alistair Francis <alistair.francis@wdc.com>"]
 description = """A demo to use the Slint GUI library with a ST7789 display via SPI using libtock-rs."""
 license = "Apache-2.0 OR MIT"
@@ -29,3 +29,5 @@ display-interface = "0.5"
 libtock_build_scripts = { path = "../../build_scripts" }
 
 slint-build = { git = "https://github.com/slint-ui/slint" }
+
+[workspace]

--- a/demos/st7789-slint/Makefile
+++ b/demos/st7789-slint/Makefile
@@ -1,0 +1,20 @@
+# Makefile for the demo app.
+
+# Crate name of the demo app
+DEMO := st7789-slint
+
+all: tab
+
+include ../../Targets.mk
+
+$(ELF_TARGETS):
+	LIBTOCK_LINKER_FLASH=$(F) LIBTOCK_LINKER_RAM=$(R) cargo build --target=$(T) --release
+	@mkdir -p target/$(A).$(F).$(R)/
+	@cp target/$(T)/release/$(DEMO) target/$(A).$(F).$(R)/
+	$(eval ELF_LIST += target/$(A).$(F).$(R)/$(DEMO),$(A).$(F).$(R))
+
+# This target (`make tab`) is not parallel-safe
+.PHONY: tab
+tab: $(ELF_TARGETS)
+	@mkdir -p target/tab
+	elf2tab --kernel-major 2 --kernel-minor 1 -n $(DEMO) -o target/tab/$(DEMO).tab --stack 1024 --minimum-footer-size 256 $(ELF_LIST)

--- a/demos/st7789/Cargo.toml
+++ b/demos/st7789/Cargo.toml
@@ -2,7 +2,7 @@
 name = "st7789"
 version = "0.1.0"
 edition = "2021"
-rust-version.workspace = true
+rust-version = "1.87"
 authors = ["Alistair Francis <alistair.francis@wdc.com>"]
 description = """A demo to drive a ST7789 display via SPI using libtock-rs."""
 license = "Apache-2.0 OR MIT"
@@ -18,3 +18,5 @@ embedded-graphics = "0.8"
 
 [build-dependencies]
 libtock_build_scripts = { path = "../../build_scripts" }
+
+[workspace]

--- a/demos/st7789/Makefile
+++ b/demos/st7789/Makefile
@@ -1,0 +1,20 @@
+# Makefile for the demo app.
+
+# Crate name of the demo app
+DEMO := st7789
+
+all: tab
+
+include ../../Targets.mk
+
+$(ELF_TARGETS):
+	LIBTOCK_LINKER_FLASH=$(F) LIBTOCK_LINKER_RAM=$(R) cargo build --target=$(T) --release
+	@mkdir -p target/$(A).$(F).$(R)/
+	@cp target/$(T)/release/$(DEMO) target/$(A).$(F).$(R)/
+	$(eval ELF_LIST += target/$(A).$(F).$(R)/$(DEMO),$(A).$(F).$(R))
+
+# This target (`make tab`) is not parallel-safe
+.PHONY: tab
+tab: $(ELF_TARGETS)
+	@mkdir -p target/tab
+	elf2tab --kernel-major 2 --kernel-minor 1 -n $(DEMO) -o target/tab/$(DEMO).tab --stack 1024 --minimum-footer-size 256 $(ELF_LIST)


### PR DESCRIPTION
This removes the main makefile changes needed to build the st7789 demos, and removes them from the libtock-rs workspace, and instead builds them as standalone apps. This better mimics having out-of-tree apps and is more scalable for future demos. 