### PR TITLE
Fix IEEE 802.15.4 address handling and raw transmit error propagation (closes 596)

### DIFF
--- a/apis/net/ieee802154/src/lib.rs
+++ b/apis/net/ieee802154/src/lib.rs
@@ -149,7 +149,7 @@ impl<S: Syscalls, C: Config> Ieee802154<S, C> {
         S::command(DRIVER_NUM, command::GET_PAN, 0, 0)
             .to_result::<u32, _>()
             // Driver adds 1 to make the value positive.
-            .map(|pan| pan as u16 - 1)
+            .map(|pan| (pan - 1) as u16)
     }
 
     #[inline(always)]

--- a/apis/net/ieee802154/src/lib.rs
+++ b/apis/net/ieee802154/src/lib.rs
@@ -90,8 +90,8 @@ impl<S: Syscalls, C: Config> Ieee802154<S, C> {
         let _ = S::command(
             DRIVER_NUM,
             command::SET_SHORT_ADDR,
-            // Driver expects 1 added to make the value positive.
-            short_addr as u32 + 1,
+            // Driver expects the value as-is.
+            short_addr as u32,
             0,
         );
     }
@@ -110,7 +110,7 @@ impl<S: Syscalls, C: Config> Ieee802154<S, C> {
         let _ = S::command(
             DRIVER_NUM,
             command::SET_PAN,
-            pan as u32 + 1, // Driver expects 1 added to make the value positive.
+            pan as u32, // Driver expects the value as-is.
             0,
         );
     }
@@ -136,7 +136,7 @@ impl<S: Syscalls, C: Config> Ieee802154<S, C> {
         S::command(DRIVER_NUM, command::GET_SHORT_ADDR, 0, 0)
             .to_result::<u32, _>()
             // Driver adds 1 to make the value positive.
-            .map(|addr| addr as u16 - 1)
+            .map(|addr| (addr - 1) as u16)
     }
 
     #[inline(always)]
@@ -192,8 +192,11 @@ impl<S: Syscalls, C: Config> Ieee802154<S, C> {
 
             loop {
                 S::yield_wait();
-                if called.get().is_some() {
-                    return Ok(());
+                if let Some((status,)) = called.get() {
+                    return match status {
+                        0 => Ok(()),
+                        error => Err(error.try_into().unwrap_or(ErrorCode::Fail)),
+                    };
                 }
             }
         })

--- a/apis/net/ieee802154/src/tests.rs
+++ b/apis/net/ieee802154/src/tests.rs
@@ -103,6 +103,16 @@ fn configure() {
     assert_eq!(Ieee802154::get_address_long().unwrap(), addr_long);
     assert_eq!(Ieee802154::get_channel().unwrap(), channel);
     assert_eq!(Ieee802154::get_tx_power().unwrap(), tx_power);
+
+    for pan in [0x0000, 0x0001, 0xcafe, 0xffff] {
+        Ieee802154::set_pan(pan);
+        assert_eq!(Ieee802154::get_pan().unwrap(), pan);
+    }
+
+    for address in [0x0000, 0x0001, 0xdead, 0xffff] {
+        Ieee802154::set_address_short(address);
+        assert_eq!(Ieee802154::get_address_short().unwrap(), address);
+    }
 }
 
 #[test]

--- a/unittest/src/fake/ieee802154/mod.rs
+++ b/unittest/src/fake/ieee802154/mod.rs
@@ -261,8 +261,10 @@ impl crate::fake::SyscallDriver for Ieee802154Phy {
                 command_return::success()
             }
             command::COMMIT_CFG => command_return::success(),
-            command::GET_SHORT_ADDR => command_return::success_u32(self.addr_short.get() as u32),
-            command::GET_PAN => command_return::success_u32(self.pan.get() as u32),
+            command::GET_SHORT_ADDR => {
+                command_return::success_u32(self.addr_short.get() as u32 + 1)
+            }
+            command::GET_PAN => command_return::success_u32(self.pan.get() as u32 + 1),
             command::GET_CHAN => command_return::success_u32(self.chan.get() as u32),
             command::GET_TX_PWR => command_return::success_u32(self.tx_power.get() as i32 as u32),
             command::SET_LONG_ADDR => {

--- a/unittest/src/fake/ieee802154/mod.rs
+++ b/unittest/src/fake/ieee802154/mod.rs
@@ -289,7 +289,7 @@ impl crate::fake::SyscallDriver for Ieee802154Phy {
                 self.tx_buf.set(tx_buf);
                 self.transmitted_frames.set(transmitted_frames);
                 self.share_ref
-                    .schedule_upcall(subscribe::FRAME_TRANSMITTED, (2137, 0, 0))
+                    .schedule_upcall(subscribe::FRAME_TRANSMITTED, (0, 0, 0))
                     .expect("Unable to schedule upcall {}");
 
                 command_return::success()


### PR DESCRIPTION
# Overview

This PR fixes three issues in the libtock-rs IEEE 802.15.4 API and closes #596. The issues fixed are:

1. `set_address_short()` and `set_pan()` incorrectly added 1 to values before passing them to the Tock driver.
2. The getter response decoding narrowed values to `u16` before subtracting the offset added by the driver.
3. `transmit_frame_raw()` ignored errors reported through the transmission-complete upcall.

This work follows the discussion [Why do Tock's MAC and physical IEEE 802.15.4 capsule drivers add 1 to their `CommandReturn::success_u32` return values?](https://github.com/tock/tock/discussions/4739).

Other IEEE 802.15.4 changes are outside the scope of this PR and will be addressed separately.

## Address and PAN setters

The Tock IEEE 802.15.4 drivers expect short addresses and PAN IDs to be passed without modification:

- [`SET_SHORT_ADDR`](https://github.com/tock/tock/blob/f547b95c9a257d879e20f1129953ab1f69b2b5b4/capsules/extra/src/ieee802154/driver.rs#L682) passes `arg1 as u16` directly to `set_address()`.
- [`SET_PAN`](https://github.com/tock/tock/blob/f547b95c9a257d879e20f1129953ab1f69b2b5b4/capsules/extra/src/ieee802154/driver.rs#L705) passes `arg1 as u16` directly to `set_pan()`.

However, libtock-rs previously added 1 before invoking these commands:

```rust
short_addr as u32 + 1
pan as u32 + 1
```

This shifted every configured value and caused `0xffff` to wrap to zero when the driver narrowed it to `u16`.

This PR removes the incorrect additions and passes both values to the driver as-is.

## Address and PAN getters

Unlike the setter commands, the Tock drivers add 1 when returning a short address or PAN ID:

- [`GET_SHORT_ADDR`](https://github.com/tock/tock/blob/f547b95c9a257d879e20f1129953ab1f69b2b5b4/capsules/extra/src/ieee802154/driver.rs#L717-L721)
- [`GET_PAN`](https://github.com/tock/tock/blob/f547b95c9a257d879e20f1129953ab1f69b2b5b4/capsules/extra/src/ieee802154/driver.rs#L739-L743)

libtock-rs must therefore subtract 1 when decoding these responses. The subtraction must happen while the value is still a `u32`:

```rust
.map(|value| (value - 1) as u16)
```

Casting before subtracting is incorrect for `0xffff`. The driver encodes this value as `0x1_0000`, which requires 17 bits. Narrowing it first produces zero, after which subtracting 1 can overflow.

## Raw transmission errors

`transmit_frame_raw()` previously returned `Ok(())` whenever the transmission-complete upcall ran, regardless of the status reported by that upcall.

This PR checks the callback status and:

- Returns `Ok(())` when the status is zero.
- Converts a nonzero status into an `ErrorCode`.
- Falls back to `ErrorCode::Fail` if the status is not a recognized error code.

## Fake driver and tests

The fake IEEE 802.15.4 driver now matches the Tock drivers by adding 1 to values returned by `GET_SHORT_ADDR` and `GET_PAN`.

The configuration tests now exercise round trips for:

- Zero: `0x0000`
- One: `0x0001`
- Representative intermediate values
- The maximum 16-bit value: `0xffff`

These cases verify both the setter behavior and correct decoding of the getter responses.

One code discrepancy to fix before publishing: the current local diff changes `get_address_short()` to subtract before narrowing, but `get_pan()` still contains:

```rust
.map(|pan| pan as u16 - 1)
```

To match this description and handle `0xffff`, it should be:

```rust
.map(|pan| (pan - 1) as u16)
```

# AI Usage
I used OpenAI Codex to help with the fix and Google Gemni to review the patch. I reviewed all committed code.