### PR TITLE
add psc3m5_evk as target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,7 @@ $(eval $(call platform_build,imxrt1050,thumbv7em-none-eabi))
 $(eval $(call platform_build,msp432,thumbv7em-none-eabi))
 $(eval $(call platform_build,clue_nrf52840,thumbv7em-none-eabi))
 $(eval $(call platform_flash,clue_nrf52840,thumbv7em-none-eabi))
+$(eval $(call platform_build,psc3m5_evk,thumbv8m.main-none-eabi))
 
 .PHONY: demos
 demos:

--- a/build_scripts/src/lib.rs
+++ b/build_scripts/src/lib.rs
@@ -25,6 +25,7 @@ const PLATFORMS: &[(&str, &str, &str, &str, &str)] = &[
     ("stm32f3discovery"   , "0x08020000", "0x0020000", "0x20004000", "48K"    ),
     ("stm32f412gdiscovery", "0x08030000", "256K"     , "0x20004000", "112K"   ),
     ("nano33ble"          , "0x00050000", "704K"     , "0x20005000", "240K"   ),
+    ("psc3m5_evk"         , "0x32020000", "0x20000"  , "0x34006000", "0x5800" ),
 ];
 
 /// Helper function to configure cargo to use suitable linker scripts for

--- a/runner/src/elf2tab.rs
+++ b/runner/src/elf2tab.rs
@@ -23,6 +23,7 @@ fn get_platform_architecture(platform: &str) -> Option<&'static str> {
         "imxrt1050" | "teensy40" => Some("cortex-m7"),
         "opentitan" | "esp32_c3_devkitm_1" => Some("riscv32imc"),
         "hifive1" | "qemu_rv32_virt" => Some("riscv32imac"),
+        "psc3m5_evk" => Some("cortex-m33"),
         _ => None,
     }
 }


### PR DESCRIPTION
For the PR to add the board to tock. This adds the platform to libtock-rs. https://github.com/tock/tock/pull/4779