### PR TITLE
layout: don't give the NOLOAD .stack section a flash LMA

### DIFF
--- a/build_scripts/libtock_layout.ld
+++ b/build_scripts/libtock_layout.ld
@@ -136,7 +136,7 @@ SECTIONS {
         KEEP(*(.stack_buffer))
         . = ALIGN(16);
         _stack_top = .;  /* Used in rt_header */
-    } > RAM AT > FLASH
+    } > RAM
 
     /* Read-write data section. This is deployed as part of FLASH but is copied
      * into RAM at runtime.


### PR DESCRIPTION
The .stack section is NOLOAD but used `> RAM AT > FLASH`. Because it precedes .data and was also assigned a flash load address, the linker reserved stack-sized space in the flash LMA layout, leaving a gap between .rodata and .data. elf2tab pads gaps between load segments, so this gap was emitted as zero bytes into the TBF, inflating the flash image for stack space that is never loaded from flash.

Drop `AT > FLASH` so .stack's LMA equals its RAM VMA and .data follows .rodata with no gap. rt_header uses LOADADDR(.data) and _sram_origin/_stack_top are VMAs, so ARM/RISC-V behavior should be unchanged.