### PR TITLE
IEEE 802.15.4 Examples and API Fixes

### DIFF
--- a/apis/net/ieee802154/src/lib.rs
+++ b/apis/net/ieee802154/src/lib.rs
@@ -169,7 +169,8 @@ impl<S: Syscalls, C: Config> Ieee802154<S, C> {
 
 // Transmission
 impl<S: Syscalls, C: Config> Ieee802154<S, C> {
-    pub fn transmit_frame(frame: &[u8]) -> Result<(), ErrorCode> {
+    /// Transmit a frame using the IEEE 802.15.4 Phy Driver.
+    pub fn transmit_frame_raw(frame: &[u8]) -> Result<(), ErrorCode> {
         let called: Cell<Option<(u32,)>> = Cell::new(None);
         share::scope::<
             (
@@ -187,7 +188,7 @@ impl<S: Syscalls, C: Config> Ieee802154<S, C> {
                 subscribe, &called,
             )?;
 
-            S::command(DRIVER_NUM, command::TRANSMIT, 0, 0).to_result::<(), ErrorCode>()?;
+            S::command(DRIVER_NUM, command::TRANSMIT_RAW, 0, 0).to_result::<(), ErrorCode>()?;
 
             loop {
                 S::yield_wait();
@@ -253,7 +254,7 @@ mod command {
     pub const GET_PAN: u32 = 10;
     pub const GET_CHAN: u32 = 11;
     pub const GET_TX_PWR: u32 = 12;
-    pub const TRANSMIT: u32 = 27;
+    pub const TRANSMIT_RAW: u32 = 27;
     pub const SET_LONG_ADDR: u32 = 28;
     pub const GET_LONG_ADDR: u32 = 29;
     pub const TURN_ON: u32 = 30;

--- a/apis/net/ieee802154/src/tests.rs
+++ b/apis/net/ieee802154/src/tests.rs
@@ -111,8 +111,8 @@ fn transmit_frame() {
     let driver = fake::Ieee802154Phy::new();
     kernel.add_driver(&driver);
 
-    Ieee802154::transmit_frame(b"foo").unwrap();
-    Ieee802154::transmit_frame(b"bar").unwrap();
+    Ieee802154::transmit_frame_raw(b"foo").unwrap();
+    Ieee802154::transmit_frame_raw(b"bar").unwrap();
     assert_eq!(
         driver.take_transmitted_frames(),
         &[&b"foo"[..], &b"bar"[..]],

--- a/examples/ieee802154_raw.rs
+++ b/examples/ieee802154_raw.rs
@@ -11,6 +11,7 @@
 
 #![no_main]
 #![no_std]
+use core::fmt::Write;
 use libtock::console::Console;
 use libtock::ieee802154::{Ieee802154, RxOperator as _, RxRingBuffer, RxSingleBufferOperator};
 use libtock::runtime::{set_main, stack_size};

--- a/examples/ieee802154_raw.rs
+++ b/examples/ieee802154_raw.rs
@@ -1,4 +1,13 @@
 //! An example showing use of IEEE 802.15.4 networking.
+//!
+//! The kernel contains a standard and phy 15.4 driver. This example
+//! expects the kernel to be configured with the phy 15.4 driver to
+//! allow direct access to the radio and the ability to send "raw"
+//! frames. An example board file using this driver is provided at
+//! `boards/tutorials/nrf52840dk-thread-tutorial`.
+//!
+//! "No Support" Errors for setting the channel/tx power are a telltale
+//! sign that the kernel is not configured with the phy 15.4 driver.
 
 #![no_main]
 #![no_std]
@@ -17,21 +26,43 @@ fn main() {
     let tx_power: i8 = -3;
     let channel: u8 = 11;
 
+    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
+
     Ieee802154::set_pan(pan);
+    writeln!(Console::writer(), "Set PAN to {:#06x}\n", pan).unwrap();
+
     Ieee802154::set_address_short(addr_short);
+    writeln!(
+        Console::writer(),
+        "Set short address to {:#06x}\n",
+        addr_short
+    )
+    .unwrap();
+
     Ieee802154::set_address_long(addr_long);
+    writeln!(
+        Console::writer(),
+        "Set long address to {:#018x}\n",
+        addr_long
+    )
+    .unwrap();
+
     Ieee802154::set_tx_power(tx_power).unwrap();
+    writeln!(Console::writer(), "Set TX power to {}\n", tx_power).unwrap();
+
     Ieee802154::set_channel(channel).unwrap();
+    writeln!(Console::writer(), "Set channel to {}\n", channel).unwrap();
 
     // Don't forget to commit the config!
     Ieee802154::commit_config();
+    writeln!(Console::writer(), "Committed radio configuration!\n").unwrap();
 
     // Turn the radio on
     Ieee802154::radio_on().unwrap();
     assert!(Ieee802154::is_on());
 
     // Transmit a frame
-    Ieee802154::transmit_frame(b"foobar").unwrap();
+    Ieee802154::transmit_frame_raw(b"foobar").unwrap();
 
     Console::write(b"Transmitted frame!\n").unwrap();
 

--- a/examples/ieee802154_rx_raw.rs
+++ b/examples/ieee802154_rx_raw.rs
@@ -1,5 +1,14 @@
 //! An example showing use of IEEE 802.15.4 networking.
 //! It infinitely received a frame and prints its content to Console.
+//!
+//! The kernel contains a standard and phy 15.4 driver. This example
+//! expects the kernel to be configured with the phy 15.4 driver to
+//! allow direct access to the radio and the ability to send "raw"
+//! frames. An example board file using this driver is provided at
+//! `boards/tutorials/nrf52840dk-thread-tutorial`.
+//!
+//! "No Support" Errors for setting the channel/tx power are a telltale
+//! sign that the kernel is not configured with the phy 15.4 driver.
 
 #![no_main]
 #![no_std]
@@ -16,7 +25,7 @@ fn main() {
     let pan: u16 = 0xcafe;
     let addr_short: u16 = 0xdead;
     let addr_long: u64 = 0xdead_dad;
-    let tx_power: i8 = 5;
+    let tx_power: i8 = 4;
     let channel: u8 = 11;
 
     Ieee802154::set_pan(pan);

--- a/examples/ieee802154_rx_raw.rs
+++ b/examples/ieee802154_rx_raw.rs
@@ -70,12 +70,19 @@ fn main() {
         let frame = operator.receive_frame().unwrap();
 
         let body_len = frame.payload_len;
+
+        // Parse the counter.
+        let text = &frame.body[..body_len as usize - core::mem::size_of::<usize>()];
+        let counter_bytes =
+            &frame.body[body_len as usize - core::mem::size_of::<usize>()..body_len as usize];
+        let counter = usize::from_be_bytes(counter_bytes.try_into().unwrap());
+
         writeln!(
             Console::writer(),
-            "Received frame with body of len {}: {} {:?}!\n",
+            "Received frame with body of len {}: \"{} {}\"\n",
             body_len,
-            core::str::from_utf8(&frame.body).unwrap(),
-            &frame.body[..frame.body.len() - core::mem::size_of::<usize>()]
+            core::str::from_utf8(text).unwrap_or("-- error decoding utf8 string --"),
+            counter,
         )
         .unwrap();
     }

--- a/examples/ieee802154_rx_raw.rs
+++ b/examples/ieee802154_rx_raw.rs
@@ -12,7 +12,7 @@
 
 #![no_main]
 #![no_std]
-use core::fmt::Write as _;
+use core::fmt::Write;
 use libtock::console::Console;
 use libtock::ieee802154::{Ieee802154, RxOperator as _, RxRingBuffer, RxSingleBufferOperator};
 use libtock::runtime::{set_main, stack_size};
@@ -28,18 +28,41 @@ fn main() {
     let tx_power: i8 = 4;
     let channel: u8 = 11;
 
+    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
+
     Ieee802154::set_pan(pan);
+    writeln!(Console::writer(), "Set PAN to {:#06x}\n", pan).unwrap();
+
     Ieee802154::set_address_short(addr_short);
+    writeln!(
+        Console::writer(),
+        "Set short address to {:#06x}\n",
+        addr_short
+    )
+    .unwrap();
+
     Ieee802154::set_address_long(addr_long);
+    writeln!(
+        Console::writer(),
+        "Set long address to {:#018x}\n",
+        addr_long
+    )
+    .unwrap();
+
     Ieee802154::set_tx_power(tx_power).unwrap();
+    writeln!(Console::writer(), "Set TX power to {}\n", tx_power).unwrap();
+
     Ieee802154::set_channel(channel).unwrap();
+    writeln!(Console::writer(), "Set channel to {}\n", channel).unwrap();
 
     // Don't forget to commit the config!
     Ieee802154::commit_config();
+    writeln!(Console::writer(), "Committed radio configuration!\n").unwrap();
 
     // Turn the radio on
     Ieee802154::radio_on().unwrap();
     assert!(Ieee802154::is_on());
+    writeln!(Console::writer(), "Radio is on!\n").unwrap();
 
     let mut buf = RxRingBuffer::<2>::new();
     let mut operator = RxSingleBufferOperator::new(&mut buf);

--- a/examples/ieee802154_rx_tx_raw.rs
+++ b/examples/ieee802154_rx_tx_raw.rs
@@ -13,7 +13,7 @@
 
 #![no_main]
 #![no_std]
-use core::fmt::Write as _;
+use core::fmt::Write;
 use libtock::alarm::{Alarm, Milliseconds};
 use libtock::console::Console;
 use libtock::ieee802154::{Ieee802154, RxOperator as _, RxRingBuffer, RxSingleBufferOperator};
@@ -30,18 +30,41 @@ fn main() {
     let tx_power: i8 = 4;
     let channel: u8 = 11;
 
+    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
+
     Ieee802154::set_pan(pan);
+    writeln!(Console::writer(), "Set PAN to {:#06x}\n", pan).unwrap();
+
     Ieee802154::set_address_short(addr_short);
+    writeln!(
+        Console::writer(),
+        "Set short address to {:#06x}\n",
+        addr_short
+    )
+    .unwrap();
+
     Ieee802154::set_address_long(addr_long);
+    writeln!(
+        Console::writer(),
+        "Set long address to {:#018x}\n",
+        addr_long
+    )
+    .unwrap();
+
     Ieee802154::set_tx_power(tx_power).unwrap();
+    writeln!(Console::writer(), "Set TX power to {}\n", tx_power).unwrap();
+
     Ieee802154::set_channel(channel).unwrap();
+    writeln!(Console::writer(), "Set channel to {}\n", channel).unwrap();
 
     // Don't forget to commit the config!
     Ieee802154::commit_config();
+    writeln!(Console::writer(), "Committed radio configuration!\n").unwrap();
 
     // Turn the radio on
     Ieee802154::radio_on().unwrap();
     assert!(Ieee802154::is_on());
+    writeln!(Console::writer(), "Radio is on!\n").unwrap();
 
     let mut buf = RxRingBuffer::<2>::new();
     let mut operator = RxSingleBufferOperator::new(&mut buf);

--- a/examples/ieee802154_rx_tx_raw.rs
+++ b/examples/ieee802154_rx_tx_raw.rs
@@ -1,6 +1,15 @@
 //! An example showing use of IEEE 802.15.4 networking.
 //! It infinitely sends a frame with a constantly incremented counter,
 //! and after each send receives a frame and prints it to Console.
+//!
+//! The kernel contains a standard and phy 15.4 driver. This example
+//! expects the kernel to be configured with the phy 15.4 driver to
+//! allow direct access to the radio and the ability to send "raw"
+//! frames. An example board file using this driver is provided at
+//!
+//! "No Support" Errors for setting the channel/tx power are a telltale
+//! sign that the kernel is not configured with the phy 15.4 driver.
+//! `boards/tutorials/nrf52840dk-thread-tutorial`.
 
 #![no_main]
 #![no_std]
@@ -18,7 +27,7 @@ fn main() {
     let pan: u16 = 0xcafe;
     let addr_short: u16 = 0xdead;
     let addr_long: u64 = 0xdead_dad;
-    let tx_power: i8 = 5;
+    let tx_power: i8 = 4;
     let channel: u8 = 11;
 
     Ieee802154::set_pan(pan);
@@ -54,7 +63,7 @@ fn main() {
         set_buf_cnt(&mut buf, &mut counter);
 
         // Transmit a frame
-        Ieee802154::transmit_frame(&buf).unwrap();
+        Ieee802154::transmit_frame_raw(&buf).unwrap();
 
         writeln!(Console::writer(), "Transmitted frame {counter}!\n").unwrap();
 

--- a/examples/ieee802154_rx_tx_raw.rs
+++ b/examples/ieee802154_rx_tx_raw.rs
@@ -93,18 +93,19 @@ fn main() {
         let frame = operator.receive_frame().unwrap();
 
         let body_len = frame.payload_len;
+
+        // Parse the counter.
+        let text = &frame.body[..body_len as usize - core::mem::size_of::<usize>()];
+        let counter_bytes =
+            &frame.body[body_len as usize - core::mem::size_of::<usize>()..body_len as usize];
+        let received_counter = usize::from_be_bytes(counter_bytes.try_into().unwrap());
+
         writeln!(
             Console::writer(),
-            "Received frame with body of len {}: {}-{} {:?}!\n",
+            "Received frame with body of len {}: \"{} {}\"\n",
             body_len,
-            core::str::from_utf8(&frame.body[..frame.body.len() - core::mem::size_of::<usize>()])
-                .unwrap_or("<error decoding>"),
-            usize::from_le_bytes(
-                frame.body[frame.body.len() - core::mem::size_of::<usize>()..]
-                    .try_into()
-                    .unwrap()
-            ),
-            frame.body
+            core::str::from_utf8(text).unwrap_or("-- error decoding utf8 string --"),
+            received_counter,
         )
         .unwrap();
 

--- a/examples/ieee802154_tx_raw.rs
+++ b/examples/ieee802154_tx_raw.rs
@@ -12,7 +12,7 @@
 
 #![no_main]
 #![no_std]
-use core::fmt::Write as _;
+use core::fmt::Write;
 
 use libtock::alarm::{Alarm, Milliseconds};
 use libtock::console::Console;
@@ -30,18 +30,41 @@ fn main() {
     let tx_power: i8 = 4;
     let channel: u8 = 11;
 
+    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
+
     Ieee802154::set_pan(pan);
+    writeln!(Console::writer(), "Set PAN to {:#06x}\n", pan).unwrap();
+
     Ieee802154::set_address_short(addr_short);
+    writeln!(
+        Console::writer(),
+        "Set short address to {:#06x}\n",
+        addr_short
+    )
+    .unwrap();
+
     Ieee802154::set_address_long(addr_long);
+    writeln!(
+        Console::writer(),
+        "Set long address to {:#018x}\n",
+        addr_long
+    )
+    .unwrap();
+
     Ieee802154::set_tx_power(tx_power).unwrap();
+    writeln!(Console::writer(), "Set TX power to {}\n", tx_power).unwrap();
+
     Ieee802154::set_channel(channel).unwrap();
+    writeln!(Console::writer(), "Set channel to {}\n", channel).unwrap();
 
     // Don't forget to commit the config!
     Ieee802154::commit_config();
+    writeln!(Console::writer(), "Committed radio configuration!\n").unwrap();
 
     // Turn the radio on
     Ieee802154::radio_on().unwrap();
     assert!(Ieee802154::is_on());
+    writeln!(Console::writer(), "Radio is on!\n").unwrap();
 
     let mut counter = 0_usize;
     let mut buf = [

--- a/examples/ieee802154_tx_raw.rs
+++ b/examples/ieee802154_tx_raw.rs
@@ -1,5 +1,14 @@
 //! An example showing use of IEEE 802.15.4 networking.
 //! It infinitely sends a frame with a constantly incremented counter.
+//!
+//! The kernel contains a standard and phy 15.4 driver. This example
+//! expects the kernel to be configured with the phy 15.4 driver to
+//! allow direct access to the radio and the ability to send "raw"
+//! frames. An example board file using this driver is provided at
+//! `boards/tutorials/nrf52840dk-thread-tutorial`.
+//!
+//! "No Support" Errors for setting the channel/tx power are a telltale
+//! sign that the kernel is not configured with the phy 15.4 driver.
 
 #![no_main]
 #![no_std]
@@ -18,7 +27,7 @@ fn main() {
     let pan: u16 = 0xcafe;
     let addr_short: u16 = 0xdead;
     let addr_long: u64 = 0xdeaddad;
-    let tx_power: i8 = 5;
+    let tx_power: i8 = 4;
     let channel: u8 = 11;
 
     Ieee802154::set_pan(pan);
@@ -51,7 +60,7 @@ fn main() {
         set_buf_cnt(&mut buf, &mut counter);
 
         // Transmit a frame
-        Ieee802154::transmit_frame(&buf).unwrap();
+        Ieee802154::transmit_frame_raw(&buf).unwrap();
 
         writeln!(Console::writer(), "Transmitted frame {counter}!\n").unwrap();
 

--- a/unittest/src/fake/ieee802154/mod.rs
+++ b/unittest/src/fake/ieee802154/mod.rs
@@ -40,6 +40,7 @@ impl Frame {
     }
 }
 
+/// Fake IEEE 802.15.4 PHY driver implementation.
 pub struct Ieee802154Phy {
     pan: Cell<u16>,
     addr_short: Cell<u16>,


### PR DESCRIPTION
# IEEE 802.15.4 Examples and API Fixes

This PR updates the `libtock-rs` 15.4 API to account for the Phy/Standard 15.4 drivers in the kernel.

For context, the kernel has two 15.4 driver interfaces (that are mutually exclusive): a standard 15.4 driver and a Phy driver. The standard driver accepts payloads and forms the frame (adding headers, handling encryption, etc.). The Phy driver takes a buffer and transmits this buffer without modification. 

The existing 15.4 API uses the standard driver. However, this driver does not expose functionality for things such as setting the channel or tx power (resulting in the errors in https://github.com/tock/libtock-rs/issues/586).

## Changes 
- Update 15.4 API to include transmit "raw" (using Phy driver).
- Remove set channel / tx power from standard examples.
- Add a "tx_raw" example.
- Adds some more debug prints to the examples.

## TODO
- [x] I only have one board with me currently so I need to test tx/rx functionality together with two boards. I'll ping once this is ready to merge on my end.
- [x] We should integrate the libtock-rs 15.4 examples into the 15.4/OpenThread Nightly CI test.