### PR TITLE
api: screen: return if command fails

### DIFF
--- a/apis/display/screen/src/lib.rs
+++ b/apis/display/screen/src/lib.rs
@@ -38,11 +38,12 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val = S::command(DRIVER_NUM, command::SET_BRIGHTNESS, value as u32, 0).to_result();
+            S::command(DRIVER_NUM, command::SET_BRIGHTNESS, value as u32, 0)
+                .to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })
@@ -53,11 +54,11 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val = S::command(DRIVER_NUM, command::SET_INVERT_ON, 0, 0).to_result();
+            S::command(DRIVER_NUM, command::SET_INVERT_ON, 0, 0).to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })
@@ -68,11 +69,11 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val = S::command(DRIVER_NUM, command::SET_INVERT_OFF, 0, 0).to_result();
+            S::command(DRIVER_NUM, command::SET_INVERT_OFF, 0, 0).to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })
@@ -119,6 +120,9 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
             let val = S::command(DRIVER_NUM, command::GET_ROTATION, 0, 0).to_result();
+            if val.is_err() {
+                return val;
+            }
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
@@ -153,17 +157,17 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val = S::command(
+            S::command(
                 DRIVER_NUM,
                 command::SET_RESOLUTION,
                 width as u32,
                 height as u32,
             )
-            .to_result();
+            .to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })
@@ -179,12 +183,12 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val =
-                S::command(DRIVER_NUM, command::SET_PIXEL_FORMAT, format as u32, 0).to_result();
+            S::command(DRIVER_NUM, command::SET_PIXEL_FORMAT, format as u32, 0)
+                .to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })
@@ -197,11 +201,11 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val = S::command(DRIVER_NUM, command::SET_WRITE_FRAME, data1, data2).to_result();
+            S::command(DRIVER_NUM, command::SET_WRITE_FRAME, data1, data2).to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })
@@ -221,11 +225,11 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
             let (allow_ro, subscribe) = handle.split();
             S::allow_ro::<C, DRIVER_NUM, { allow_ro::WRITE_BUFFER_ID }>(allow_ro, s)?;
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val = S::command(DRIVER_NUM, command::WRITE, s.len() as u32, 0).to_result();
+            S::command(DRIVER_NUM, command::WRITE, s.len() as u32, 0).to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })
@@ -249,11 +253,11 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
                 let (allow_ro, subscribe) = handle.split();
                 S::allow_ro::<C, DRIVER_NUM, { allow_ro::WRITE_BUFFER_ID }>(allow_ro, s)?;
                 S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-                let val = S::command(DRIVER_NUM, command::FILL, 0, 0).to_result();
+                S::command(DRIVER_NUM, command::FILL, 0, 0).to_result::<(), _>()?;
                 loop {
                     S::yield_wait();
                     if let Some((_,)) = called.get() {
-                        return val;
+                        return Ok(());
                     }
                 }
             })

--- a/apis/display/screen/src/lib.rs
+++ b/apis/display/screen/src/lib.rs
@@ -120,9 +120,7 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
             let val = S::command(DRIVER_NUM, command::GET_ROTATION, 0, 0).to_result();
-            if val.is_err() {
-                return val;
-            }
+            val?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {

--- a/apis/display/screen/src/lib.rs
+++ b/apis/display/screen/src/lib.rs
@@ -135,11 +135,12 @@ impl<S: Syscalls, C: Config> Screen<S, C> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope(|subscribe| {
             S::subscribe::<_, _, C, DRIVER_NUM, { subscribe::WRITE }>(subscribe, &called)?;
-            let val = S::command(DRIVER_NUM, command::SET_ROTATION, rotation as u32, 0).to_result();
+            S::command(DRIVER_NUM, command::SET_ROTATION, rotation as u32, 0)
+                .to_result::<(), _>()?;
             loop {
                 S::yield_wait();
                 if let Some((_,)) = called.get() {
-                    return val;
+                    return Ok(());
                 }
             }
         })

--- a/unittest/src/fake/screen/mod.rs
+++ b/unittest/src/fake/screen/mod.rs
@@ -163,11 +163,11 @@ impl crate::fake::SyscallDriver for Screen {
             }
 
             GET_RESOLUTION_WIDTH_HEIGHT => {
-                self.share_ref
-                    .schedule_upcall(0, (0, 0, 0))
-                    .expect("Unable to schedule upcall {}");
                 if argument0 < self.screen_resolution_width_height.len() as u32 {
                     if Option::is_some(&self.screen_setup) {
+                        self.share_ref
+                            .schedule_upcall(0, (0, 0, 0))
+                            .expect("Unable to schedule upcall {}");
                         crate::command_return::success_2_u32(
                             self.screen_resolution_width_height[argument0 as usize]
                                 .unwrap()
@@ -193,11 +193,11 @@ impl crate::fake::SyscallDriver for Screen {
             }
 
             PIXEL_FORMAT => {
-                self.share_ref
-                    .schedule_upcall(0, (0, 0, 0))
-                    .expect("Unable to schedule upcall {}");
                 if argument0 < self.screen_pixel_format.len() as u32 {
                     if Option::is_some(&self.screen_setup) {
+                        self.share_ref
+                            .schedule_upcall(0, (0, 0, 0))
+                            .expect("Unable to schedule upcall {}");
                         crate::command_return::success_u32(
                             self.screen_pixel_format[argument0 as usize] as u32,
                         )
@@ -217,13 +217,13 @@ impl crate::fake::SyscallDriver for Screen {
             }
 
             SET_ROTATION => {
-                self.share_ref
-                    .schedule_upcall(0, (0, 0, 0))
-                    .expect("Unable to schedule upcall {}");
                 if argument0 > 359 {
                     command_return::failure(ErrorCode::Invalid)
                 } else {
                     self.rotation.set(argument0 as u16);
+                    self.share_ref
+                        .schedule_upcall(0, (0, 0, 0))
+                        .expect("Unable to schedule upcall {}");
                     command_return::success()
                 }
             }
@@ -245,11 +245,11 @@ impl crate::fake::SyscallDriver for Screen {
             GET_PIXEL_FORMAT => command_return::success_u32(self.pixel_format.get()),
 
             SET_PIXEL_FORMAT => {
-                self.share_ref
-                    .schedule_upcall(0, (0, 0, 0))
-                    .expect("Unable to schedule upcall {}");
                 if argument0 < self.pixel_modes.unwrap() as u32 {
                     self.pixel_format.set(argument0);
+                    self.share_ref
+                        .schedule_upcall(0, (0, 0, 0))
+                        .expect("Unable to schedule upcall {}");
                     command_return::success()
                 } else {
                     command_return::failure(ErrorCode::Invalid)

--- a/unittest/src/fake/screen/tests.rs
+++ b/unittest/src/fake/screen/tests.rs
@@ -69,6 +69,9 @@ fn command() {
     // Set and validate pixel format
     assert!(screen.command(SET_PIXEL_FORMAT, 1, 0).is_success());
 
+    // Ensure that an invalid pixel format returns an error.
+    assert!(screen.command(SET_PIXEL_FORMAT, 99999, 0).is_failure());
+
     // Kernel setup for screen and buffer simulation
     let kernel = fake::Kernel::new();
     kernel.add_driver(&screen);


### PR DESCRIPTION
Right now the screen driver calls yield no matter what command returns. However, if a command returns an error no upcall will be called. This checks the return from the command and only calls yield if command returned success.