### PR TITLE
Upgrade to Rust 1.88

### DIFF
--- a/apis/peripherals/gpio/src/lib.rs
+++ b/apis/peripherals/gpio/src/lib.rs
@@ -126,12 +126,12 @@ pub struct Pin<S: Syscalls> {
 }
 
 impl<S: Syscalls> Pin<S> {
-    pub fn make_output(&mut self) -> Result<OutputPin<S>, ErrorCode> {
+    pub fn make_output(&mut self) -> Result<OutputPin<'_, S>, ErrorCode> {
         Gpio::<S>::enable_gpio_output(self.pin_number)?;
         Ok(OutputPin { pin: self })
     }
 
-    pub fn make_input<P: Pull>(&self) -> Result<InputPin<S, P>, ErrorCode> {
+    pub fn make_input<P: Pull>(&self) -> Result<InputPin<'_, S, P>, ErrorCode> {
         Gpio::<S>::enable_gpio_input(self.pin_number, P::MODE)?;
         Ok(InputPin {
             pin: self,

--- a/build_scripts/src/lib.rs
+++ b/build_scripts/src/lib.rs
@@ -70,12 +70,12 @@ pub fn auto_layout() {
 
     // Note: we need to print these rerun-if commands before using the variable
     // or file, so that if the build script fails cargo knows when to re-run it.
-    println!("cargo:rerun-if-env-changed={}", LINKER_FLASH_VAR);
-    println!("cargo:rerun-if-env-changed={}", LINKER_FLASH_LEN_VAR);
-    println!("cargo:rerun-if-env-changed={}", LINKER_RAM_VAR);
-    println!("cargo:rerun-if-env-changed={}", LINKER_RAM_LEN_VAR);
-    println!("cargo:rerun-if-env-changed={}", PLATFORM_VAR);
-    println!("cargo:rerun-if-env-changed={}", TBF_HEADER_SIZE_VAR);
+    println!("cargo:rerun-if-env-changed={LINKER_FLASH_VAR}");
+    println!("cargo:rerun-if-env-changed={LINKER_FLASH_LEN_VAR}");
+    println!("cargo:rerun-if-env-changed={LINKER_RAM_VAR}");
+    println!("cargo:rerun-if-env-changed={LINKER_RAM_LEN_VAR}");
+    println!("cargo:rerun-if-env-changed={PLATFORM_VAR}");
+    println!("cargo:rerun-if-env-changed={TBF_HEADER_SIZE_VAR}");
 
     let platform = get_env_var(PLATFORM_VAR);
     let flash_start = get_env_var(LINKER_FLASH_VAR);
@@ -103,16 +103,15 @@ pub fn auto_layout() {
                 .iter()
                 .find(|&&(name, _, _, _, _)| name == platform)
             {
-                None => panic!("Unknown platform: {}", platform),
+                None => panic!("Unknown platform: {platform}"),
                 Some(&(_, flash_start, flash_len, ram_start, ram_len)) => {
                     (flash_start, flash_len, ram_start, ram_len)
                 }
             }
         }
         _ => panic!(
-            "Must specify either {} or both {} and {}; please see \
-                     libtock_build_scripts' documentation for more information.",
-            PLATFORM_VAR, LINKER_FLASH_VAR, LINKER_RAM_VAR
+            "Must specify either {PLATFORM_VAR} or both {LINKER_FLASH_VAR} and {LINKER_RAM_VAR}; please see \
+                     libtock_build_scripts' documentation for more information."
         ),
     };
     let tbf_header_size;
@@ -147,7 +146,7 @@ pub fn auto_layout() {
     let layout_name = format!("{flash_start}.{flash_len}.{ram_start}.{ram_len}.ld");
     let layout_path: PathBuf = [out_dir, &layout_name].iter().collect();
     let mut layout_file =
-        File::create(&layout_path).unwrap_or_else(|e| panic!("Could not open layout file: {}", e));
+        File::create(&layout_path).unwrap_or_else(|e| panic!("Could not open layout file: {e}"));
     writeln!(
         layout_file,
         "\
@@ -156,8 +155,7 @@ pub fn auto_layout() {
         FLASH_LENGTH = {flash_len};\n\
         RAM_START = {ram_start};\n\
         RAM_LENGTH = {ram_len};\n\
-        INCLUDE {};",
-        LIBTOCK_LAYOUT_NAME
+        INCLUDE {LIBTOCK_LAYOUT_NAME};"
     )
     .expect("Failed to write layout file");
     drop(layout_file);
@@ -166,7 +164,7 @@ pub fn auto_layout() {
     // string, and copy those contents into out_dir at runtime.
     let libtock_layout_path: PathBuf = [out_dir, LIBTOCK_LAYOUT_NAME].iter().collect();
     let mut libtock_layout_file = File::create(libtock_layout_path)
-        .unwrap_or_else(|e| panic!("Could not open {}: {}", LIBTOCK_LAYOUT_NAME, e));
+        .unwrap_or_else(|e| panic!("Could not open {LIBTOCK_LAYOUT_NAME}: {e}"));
     write!(
         libtock_layout_file,
         "{}",
@@ -177,7 +175,7 @@ pub fn auto_layout() {
 
     // Tell rustc which linker script to use and where to find it.
     println!("cargo:rustc-link-arg=-T{}", layout_path.display());
-    println!("cargo:rustc-link-search={}", out_dir);
+    println!("cargo:rustc-link-search={out_dir}");
 
     // Configure the alignment size for the linker. This prevents the linker
     // from assuming very large pages (i.e. 65536 bytes) and unnecessarily
@@ -192,6 +190,6 @@ fn get_env_var(name: &str) -> Option<String> {
     match var(name) {
         Ok(value) => Some(value),
         Err(VarError::NotPresent) => None,
-        Err(VarError::NotUnicode(value)) => panic!("Non-Unicode value in {}: {:?}", name, value),
+        Err(VarError::NotUnicode(value)) => panic!("Non-Unicode value in {name}: {value:?}"),
     }
 }

--- a/demos/st7789-slint/src/main.rs
+++ b/demos/st7789-slint/src/main.rs
@@ -105,7 +105,7 @@ impl slint::platform::Platform for SlintPlatform {
     }
 
     fn debug_log(&self, arguments: core::fmt::Arguments) {
-        writeln!(Console::writer(), "{}\r", arguments).unwrap();
+        writeln!(Console::writer(), "{arguments}\r").unwrap();
     }
 
     fn run_event_loop(&self) -> Result<(), slint::PlatformError> {

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -22,7 +22,7 @@ fn main() {
 
     loop {
         match Adc::read_single_sample_sync() {
-            Ok(adc_val) => writeln!(Console::writer(), "Sample: {}\n", adc_val).unwrap(),
+            Ok(adc_val) => writeln!(Console::writer(), "Sample: {adc_val}\n").unwrap(),
             Err(_) => writeln!(Console::writer(), "error while reading sample",).unwrap(),
         }
 

--- a/examples/ambient_light.rs
+++ b/examples/ambient_light.rs
@@ -22,12 +22,9 @@ fn main() {
 
     loop {
         match AmbientLight::read_intensity_sync() {
-            Ok(intensity_val) => writeln!(
-                Console::writer(),
-                "Light intensity: {} lux\n",
-                intensity_val
-            )
-            .unwrap(),
+            Ok(intensity_val) => {
+                writeln!(Console::writer(), "Light intensity: {intensity_val} lux\n").unwrap()
+            }
             Err(_) => writeln!(Console::writer(), "error while reading light intensity",).unwrap(),
         }
 

--- a/examples/blink.rs
+++ b/examples/blink.rs
@@ -16,9 +16,9 @@ fn main() {
         loop {
             for led_index in 0..leds_count {
                 if count & (1 << led_index) > 0 {
-                    let _ = Leds::on(led_index as u32);
+                    let _ = Leds::on(led_index);
                 } else {
-                    let _ = Leds::off(led_index as u32);
+                    let _ = Leds::off(led_index);
                 }
             }
 

--- a/examples/buttons.rs
+++ b/examples/buttons.rs
@@ -17,10 +17,10 @@ stack_size! {0x1000}
 fn main() {
     let listener = ButtonListener(|button, state| {
         let _ = Leds::toggle(button);
-        writeln!(Console::writer(), "button {:?}: {:?}", button, state).unwrap();
+        writeln!(Console::writer(), "button {button:?}: {state:?}").unwrap();
     });
     if let Ok(buttons_count) = Buttons::count() {
-        writeln!(Console::writer(), "button count: {}", buttons_count).unwrap();
+        writeln!(Console::writer(), "button count: {buttons_count}").unwrap();
 
         share::scope(|subscribe| {
             // Subscribe to the button callback.

--- a/examples/gpio.rs
+++ b/examples/gpio.rs
@@ -19,7 +19,7 @@ stack_size! {0x1000}
 
 fn main() {
     let listener = gpio::GpioInterruptListener(|gpio_index, state| {
-        writeln!(Console::writer(), "GPIO[{}]: {:?}", gpio_index, state).unwrap();
+        writeln!(Console::writer(), "GPIO[{gpio_index}]: {state:?}").unwrap();
     });
 
     if !Gpio::count().is_ok_and(|c| c > 0) {

--- a/examples/i2c_master_write_read.rs
+++ b/examples/i2c_master_write_read.rs
@@ -32,19 +32,13 @@ fn main() {
     let rx_len = 2;
 
     writeln!(Console::writer(), "i2c-master: write-read sample\r").unwrap();
-    writeln!(
-        Console::writer(),
-        "i2c-master: slave address 0x{:x}!\r",
-        addr
-    )
-    .unwrap();
+    writeln!(Console::writer(), "i2c-master: slave address 0x{addr:x}!\r").unwrap();
 
     let mut i: u32 = 0;
     loop {
         writeln!(
             Console::writer(),
-            "i2c-master: write-read operation {:?}\r",
-            i
+            "i2c-master: write-read operation {i:?}\r"
         )
         .unwrap();
 
@@ -57,8 +51,7 @@ fn main() {
         if let Err(why) = I2CMasterSlave::i2c_master_slave_write_sync(addr, &tx_buf, tx_len) {
             writeln!(
                 Console::writer(),
-                "i2c-master: write operation failed {:?}",
-                why
+                "i2c-master: write operation failed {why:?}"
             )
             .unwrap();
         } else {
@@ -80,8 +73,7 @@ fn main() {
                 Err(why) => {
                     writeln!(
                         Console::writer(),
-                        "i2c-master: read operation failed {:?}",
-                        why
+                        "i2c-master: read operation failed {why:?}"
                     )
                     .unwrap();
                 }

--- a/examples/i2c_slave_send_recv.rs
+++ b/examples/i2c_slave_send_recv.rs
@@ -26,12 +26,12 @@ fn main() {
     assert!(addr <= 0x7f);
 
     writeln!(Console::writer(), "i2c-slave: setting up\r").unwrap();
-    writeln!(Console::writer(), "i2c-slave: address 0x{:x}!\r", addr).unwrap();
+    writeln!(Console::writer(), "i2c-slave: address 0x{addr:x}!\r").unwrap();
 
     I2CMasterSlave::i2c_master_slave_set_slave_address(addr).expect("i2c-target: Failed to listen");
     let mut i: u32 = 0;
     loop {
-        writeln!(Console::writer(), "i2c-slave: operation {:?}\r", i).unwrap();
+        writeln!(Console::writer(), "i2c-slave: operation {i:?}\r").unwrap();
 
         // Expect a write, if the master reads here, the IP may stretch clocks!
         let r = I2CMasterSlave::i2c_master_slave_write_recv_sync(&mut rx_buf);
@@ -39,8 +39,7 @@ fn main() {
         if let Err(why) = r.1 {
             writeln!(
                 Console::writer(),
-                "i2c-slave: error to receiving data {:?}\r",
-                why
+                "i2c-slave: error to receiving data {why:?}\r"
             )
             .unwrap();
         } else {
@@ -73,8 +72,7 @@ fn main() {
                 Err(why) => {
                     writeln!(
                         Console::writer(),
-                        "i2c-slave: error setting up read_send {:?}\r",
-                        why
+                        "i2c-slave: error setting up read_send {why:?}\r"
                     )
                     .unwrap();
                 }

--- a/examples/ieee802154_rx_tx.rs
+++ b/examples/ieee802154_rx_tx.rs
@@ -56,7 +56,7 @@ fn main() {
         // Transmit a frame
         Ieee802154::transmit_frame(&buf).unwrap();
 
-        writeln!(Console::writer(), "Transmitted frame {}!\n", counter).unwrap();
+        writeln!(Console::writer(), "Transmitted frame {counter}!\n").unwrap();
 
         let frame = operator.receive_frame().unwrap();
 

--- a/examples/ieee802154_tx.rs
+++ b/examples/ieee802154_tx.rs
@@ -17,7 +17,7 @@ fn main() {
     // Configure the radio
     let pan: u16 = 0xcafe;
     let addr_short: u16 = 0xdead;
-    let addr_long: u64 = 0xdead_dad;
+    let addr_long: u64 = 0xdeaddad;
     let tx_power: i8 = 5;
     let channel: u8 = 11;
 
@@ -53,7 +53,7 @@ fn main() {
         // Transmit a frame
         Ieee802154::transmit_frame(&buf).unwrap();
 
-        writeln!(Console::writer(), "Transmitted frame {}!\n", counter).unwrap();
+        writeln!(Console::writer(), "Transmitted frame {counter}!\n").unwrap();
 
         counter += 1;
     }

--- a/examples/kv.rs
+++ b/examples/kv.rs
@@ -19,16 +19,16 @@ fn get_and_print(key: &[u8], value: &mut [u8]) {
     match KeyValue::get(key, value) {
         Ok(val_length) => {
             let val_length: usize = val_length as usize;
-            writeln!(Console::writer(), "Got value len: {}", val_length).unwrap();
+            writeln!(Console::writer(), "Got value len: {val_length}").unwrap();
 
             match str::from_utf8(&value[0..val_length]) {
-                Ok(val_str) => writeln!(Console::writer(), "Value: {}", val_str).unwrap(),
+                Ok(val_str) => writeln!(Console::writer(), "Value: {val_str}").unwrap(),
                 Err(_) => {
                     write!(Console::writer(), "Value: ").unwrap();
-                    for i in 0..val_length {
-                        write!(Console::writer(), "{:02x}", value[i]).unwrap();
+                    for val in &value[0..val_length] {
+                        write!(Console::writer(), "{val:02x}").unwrap();
                     }
-                    write!(Console::writer(), "\n").unwrap();
+                    writeln!(Console::writer()).unwrap();
                 }
             }
         }

--- a/examples/leds.rs
+++ b/examples/leds.rs
@@ -14,7 +14,7 @@ fn main() {
     if let Ok(leds_count) = Leds::count() {
         loop {
             for led_index in 0..leds_count {
-                let _ = Leds::toggle(led_index as u32);
+                let _ = Leds::toggle(led_index);
             }
             Alarm::sleep_for(Milliseconds(250)).unwrap();
         }

--- a/examples/music.rs
+++ b/examples/music.rs
@@ -84,7 +84,7 @@ const TEMPO: u32 = 114;
 const WHOLE_NOTE: u32 = (60000 * 4) / TEMPO;
 
 fn main() {
-    if let Err(_) = Buzzer::exists() {
+    if Buzzer::exists().is_err() {
         writeln!(Console::writer(), "There is no available buzzer").unwrap();
         return;
     }

--- a/examples/proximity.rs
+++ b/examples/proximity.rs
@@ -22,7 +22,7 @@ fn main() {
     writeln!(Console::writer(), "proximity driver available").unwrap();
     loop {
         match Proximity::read_sync() {
-            Ok(prox_val) => writeln!(Console::writer(), "Proximity: {}\n", prox_val).unwrap(),
+            Ok(prox_val) => writeln!(Console::writer(), "Proximity: {prox_val}\n").unwrap(),
             Err(_) => writeln!(Console::writer(), "error while reading proximity",).unwrap(),
         }
 

--- a/examples/rng.rs
+++ b/examples/rng.rs
@@ -14,8 +14,8 @@ struct Randomness<'a, const N: usize>(&'a [u8; N]);
 
 impl<'a, const N: usize> core::fmt::Display for Randomness<'a, N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut bytes = self.0.iter();
-        while let Some(&byte) = bytes.next() {
+        let bytes = self.0.iter();
+        for &byte in bytes {
             write!(f, "{byte:02x}")?;
         }
         Ok(())

--- a/examples/rng_async.rs
+++ b/examples/rng_async.rs
@@ -37,7 +37,7 @@ fn main() {
         buffer.iter().for_each(|&byte| {
             let _ = write!(console_writer, "{byte:02x}");
         });
-        let _ = writeln!(console_writer, "");
+        let _ = writeln!(console_writer);
 
         let _ = Alarm::sleep_for(Milliseconds(2000));
     }

--- a/examples/screen.rs
+++ b/examples/screen.rs
@@ -18,7 +18,7 @@ fn main() {
     let resolutions = match Screen::get_resolution_modes_count() {
         Ok(val) => val,
         Err(e) => {
-            let _ = writeln!(Console::writer(), "{:?}\n", e);
+            let _ = writeln!(Console::writer(), "{e:?}\n");
             0
         }
     };
@@ -35,7 +35,7 @@ fn main() {
         let (width, height) = match Screen::get_resolution_width_height(index as usize) {
             Ok((width, height)) => (width, height),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
                 (0, 0)
             }
         };
@@ -57,7 +57,7 @@ fn main() {
     let pixel_format = match Screen::get_pixel_format() {
         Ok(val) => val,
         Err(e) => {
-            let _ = writeln!(Console::writer(), "{:?}\n", e);
+            let _ = writeln!(Console::writer(), "{e:?}\n");
             0
         }
     };
@@ -71,7 +71,7 @@ fn main() {
         let format = match Screen::pixel_format(index as usize) {
             Ok(val) => val,
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
                 0
             }
         };
@@ -84,10 +84,10 @@ fn main() {
     let mut buffer = [0u8; BUFFER_SIZE];
 
     // Set Screen brightness to 100%
-    let _ = match Screen::set_brightness(100) {
+    match Screen::set_brightness(100) {
         Ok(()) => (),
         Err(e) => {
-            let _ = writeln!(Console::writer(), "{:?}\n", e);
+            let _ = writeln!(Console::writer(), "{e:?}\n");
         }
     };
 
@@ -95,7 +95,7 @@ fn main() {
     let (width, height) = match Screen::get_resolution() {
         Ok((width, height)) => (width, height),
         Err(e) => {
-            let _ = writeln!(Console::writer(), "{:?}\n", e);
+            let _ = writeln!(Console::writer(), "{e:?}\n");
             (0, 0)
         }
     };
@@ -109,16 +109,16 @@ fn main() {
     };
 
     // Set full-screen write frame and clear screen
-    let _ = match Screen::set_write_frame(0, 0, width, height) {
+    match Screen::set_write_frame(0, 0, width, height) {
         Ok(()) => (),
         Err(e) => {
-            let _ = writeln!(Console::writer(), "{:?}\n", e);
+            let _ = writeln!(Console::writer(), "{e:?}\n");
         }
     };
-    let _ = match Screen::fill(&mut buffer, 0x0) {
+    match Screen::fill(&mut buffer, 0x0) {
         Ok(()) => (),
         Err(e) => {
-            let _ = writeln!(Console::writer(), "{:?}\n", e);
+            let _ = writeln!(Console::writer(), "{e:?}\n");
         }
     };
 
@@ -136,38 +136,38 @@ fn main() {
         }
 
         // Set Screen rotation (0 to 3)
-        let _ = match Screen::set_rotation(i % 4) {
+        match Screen::set_rotation(i % 4) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
 
         // Draw a red square at (10, 20)
-        let _ = match Screen::set_write_frame(10, 20, 30, 30) {
+        match Screen::set_write_frame(10, 20, 30, 30) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
-        let _ = match Screen::fill(&mut buffer, 0xF800) {
+        match Screen::fill(&mut buffer, 0xF800) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
 
         // Draw a black square at (88, 20)
-        let _ = match Screen::set_write_frame(88, 20, 30, 30) {
+        match Screen::set_write_frame(88, 20, 30, 30) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
-        let _ = match Screen::fill(&mut buffer, 0x0) {
+        match Screen::fill(&mut buffer, 0x0) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
 
@@ -175,30 +175,30 @@ fn main() {
         Alarm::sleep_for(Milliseconds(1000)).unwrap();
 
         // Clear the red square
-        let _ = match Screen::set_write_frame(10, 20, 30, 30) {
+        match Screen::set_write_frame(10, 20, 30, 30) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
-        let _ = match Screen::fill(&mut buffer, 0x0) {
+        match Screen::fill(&mut buffer, 0x0) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
 
         // Draw a green square at (88, 20)
-        let _ = match Screen::set_write_frame(88, 20, 30, 30) {
+        match Screen::set_write_frame(88, 20, 30, 30) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
-        let _ = match Screen::fill(&mut buffer, 0x07F0) {
+        match Screen::fill(&mut buffer, 0x07F0) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
 
@@ -206,16 +206,16 @@ fn main() {
         Alarm::sleep_for(Milliseconds(1000)).unwrap();
 
         // Clear screen
-        let _ = match Screen::set_write_frame(0, 0, width, height) {
+        match Screen::set_write_frame(0, 0, width, height) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
-        let _ = match Screen::fill(&mut buffer, 0x0) {
+        match Screen::fill(&mut buffer, 0x0) {
             Ok(()) => (),
             Err(e) => {
-                let _ = writeln!(Console::writer(), "{:?}\n", e);
+                let _ = writeln!(Console::writer(), "{e:?}\n");
             }
         };
     }

--- a/examples/sound_pressure.rs
+++ b/examples/sound_pressure.rs
@@ -27,12 +27,10 @@ fn main() {
             writeln!(Console::writer(), "Sound pressure driver enabled").unwrap();
             loop {
                 match SoundPressure::read_sync() {
-                    Ok(sound_pressure_val) => writeln!(
-                        Console::writer(),
-                        "Sound Pressure: {}\n",
-                        sound_pressure_val
-                    )
-                    .unwrap(),
+                    Ok(sound_pressure_val) => {
+                        writeln!(Console::writer(), "Sound Pressure: {sound_pressure_val}\n")
+                            .unwrap()
+                    }
                     Err(_) => {
                         writeln!(Console::writer(), "error while reading sound pressure",).unwrap()
                     }

--- a/examples/spi_controller_write_read.rs
+++ b/examples/spi_controller_write_read.rs
@@ -22,16 +22,13 @@ fn main() {
     {
         writeln!(
             Console::writer(),
-            "spi-controller: write-read operation failed {:?}\r",
-            why
+            "spi-controller: write-read operation failed {why:?}\r"
         )
         .unwrap();
     } else {
         writeln!(
             Console::writer(),
-            "spi-controller: write-read: wrote {:x?}: read {:x?}\r",
-            tx_buf,
-            rx_buf
+            "spi-controller: write-read: wrote {tx_buf:x?}: read {rx_buf:x?}\r"
         )
         .unwrap();
     }
@@ -40,24 +37,22 @@ fn main() {
     if let Err(why) = SpiController::spi_controller_write_sync(&tx_buf, OPERATION_LEN as u32) {
         writeln!(
             Console::writer(),
-            "spi-controller: write operation failed {:?}\r",
-            why
+            "spi-controller: write operation failed {why:?}\r"
         )
         .unwrap();
     } else {
-        writeln!(Console::writer(), "spi-controller: wrote {:x?}\r", tx_buf).unwrap();
+        writeln!(Console::writer(), "spi-controller: wrote {tx_buf:x?}\r").unwrap();
     }
 
     writeln!(Console::writer(), "spi-controller: read\r").unwrap();
     if let Err(why) = SpiController::spi_controller_read_sync(&mut rx_buf, OPERATION_LEN as u32) {
         writeln!(
             Console::writer(),
-            "spi-controller: read operation failed {:?}\r",
-            why
+            "spi-controller: read operation failed {why:?}\r"
         )
         .unwrap();
     } else {
-        writeln!(Console::writer(), "spi-controller: read {:x?}\r", rx_buf).unwrap();
+        writeln!(Console::writer(), "spi-controller: read {rx_buf:x?}\r").unwrap();
     }
 
     writeln!(Console::writer(), "spi-controller: inplace write-read\r").unwrap();
@@ -66,16 +61,13 @@ fn main() {
     {
         writeln!(
             Console::writer(),
-            "spi-controller: inplace write-read operation failed {:?}\r",
-            why
+            "spi-controller: inplace write-read operation failed {why:?}\r"
         )
         .unwrap();
     } else {
         writeln!(
             Console::writer(),
-            "spi-controller: inplace write-read: wrote {:x?}: read {:x?}\r",
-            tx_buf,
-            rx_buf
+            "spi-controller: inplace write-read: wrote {tx_buf:x?}: read {rx_buf:x?}\r"
         )
         .unwrap();
     }

--- a/examples/usb_i2c_mctp.rs
+++ b/examples/usb_i2c_mctp.rs
@@ -180,9 +180,9 @@ fn main() {
         assert_ne!(msg_len, 0);
 
         if let Err(why) = I2CMasterSlave::i2c_master_slave_write_sync(
-            target_id as u16,
+            target_id,
             &mut rx_buf[HEADER_LEN..HEADER_LEN + msg_len as usize],
-            msg_len as u16,
+            msg_len,
         ) {
             led_on(PANIC_LED);
             panic!("i2c-master: write operation failed {:?}", why);

--- a/nightly/rust-toolchain.toml
+++ b/nightly/rust-toolchain.toml
@@ -1,4 +1,4 @@
 # This is the nightly Rust toolchain used by `make test`.
 [toolchain]
-channel = "nightly-2025-05-19"
+channel = "nightly-2025-09-11"
 components = ["miri", "rust-src"]

--- a/panic_handlers/debug_panic/src/lib.rs
+++ b/panic_handlers/debug_panic/src/lib.rs
@@ -13,7 +13,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
 
     let mut writer = Console::<TockSyscalls>::writer();
     // If this printing fails, we can't panic harder, and we can't print it either.
-    let _ = writeln!(writer, "{}", info);
+    let _ = writeln!(writer, "{info}");
     // Exit with a non-zero exit code to indicate failure.
     TockSyscalls::exit_terminate(ErrorCode::Fail as u32);
 }

--- a/platform/src/error_code.rs
+++ b/platform/src/error_code.rs
@@ -266,7 +266,7 @@ impl ErrorCode {
 impl fmt::Debug for ErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.as_str() {
-            Some(s) => write!(f, "{}", s),
+            Some(s) => write!(f, "{s}"),
             None => write!(f, "code {}", *self as u16),
         }
     }

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -34,7 +34,7 @@ pub fn convert_elf(cli: &Cli, platform: &str) -> OutFiles {
     let mut tab_path = cli.elf.clone();
     tab_path.set_extension("tab");
     if cli.verbose {
-        println!("Package name: {:?}", package_name);
+        println!("Package name: {package_name:?}");
         println!("TAB path: {}", tab_path.display());
     }
     let stack_size = read_stack_size(cli);
@@ -44,7 +44,7 @@ pub fn convert_elf(cli: &Cli, platform: &str) -> OutFiles {
     let architecture =
         get_platform_architecture(platform).expect("Failed to determine ELF's architecture");
     if cli.verbose {
-        println!("ELF file: {:?}", elf);
+        println!("ELF file: {elf:?}");
         println!("TBF path: {}", tbf_path.display());
     }
 
@@ -55,7 +55,7 @@ pub fn convert_elf(cli: &Cli, platform: &str) -> OutFiles {
     if let Err(io_error) = remove_file(&tbf_path) {
         // Ignore file-no-found errors, panic on any other error.
         if io_error.kind() != ErrorKind::NotFound {
-            panic!("Unable to remove the TBF file. Error: {}", io_error);
+            panic!("Unable to remove the TBF file. Error: {io_error}");
         }
     }
 
@@ -74,15 +74,15 @@ pub fn convert_elf(cli: &Cli, platform: &str) -> OutFiles {
     ]);
     if cli.verbose {
         command.arg("-v");
-        println!("elf2tab command: {:?}", command);
+        println!("elf2tab command: {command:?}");
         println!("Spawning elf2tab");
     }
     let mut child = command.spawn().expect("failed to spawn elf2tab");
     let status = child.wait().expect("failed to wait for elf2tab");
     if cli.verbose {
-        println!("elf2tab finished. {}", status);
+        println!("elf2tab finished. {status}");
     }
-    assert!(status.success(), "elf2tab returned an error. {}", status);
+    assert!(status.success(), "elf2tab returned an error. {status}");
 
     // Verify that elf2tab created the TBF file, and that it is a file.
     match metadata(&tbf_path) {
@@ -120,7 +120,7 @@ fn read_stack_size(cli: &Cli) -> String {
         if section.shdr.name == ".stack" {
             let stack_size = section.shdr.size.to_string();
             if cli.verbose {
-                println!("Found .stack section, size: {}", stack_size);
+                println!("Found .stack section, size: {stack_size}");
             }
             return stack_size;
         }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -38,12 +38,12 @@ fn main() {
             panic!("LIBTOCK_PLATFORM must be specified to deploy")
         }
         Err(VarError::NotUnicode(platform)) => {
-            panic!("Non-UTF-8 LIBTOCK_PLATFORM value: {:?}", platform)
+            panic!("Non-UTF-8 LIBTOCK_PLATFORM value: {platform:?}")
         }
         Ok(platform) => platform,
     };
     if cli.verbose {
-        println!("Detected platform {}", platform);
+        println!("Detected platform {platform}");
     }
     let paths = elf2tab::convert_elf(&cli, &platform);
     let deploy = match cli.deploy {

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -46,8 +46,7 @@ pub fn process(cli: &Cli, mut child: Child) {
     drop(raw_mode);
     assert!(
         status.success(),
-        "Child process did not exit successfully. {}",
-        status
+        "Child process did not exit successfully. {status}"
     );
 }
 
@@ -80,7 +79,7 @@ fn forward_stdin_if_piped(child: &mut Child) -> Option<RawTerminal<Stdout>> {
                 // without sending SIGINT.
                 Err(error) if error.kind() == ErrorKind::BrokenPipe => return,
 
-                Err(error) => panic!("Failed to forward stdin: {}", error),
+                Err(error) => panic!("Failed to forward stdin: {error}"),
                 Ok(bytes) => our_stdin.consume(bytes),
             }
         }

--- a/runner/src/qemu.rs
+++ b/runner/src/qemu.rs
@@ -29,7 +29,7 @@ pub fn deploy(cli: &Cli, platform: String, tbf_path: PathBuf) -> Child {
     // QEMU's stderr through us and output_processor converts the line endings.
     qemu.stderr(Stdio::piped());
     if cli.verbose {
-        println!("QEMU command: {:?}", qemu);
+        println!("QEMU command: {qemu:?}");
         println!("Spawning QEMU")
     }
     qemu.spawn().expect("failed to spawn QEMU")
@@ -56,7 +56,7 @@ fn get_platform_args(platform: String) -> PlatformConfig {
             ],
             process_binary_load_address: "0x20030000",
         },
-        _ => panic!("Cannot deploy to platform {} via QEMU.", platform),
+        _ => panic!("Cannot deploy to platform {platform} via QEMU."),
     }
 }
 

--- a/runner/src/tockloader.rs
+++ b/runner/src/tockloader.rs
@@ -21,10 +21,10 @@ pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
             "--jtag-device",
             "nrf52",
         ],
-        _ => panic!("Cannot deploy to platform {} via tockloader", platform),
+        _ => panic!("Cannot deploy to platform {platform} via tockloader"),
     };
     if cli.verbose {
-        println!("Tockloader flags: {:?}", flags);
+        println!("Tockloader flags: {flags:?}");
     }
 
     // Tockloader listen's ability to receive every message from the Tock system
@@ -48,13 +48,10 @@ pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
 
         // We shouldn't hit this case, because the flag determination code above
         // should error out on unknown platforms.
-        _ => panic!("Unknown reliability for {}", platform),
+        _ => panic!("Unknown reliability for {platform}"),
     };
     if !reliable_listen {
-        println!(
-            "Warning: tockloader listen may miss early messages on platform {}",
-            platform
-        );
+        println!("Warning: tockloader listen may miss early messages on platform {platform}");
     }
 
     // Invoke tockloader uninstall to remove the process binary, if present.
@@ -62,7 +59,7 @@ pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
     uninstall.arg("uninstall");
     uninstall.args(flags);
     if cli.verbose {
-        println!("tockloader uninstall command: {:?}", uninstall);
+        println!("tockloader uninstall command: {uninstall:?}");
     }
     let mut child = uninstall
         .spawn()
@@ -71,7 +68,7 @@ pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
         .wait()
         .expect("failed to wait for tockloader uninstall");
     if cli.verbose {
-        println!("tockloader uninstall finished. {}", status);
+        println!("tockloader uninstall finished. {status}");
     }
 
     // Invoke tockloader install to deploy the new process binary.
@@ -80,17 +77,16 @@ pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
     install.args(flags);
     install.arg(tab_path);
     if cli.verbose {
-        println!("tockloader install command: {:?}", install);
+        println!("tockloader install command: {install:?}");
     }
     let mut child = install.spawn().expect("failed to spawn tockloader install");
     let status = child.wait().expect("failed to wait for tockloader install");
     if cli.verbose {
-        println!("tockloader install finished. {}", status);
+        println!("tockloader install finished. {status}");
     }
     assert!(
         status.success(),
-        "tockloader install returned unsuccessful status {}",
-        status
+        "tockloader install returned unsuccessful status {status}"
     );
 
     // Invoke tockloader listen to receive messages from the Tock system.
@@ -99,7 +95,7 @@ pub fn deploy(cli: &Cli, platform: String, tab_path: PathBuf) -> Child {
     listen.args(flags);
     listen.stdout(Stdio::piped());
     if cli.verbose {
-        println!("tockloader listen command: {:?}", listen);
+        println!("tockloader listen command: {listen:?}");
     }
     listen.spawn().expect("failed to spawn tockloader listen")
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,7 +6,7 @@
 # includes that feature. Whenever this value is updated, the rust-version field
 # in Cargo.toml must be updated as well.
 channel = "1.87"
-components = ["clippy", "rustfmt"]
+components = ["clippy", "rustfmt", "rust-analyzer"]
 targets = [
     "thumbv6m-none-eabi",
     "thumbv7em-none-eabi",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,7 +5,7 @@
 # you'd like to use. When you do so, update this to the first Rust version that
 # includes that feature. Whenever this value is updated, the rust-version field
 # in Cargo.toml must be updated as well.
-channel = "1.87"
+channel = "1.88"
 components = ["clippy", "rustfmt", "rust-analyzer"]
 targets = [
     "thumbv6m-none-eabi",

--- a/unittest/src/exit_test/mod.rs
+++ b/unittest/src/exit_test/mod.rs
@@ -88,8 +88,8 @@ pub(crate) fn signal_exit(exit_call: ExitCall) {
 impl std::fmt::Display for ExitCall {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {
-            ExitCall::Terminate(code) => write!(f, "exit-terminate({})", code),
-            ExitCall::Restart(code) => write!(f, "exit-restart({})", code),
+            ExitCall::Terminate(code) => write!(f, "exit-terminate({code})"),
+            ExitCall::Restart(code) => write!(f, "exit-restart({code})"),
         }
     }
 }
@@ -136,7 +136,7 @@ enum ExitMessage {
 impl std::fmt::Display for ExitMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
         match self {
-            ExitMessage::ExitCall(exit_call) => write!(f, "ExitCall({})", exit_call),
+            ExitMessage::ExitCall(exit_call) => write!(f, "ExitCall({exit_call})"),
             ExitMessage::WrongCase => write!(f, "WrongCase"),
             ExitMessage::DidNotExit => write!(f, "DidNotExit"),
         }
@@ -175,9 +175,9 @@ fn spawn_test(test_name: &str) -> ExitCall {
         .output()
         .expect("Subprocess exec failed");
     let stdout = String::from_utf8(output.stdout).expect("Subprocess produced invalid UTF-8");
-    println!("{} subprocess stdout:\n{}", test_name, stdout);
+    println!("{test_name} subprocess stdout:\n{stdout}");
     let stderr = String::from_utf8(output.stderr).expect("Subprocess produced invalid UTF-8");
-    println!("{} subprocess stderr:\n{}", test_name, stderr);
+    println!("{test_name} subprocess stderr:\n{stderr}");
 
     // Search for the exit message in stdout.
     for line in stdout.lines() {
@@ -199,7 +199,7 @@ fn spawn_test(test_name: &str) -> ExitCall {
 
 // Used by process B to send a message to process A.
 fn signal_message(message: ExitMessage) {
-    println!("{}{}", EXIT_STRING, message);
+    println!("{EXIT_STRING}{message}");
 }
 
 // Implements process B's behavior for exit_test. Verifies the test case was

--- a/unittest/src/expected_syscall.rs
+++ b/unittest/src/expected_syscall.rs
@@ -93,9 +93,6 @@ impl ExpectedSyscall {
     // incorrect system calls.
     pub(crate) fn panic_wrong_call(&self, called: &str) -> ! {
         // TODO: Implement Display for ExpectedSyscall and replace {:?} with {}
-        panic!(
-            "Expected system call {:?}, but {} was called instead.",
-            self, called
-        );
+        panic!("Expected system call {self:?}, but {called} was called instead.");
     }
 }

--- a/unittest/src/fake/low_level_debug/mod.rs
+++ b/unittest/src/fake/low_level_debug/mod.rs
@@ -56,8 +56,8 @@ impl core::fmt::Display for Message {
             Message::AlertCode(code) => {
                 write!(f, "alert code 0x{:x} ({})", code, alert_description(code))
             }
-            Message::Print1(arg0) => write!(f, "prints 0x{:x}", arg0),
-            Message::Print2(arg0, arg1) => write!(f, "prints 0x{:x} 0x{:x}", arg0, arg1),
+            Message::Print1(arg0) => write!(f, "prints 0x{arg0:x}"),
+            Message::Print2(arg0, arg1) => write!(f, "prints 0x{arg0:x} 0x{arg1:x}"),
         }
     }
 }
@@ -86,7 +86,7 @@ impl LowLevelDebug {
         // Format the message the same way as the real LowLevelDebug.
         // `libtock_unittest` doesn't support multiple processes, so we pretend
         // this is the first process (number 0).
-        println!("LowLevelDebug: App 0x0 {}", message);
+        println!("LowLevelDebug: App 0x0 {message}");
         let mut messages = self.messages.take();
         messages.push(message);
         self.messages.set(messages);

--- a/unittest/src/fake/syscalls/exit_impl.rs
+++ b/unittest/src/fake/syscalls/exit_impl.rs
@@ -5,7 +5,7 @@ pub(super) fn exit(r0: libtock_platform::Register, r1: libtock_platform::Registe
     let completion_code: u32 = r1.try_into().expect("Too large completion code");
     match exit_num {
         libtock_platform::exit_id::TERMINATE => {
-            println!("exit-terminate called with code {}", completion_code);
+            println!("exit-terminate called with code {completion_code}");
 
             #[cfg(not(miri))]
             crate::exit_test::signal_exit(crate::ExitCall::Terminate(completion_code));
@@ -13,13 +13,13 @@ pub(super) fn exit(r0: libtock_platform::Register, r1: libtock_platform::Registe
             std::process::exit(1);
         }
         libtock_platform::exit_id::RESTART => {
-            println!("exit-restart called with code {}", completion_code);
+            println!("exit-restart called with code {completion_code}");
 
             #[cfg(not(miri))]
             crate::exit_test::signal_exit(crate::ExitCall::Restart(completion_code));
 
             std::process::exit(1);
         }
-        _ => panic!("Unknown exit number {} invoked.", exit_num),
+        _ => panic!("Unknown exit number {exit_num} invoked."),
     }
 }

--- a/unittest/src/fake/syscalls/raw_syscalls_impl.rs
+++ b/unittest/src/fake/syscalls/raw_syscalls_impl.rs
@@ -7,7 +7,7 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
         match r0.try_into().expect("too-large Yield ID passed") {
             yield_id::NO_WAIT => panic!("yield-no-wait called without an argument"),
             yield_id::WAIT => super::yield_impl::yield_wait(),
-            id => panic!("unknown yield ID {}", id),
+            id => panic!("unknown yield ID {id}"),
         }
     }
 
@@ -21,14 +21,14 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
                 // we fail the test case regardless.
                 panic!("yield-wait called with an argument");
             }
-            id => panic!("unknown yield ID {}", id),
+            id => panic!("unknown yield ID {id}"),
         }
     }
 
     unsafe fn syscall1<const CLASS: usize>([r0]: [Register; 1]) -> [Register; 2] {
         match CLASS {
             syscall_class::MEMOP => super::memop_impl::memop(r0, 0u32.into()),
-            _ => panic!("Unknown syscall1 call. Class: {}", CLASS),
+            _ => panic!("Unknown syscall1 call. Class: {CLASS}"),
         }
     }
 
@@ -37,7 +37,7 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
         match CLASS {
             syscall_class::MEMOP => super::memop_impl::memop(r0, r1),
             syscall_class::EXIT => super::exit_impl::exit(r0, r1),
-            _ => panic!("Unknown syscall2 call. Class: {}", CLASS),
+            _ => panic!("Unknown syscall2 call. Class: {CLASS}"),
         }
     }
 
@@ -48,7 +48,7 @@ unsafe impl RawSyscalls for crate::fake::Syscalls {
             syscall_class::COMMAND => super::command_impl::command(r0, r1, r2, r3),
             syscall_class::ALLOW_RW => unsafe { super::allow_rw_impl::allow_rw(r0, r1, r2, r3) },
             syscall_class::ALLOW_RO => unsafe { super::allow_ro_impl::allow_ro(r0, r1, r2, r3) },
-            _ => panic!("Unknown syscall4 call. Class: {}", CLASS),
+            _ => panic!("Unknown syscall4 call. Class: {CLASS}"),
         }
     }
 }


### PR DESCRIPTION
This PR updates the rust-toolchain to 1.88 stable.

Individual commits should make for easy review:

1. 06846f310da2ab3252a9f8356551ba65d6674b1a adds `rust-analyzer` to the `rust-toolchain.toml` file (OK, this isn't striclty related but it basically helps keep IDE using the same Rust as the command line).
2. 1948c74910a32c46f2f46dcc059acd8ebaba1e07 Bumps the Rust version in `rust-toolchain.toml`
3. a9f3d20305091c7c59330c2ca7a1b4889825421a Mechanically fix new clippy lints and format using automated calls to `cargo clippy` and `cargo fmt`.