### PR TITLE
update IEEE 802.15.4 example to have packets decode as data packets with appropriate frame control fields and header

### DIFF
--- a/examples/ieee802154_tx_raw.rs
+++ b/examples/ieee802154_tx_raw.rs
@@ -17,6 +17,7 @@ use core::fmt::Write;
 use libtock::alarm::{Alarm, Milliseconds};
 use libtock::console::Console;
 use libtock::ieee802154::Ieee802154;
+use libtock::platform::ErrorCode;
 use libtock::runtime::{set_main, stack_size};
 
 set_main! {main}
@@ -24,72 +25,126 @@ stack_size! {0x600}
 
 const TRANSMIT_INTERVAL_MS: u32 = 1000;
 
-const FCF_BROADCAST_DATA: u16 = 0x9841;
-const BROADCAST_ADDRESS: u16 = 0xffff;
+const FRAME_TYPE_DATA: u16 = 1;
+const PAN_ID_COMPRESSION: u16 = 1 << 6;
+const ADDRESS_MODE_SHORT: u16 = 2;
+const FRAME_VERSION_IEEE_802154_2006: u16 = 1;
+
+// Ref: Section 7.2.2.2 Frame Type field, Table 7-3 addressing modes, and Table 7-4
+// Frame Version field (IEEE 802.15.4-2020)
+const FCF_DATA: u16 = FRAME_TYPE_DATA
+    | PAN_ID_COMPRESSION
+    | (ADDRESS_MODE_SHORT << 10)
+    | (FRAME_VERSION_IEEE_802154_2006 << 12)
+    | (ADDRESS_MODE_SHORT << 14);
+
+// Destination address configuration. 0xffff broadcasts to every device in the
+// PAN; replace it with a specific short address to send a unicast frame.
+const DESTINATION_ADDRESS: u16 = 0xffff;
+
+// Ref: Section 7.2.2 MAC Frame Format (IEEE 802.15.4-2020)
+// If the address modes above change, update these header offsets and MAC_HEADER_LEN.
+const FRAME_CONTROL_OFFSET: usize = 0;
+const SEQUENCE_NUMBER_OFFSET: usize = 2;
+const DESTINATION_PAN_ID_OFFSET: usize = 3;
+const DESTINATION_ADDRESS_OFFSET: usize = 5;
+const SOURCE_ADDRESS_OFFSET: usize = 7;
 const MAC_HEADER_LEN: usize = 9;
 
-const BEACON_TAG: &[u8; 7] = b"beacon ";
-const COUNTER_LEN: usize = 2;
-const FRAME_LEN: usize = MAC_HEADER_LEN + BEACON_TAG.len() + COUNTER_LEN;
-const COUNTER_OFFSET: usize = MAC_HEADER_LEN + BEACON_TAG.len();
+// Payload configuration: change PAYLOAD_PREFIX or populate_payload() to use
+// different fixed-length payload data.
+const COUNTER_LEN: usize = core::mem::size_of::<u16>();
+const PAYLOAD_PREFIX: &[u8] = b"beacon ";
+const PAYLOAD_PREFIX_LEN: usize = PAYLOAD_PREFIX.len();
+const PAYLOAD_LEN: usize = PAYLOAD_PREFIX_LEN + COUNTER_LEN;
 
-pub const DEVICE_NAME: &str = "board-a";
+// An IEEE 802.15.4 frame can contain at most 127 bytes, including the two-byte
+// MAC footer added by the radio. This example supplies the header and payload.
+const MAX_MAC_FRAME_LEN: usize = 127;
+const MAC_FOOTER_LEN: usize = 2;
+const MAX_PAYLOAD_LEN: usize = MAX_MAC_FRAME_LEN - MAC_FOOTER_LEN - MAC_HEADER_LEN;
+const FRAME_LEN: usize = {
+    assert!(
+        PAYLOAD_LEN <= MAX_PAYLOAD_LEN,
+        "PAYLOAD_LEN is too large for an IEEE 802.15.4 frame"
+    );
+    MAC_HEADER_LEN + PAYLOAD_LEN
+};
+
+// Source address configuration: change these values for the transmitting device.
+// The raw frame uses PAN_ID and SHORT_ADDRESS; LONG_ADDRESS configures the radio.
 pub const PAN_ID: u16 = 0xcafe;
 pub const SHORT_ADDRESS: u16 = 0x1001;
 pub const LONG_ADDRESS: u64 = 0xdeaddad;
 pub const CHANNEL: u8 = 11;
 pub const TX_POWER: i8 = 4;
 
+/// Initializes the header in an exact-length data frame.
+fn initialize_data_frame(frame: &mut [u8; FRAME_LEN]) {
+    frame[FRAME_CONTROL_OFFSET..SEQUENCE_NUMBER_OFFSET].copy_from_slice(&FCF_DATA.to_le_bytes());
+    frame[DESTINATION_PAN_ID_OFFSET..DESTINATION_ADDRESS_OFFSET]
+        .copy_from_slice(&PAN_ID.to_le_bytes());
+    frame[DESTINATION_ADDRESS_OFFSET..SOURCE_ADDRESS_OFFSET]
+        .copy_from_slice(&DESTINATION_ADDRESS.to_le_bytes());
+    frame[SOURCE_ADDRESS_OFFSET..MAC_HEADER_LEN].copy_from_slice(&SHORT_ADDRESS.to_le_bytes());
+}
+
+/// Creates every byte of the fixed-length payload for one transmission.
+///
+/// Modify this function and the payload constants above to generate different
+/// payload contents. Returning `[u8; PAYLOAD_LEN]` keeps its size fixed.
+fn populate_payload(counter: u16) -> [u8; PAYLOAD_LEN] {
+    let mut payload = [0_u8; PAYLOAD_LEN];
+    payload[..PAYLOAD_PREFIX_LEN].copy_from_slice(PAYLOAD_PREFIX);
+    payload[PAYLOAD_PREFIX_LEN..].copy_from_slice(&counter.to_be_bytes());
+    payload
+}
+
+/// Transmits only a frame whose array length is exactly [`FRAME_LEN`].
+fn transmit_data_frame(frame: &[u8; FRAME_LEN]) -> Result<(), ErrorCode> {
+    Ieee802154::transmit_frame_raw(frame)
+}
+
 fn main() {
     // Configure the radio
-    let pan: u16 = PAN_ID;
-    let addr_short: u16 = SHORT_ADDRESS;
-    let addr_long: u64 = LONG_ADDRESS;
-    let tx_power: i8 = TX_POWER;
-    let channel: u8 = CHANNEL;
+    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...").unwrap();
 
-    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
+    Ieee802154::set_pan(PAN_ID);
+    writeln!(Console::writer(), "Set PAN to {PAN_ID:#06x}").unwrap();
 
-    Ieee802154::set_pan(pan);
-    writeln!(Console::writer(), "Set PAN to {:#06x}\n", pan).unwrap();
-
-    Ieee802154::set_address_short(addr_short);
+    Ieee802154::set_address_short(SHORT_ADDRESS);
     writeln!(
         Console::writer(),
-        "Set short address to {:#06x}\n",
-        addr_short
+        "Set short address to {SHORT_ADDRESS:#06x}"
     )
     .unwrap();
 
-    Ieee802154::set_address_long(addr_long);
+    Ieee802154::set_address_long(LONG_ADDRESS);
     writeln!(
         Console::writer(),
-        "Set long address to {:#018x}\n",
-        addr_long
+        "Set long address to {LONG_ADDRESS:#018x}"
     )
     .unwrap();
 
-    Ieee802154::set_tx_power(tx_power).unwrap();
-    writeln!(Console::writer(), "Set TX power to {}\n", tx_power).unwrap();
+    Ieee802154::set_tx_power(TX_POWER).unwrap();
+    writeln!(Console::writer(), "Set TX power to {TX_POWER}").unwrap();
 
-    Ieee802154::set_channel(channel).unwrap();
-    writeln!(Console::writer(), "Set channel to {}\n", channel).unwrap();
+    Ieee802154::set_channel(CHANNEL).unwrap();
+    writeln!(Console::writer(), "Set channel to {CHANNEL}").unwrap();
 
     // Don't forget to commit the config!
     Ieee802154::commit_config();
-    writeln!(Console::writer(), "Committed radio configuration!\n").unwrap();
+    writeln!(Console::writer(), "Committed radio configuration!").unwrap();
 
     // Turn the radio on
     Ieee802154::radio_on().unwrap();
     assert!(Ieee802154::is_on());
-    writeln!(Console::writer(), "Radio is on!\n").unwrap();
+    writeln!(Console::writer(), "Radio is on!").unwrap();
 
+    // This array has exactly the length checked against MAX_MAC_FRAME_LEN above,
+    // so passing the whole array cannot accidentally transmit unused buffer bytes.
     let mut tx_frame = [0_u8; FRAME_LEN];
-    tx_frame[0..2].copy_from_slice(&FCF_BROADCAST_DATA.to_le_bytes());
-    tx_frame[3..5].copy_from_slice(&PAN_ID.to_le_bytes());
-    tx_frame[5..7].copy_from_slice(&BROADCAST_ADDRESS.to_le_bytes());
-    tx_frame[7..9].copy_from_slice(&SHORT_ADDRESS.to_le_bytes());
-    tx_frame[MAC_HEADER_LEN..COUNTER_OFFSET].copy_from_slice(BEACON_TAG);
+    initialize_data_frame(&mut tx_frame);
 
     let mut sequence = 0_u8;
     let mut counter = 0_u16;
@@ -97,23 +152,21 @@ fn main() {
     loop {
         Alarm::sleep_for(Milliseconds(TRANSMIT_INTERVAL_MS)).unwrap();
 
-        tx_frame[2] = sequence;
-        tx_frame[COUNTER_OFFSET..FRAME_LEN].copy_from_slice(&counter.to_be_bytes());
+        tx_frame[SEQUENCE_NUMBER_OFFSET] = sequence;
 
-        match Ieee802154::transmit_frame_raw(&tx_frame) {
-            Ok(()) => {}
-            Err(error) => {
-                writeln!(Console::writer(), "TX failed: {:?}", error).unwrap();
-                continue;
-            }
+        // Replace the entire payload on every iteration.
+        let payload = populate_payload(counter);
+        tx_frame[MAC_HEADER_LEN..].copy_from_slice(&payload);
+
+        if let Err(error) = transmit_data_frame(&tx_frame) {
+            writeln!(Console::writer(), "TX failed: {error:?}").unwrap();
+            // Retry the same sequence number and counter after the next interval.
+            continue;
         }
 
         writeln!(
             Console::writer(),
-            "TX broadcast: src={:#06x}, sequence={}, count={}",
-            SHORT_ADDRESS,
-            sequence,
-            counter,
+            "TX data: src={SHORT_ADDRESS:#06x}, dst={DESTINATION_ADDRESS:#06x}, sequence={sequence}, count={counter}",
         )
         .unwrap();
 

--- a/examples/ieee802154_tx_raw.rs
+++ b/examples/ieee802154_tx_raw.rs
@@ -22,13 +22,31 @@ use libtock::runtime::{set_main, stack_size};
 set_main! {main}
 stack_size! {0x600}
 
+const TRANSMIT_INTERVAL_MS: u32 = 1000;
+
+const FCF_BROADCAST_DATA: u16 = 0x9841;
+const BROADCAST_ADDRESS: u16 = 0xffff;
+const MAC_HEADER_LEN: usize = 9;
+
+const BEACON_TAG: &[u8; 7] = b"beacon ";
+const COUNTER_LEN: usize = 2;
+const FRAME_LEN: usize = MAC_HEADER_LEN + BEACON_TAG.len() + COUNTER_LEN;
+const COUNTER_OFFSET: usize = MAC_HEADER_LEN + BEACON_TAG.len();
+
+pub const DEVICE_NAME: &str = "board-a";
+pub const PAN_ID: u16 = 0xcafe;
+pub const SHORT_ADDRESS: u16 = 0x1001;
+pub const LONG_ADDRESS: u64 = 0xdeaddad;
+pub const CHANNEL: u8 = 11;
+pub const TX_POWER: i8 = 4;
+
 fn main() {
     // Configure the radio
-    let pan: u16 = 0xcafe;
-    let addr_short: u16 = 0xdead;
-    let addr_long: u64 = 0xdeaddad;
-    let tx_power: i8 = 4;
-    let channel: u8 = 11;
+    let pan: u16 = PAN_ID;
+    let addr_short: u16 = SHORT_ADDRESS;
+    let addr_long: u64 = LONG_ADDRESS;
+    let tx_power: i8 = TX_POWER;
+    let channel: u8 = CHANNEL;
 
     writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
 
@@ -66,27 +84,40 @@ fn main() {
     assert!(Ieee802154::is_on());
     writeln!(Console::writer(), "Radio is on!\n").unwrap();
 
-    let mut counter = 0_usize;
-    let mut buf = [
-        b'f', b'r', b'a', b'm', b'e', b' ', b'n', b'.', b'o', b'.', b' ', b'\0', b'\0', b'\0',
-        b'\0',
-    ];
-    fn set_buf_cnt(buf: &mut [u8], counter: &mut usize) {
-        let buf_len = buf.len();
-        let buf_cnt = &mut buf[buf_len - core::mem::size_of_val(&counter)..];
-        buf_cnt.copy_from_slice(&counter.to_be_bytes());
-    }
+    let mut tx_frame = [0_u8; FRAME_LEN];
+    tx_frame[0..2].copy_from_slice(&FCF_BROADCAST_DATA.to_le_bytes());
+    tx_frame[3..5].copy_from_slice(&PAN_ID.to_le_bytes());
+    tx_frame[5..7].copy_from_slice(&BROADCAST_ADDRESS.to_le_bytes());
+    tx_frame[7..9].copy_from_slice(&SHORT_ADDRESS.to_le_bytes());
+    tx_frame[MAC_HEADER_LEN..COUNTER_OFFSET].copy_from_slice(BEACON_TAG);
+
+    let mut sequence = 0_u8;
+    let mut counter = 0_u16;
 
     loop {
-        Alarm::sleep_for(Milliseconds(1000)).unwrap();
+        Alarm::sleep_for(Milliseconds(TRANSMIT_INTERVAL_MS)).unwrap();
 
-        set_buf_cnt(&mut buf, &mut counter);
+        tx_frame[2] = sequence;
+        tx_frame[COUNTER_OFFSET..FRAME_LEN].copy_from_slice(&counter.to_be_bytes());
 
-        // Transmit a frame
-        Ieee802154::transmit_frame_raw(&buf).unwrap();
+        match Ieee802154::transmit_frame_raw(&tx_frame) {
+            Ok(()) => {}
+            Err(error) => {
+                writeln!(Console::writer(), "TX failed: {:?}", error).unwrap();
+                continue;
+            }
+        }
 
-        writeln!(Console::writer(), "Transmitted frame {counter}!\n").unwrap();
+        writeln!(
+            Console::writer(),
+            "TX broadcast: src={:#06x}, sequence={}, count={}",
+            SHORT_ADDRESS,
+            sequence,
+            counter,
+        )
+        .unwrap();
 
-        counter += 1;
+        sequence = sequence.wrapping_add(1);
+        counter = counter.wrapping_add(1);
     }
 }


### PR DESCRIPTION
# Overview
This closes issue #586 and updates the IEEE 802.15.4 tx example to have packets decode as data packets with appropriate frame control fields and header. The packet now decodes as an 802.15.4 data packet as shown below (The 6LoWPAN reference can be ignored since 802.15.4 packets don't have a payload protocol field so the analyzer has to guess at it)

<img width="1912" height="810" alt="image" src="https://github.com/user-attachments/assets/284806cf-9342-40aa-9387-65af20da0220" />

Two issues to note, neither I think related to the libtock-rs code.
1. As discussed in #586 the delta time is 500 ms instead of 1000 ms. I plan on investigating this, but think it is not related to the example code being modified.
2. For frame 157 with the seq number 163 the delta is 1000 ms. This is because now that `transmit_frame_raw` checks the status code, sometimes it is busy as seen in the tock console output
```
TX broadcast: src=0x1001, sequence=159, count=159
TX broadcast: src=0x1001, sequence=160, count=160
TX broadcast: src=0x1001, sequence=161, count=161
TX broadcast: src=0x1001, sequence=162, count=162
TX failed: BUSY
TX broadcast: src=0x1001, sequence=163, count=163
TX broadcast: src=0x1001, sequence=164, count=164
TX broadcast: src=0x1001, sequence=165, count=165
TX broadcast: src=0x1001, sequence=166, count=166
TX broadcast: src=0x1001, sequence=167, count=167
```
Codex thinks this is because:
```
The likely bug is in the Tock nRF52840 IEEE 802.15.4 radio driver, not your frame-building code.
The driver stores CCA/CSMA retry state here:
cca_count
cca_be
They are initialized once at boot in [ieee802154_radio.rs (line 697)](/home/user/workspace/tockos/pr/libtock-rs/tock/chips/nrf52840/src/ieee802154_radio.rs:697), but never reset when beginning a new transmission.
```
This is something I need to investigate in a separate issue, but I don't feel it is relevant to the code being committed in this PR.

I generated 621 packets and the sequence number rolled over multiple times correctly. I did not see any missing packets. 

# AI usage
I used OpenAI Codex for help with code generation and evaluation. I reviewed any code it generated.

# Testing
`make test` passed