### PR TITLE
Update IEEE 802.15.4 receive example to show packets decode as data packets with appropriate frame control fields and header

### DIFF
--- a/examples/ieee802154_rx_raw.rs
+++ b/examples/ieee802154_rx_raw.rs
@@ -20,40 +20,258 @@ use libtock::runtime::{set_main, stack_size};
 set_main! {main}
 stack_size! {0x600}
 
+const FRAME_TYPE_DATA: u8 = 1;
+
+fn frame_type_name(frame_type: u8) -> &'static str {
+    match frame_type {
+        0 => "Beacon",
+        FRAME_TYPE_DATA => "Data",
+        2 => "Acknowledgment",
+        3 => "MAC command",
+        5 => "Multipurpose",
+        6 => "Fragment",
+        7 => "Extended",
+        _ => "Reserved",
+    }
+}
+
+fn address_mode_name(address_mode: u8) -> &'static str {
+    match address_mode {
+        0 => "None",
+        2 => "Short",
+        3 => "Extended",
+        _ => "Reserved",
+    }
+}
+
+fn frame_version_name(frame_version: u8) -> &'static str {
+    match frame_version {
+        0 => "IEEE 802.15.4-2003",
+        1 => "IEEE 802.15.4-2006",
+        2 => "IEEE 802.15.4",
+        _ => "Reserved",
+    }
+}
+
+fn read_u16(bytes: &[u8], offset: &mut usize) -> Option<u16> {
+    let value = bytes.get(*offset..*offset + 2)?;
+    *offset += 2;
+    Some(u16::from_le_bytes([value[0], value[1]]))
+}
+
+fn print_address(label: &str, address_mode: u8, bytes: &[u8], offset: &mut usize) -> bool {
+    match address_mode {
+        0 => true,
+        2 => {
+            let Some(address) = read_u16(bytes, offset) else {
+                return false;
+            };
+            writeln!(Console::writer(), "{label} address: {address:#06x}").unwrap();
+            true
+        }
+        3 => {
+            let Some(address) = bytes.get(*offset..*offset + 8) else {
+                return false;
+            };
+            *offset += 8;
+            let address = u64::from_le_bytes([
+                address[0], address[1], address[2], address[3], address[4], address[5], address[6],
+                address[7],
+            ]);
+            writeln!(Console::writer(), "{label} address: {address:#018x}").unwrap();
+            true
+        }
+        _ => false,
+    }
+}
+
+fn print_payload(payload: &[u8]) {
+    write!(Console::writer(), "Payload ({} bytes) hex: ", payload.len()).unwrap();
+    for byte in payload {
+        write!(Console::writer(), "{byte:02x}").unwrap();
+    }
+    writeln!(Console::writer()).unwrap();
+
+    if let Ok(text) = core::str::from_utf8(payload) {
+        writeln!(Console::writer(), "Payload UTF-8: {text:?}").unwrap();
+    } else {
+        writeln!(Console::writer(), "Payload is not valid UTF-8").unwrap();
+    }
+}
+
+fn print_frame(frame: &[u8]) {
+    if frame.len() < 3 {
+        writeln!(
+            Console::writer(),
+            "Malformed frame: expected at least a 3-byte MAC header\n"
+        )
+        .unwrap();
+        return;
+    }
+
+    let frame_control = u16::from_le_bytes([frame[0], frame[1]]);
+    let frame_type = (frame_control & 0x0007) as u8;
+    let security_enabled = frame_control & 0x0008 != 0;
+    let frame_pending = frame_control & 0x0010 != 0;
+    let acknowledgment_requested = frame_control & 0x0020 != 0;
+    let pan_id_compression = frame_control & 0x0040 != 0;
+    let sequence_number_suppressed = frame_control & 0x0100 != 0;
+    let information_elements_present = frame_control & 0x0200 != 0;
+    let destination_address_mode = ((frame_control >> 10) & 0x0003) as u8;
+    let frame_version = ((frame_control >> 12) & 0x0003) as u8;
+    let source_address_mode = ((frame_control >> 14) & 0x0003) as u8;
+
+    writeln!(Console::writer(), "Frame control: {frame_control:#06x}").unwrap();
+    writeln!(
+        Console::writer(),
+        "Frame type: {} ({frame_type})",
+        frame_type_name(frame_type)
+    )
+    .unwrap();
+    writeln!(Console::writer(), "Security enabled: {security_enabled}").unwrap();
+    writeln!(Console::writer(), "Frame pending: {frame_pending}").unwrap();
+    writeln!(
+        Console::writer(),
+        "Acknowledgment requested: {acknowledgment_requested}"
+    )
+    .unwrap();
+    writeln!(
+        Console::writer(),
+        "PAN ID compression: {pan_id_compression}"
+    )
+    .unwrap();
+    writeln!(
+        Console::writer(),
+        "Sequence number suppression: {sequence_number_suppressed}"
+    )
+    .unwrap();
+    writeln!(
+        Console::writer(),
+        "Information elements present: {information_elements_present}"
+    )
+    .unwrap();
+    writeln!(
+        Console::writer(),
+        "Destination address mode: {} ({destination_address_mode})",
+        address_mode_name(destination_address_mode)
+    )
+    .unwrap();
+    writeln!(
+        Console::writer(),
+        "Frame version: {} ({frame_version})",
+        frame_version_name(frame_version)
+    )
+    .unwrap();
+    writeln!(
+        Console::writer(),
+        "Source address mode: {} ({source_address_mode})",
+        address_mode_name(source_address_mode)
+    )
+    .unwrap();
+
+    // The transmitter uses the IEEE 802.15.4-2006 header format, in which the
+    // sequence number is always present and PAN ID compression means that the
+    // source PAN ID is the same as the destination PAN ID.
+    if frame_version > 1 {
+        writeln!(
+            Console::writer(),
+            "Address decoding for this frame version is not supported\n"
+        )
+        .unwrap();
+        return;
+    }
+
+    let sequence_number = frame[2];
+    let mut offset = 3;
+    writeln!(Console::writer(), "Sequence number: {sequence_number}").unwrap();
+
+    let destination_pan = if destination_address_mode != 0 {
+        let Some(pan) = read_u16(frame, &mut offset) else {
+            writeln!(Console::writer(), "Malformed destination PAN ID\n").unwrap();
+            return;
+        };
+        writeln!(Console::writer(), "Destination PAN ID: {pan:#06x}").unwrap();
+        Some(pan)
+    } else {
+        None
+    };
+
+    if !print_address("Destination", destination_address_mode, frame, &mut offset) {
+        writeln!(Console::writer(), "Malformed destination address\n").unwrap();
+        return;
+    }
+
+    if source_address_mode != 0 {
+        if pan_id_compression {
+            if let Some(pan) = destination_pan {
+                writeln!(Console::writer(), "Source PAN ID: {pan:#06x} (compressed)").unwrap();
+            } else {
+                writeln!(
+                    Console::writer(),
+                    "Malformed header: compressed source PAN ID has no destination PAN ID\n"
+                )
+                .unwrap();
+                return;
+            }
+        } else {
+            let Some(pan) = read_u16(frame, &mut offset) else {
+                writeln!(Console::writer(), "Malformed source PAN ID\n").unwrap();
+                return;
+            };
+            writeln!(Console::writer(), "Source PAN ID: {pan:#06x}").unwrap();
+        }
+    }
+
+    if !print_address("Source", source_address_mode, frame, &mut offset) {
+        writeln!(Console::writer(), "Malformed source address\n").unwrap();
+        return;
+    }
+
+    writeln!(Console::writer(), "MAC header length: {offset} bytes").unwrap();
+
+    if frame_type == FRAME_TYPE_DATA {
+        if security_enabled || information_elements_present {
+            writeln!(
+                Console::writer(),
+                "Payload decoding for secured frames or frames with information elements is not supported\n"
+            )
+            .unwrap();
+            return;
+        }
+        print_payload(&frame[offset..]);
+    }
+
+    writeln!(Console::writer()).unwrap();
+}
+
 fn main() {
     // Configure the radio
     let pan: u16 = 0xcafe;
     let addr_short: u16 = 0xdead;
-    let addr_long: u64 = 0xdead_dad;
+    let addr_long: u64 = 0x0dea_ddad;
     let tx_power: i8 = 4;
     let channel: u8 = 11;
 
     writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
 
     Ieee802154::set_pan(pan);
-    writeln!(Console::writer(), "Set PAN to {:#06x}\n", pan).unwrap();
+    writeln!(Console::writer(), "Set PAN to {pan:#06x}\n").unwrap();
 
     Ieee802154::set_address_short(addr_short);
     writeln!(
         Console::writer(),
-        "Set short address to {:#06x}\n",
-        addr_short
+        "Set short address to {addr_short:#06x}\n"
     )
     .unwrap();
 
     Ieee802154::set_address_long(addr_long);
-    writeln!(
-        Console::writer(),
-        "Set long address to {:#018x}\n",
-        addr_long
-    )
-    .unwrap();
+    writeln!(Console::writer(), "Set long address to {addr_long:#018x}\n").unwrap();
 
     Ieee802154::set_tx_power(tx_power).unwrap();
-    writeln!(Console::writer(), "Set TX power to {}\n", tx_power).unwrap();
+    writeln!(Console::writer(), "Set TX power to {tx_power}\n").unwrap();
 
     Ieee802154::set_channel(channel).unwrap();
-    writeln!(Console::writer(), "Set channel to {}\n", channel).unwrap();
+    writeln!(Console::writer(), "Set channel to {channel}\n").unwrap();
 
     // Don't forget to commit the config!
     Ieee802154::commit_config();
@@ -68,22 +286,9 @@ fn main() {
     let mut operator = RxSingleBufferOperator::new(&mut buf);
     loop {
         let frame = operator.receive_frame().unwrap();
+        let frame_len = usize::from(frame.payload_len).min(frame.body.len());
 
-        let body_len = frame.payload_len;
-
-        // Parse the counter.
-        let text = &frame.body[..body_len as usize - core::mem::size_of::<usize>()];
-        let counter_bytes =
-            &frame.body[body_len as usize - core::mem::size_of::<usize>()..body_len as usize];
-        let counter = usize::from_be_bytes(counter_bytes.try_into().unwrap());
-
-        writeln!(
-            Console::writer(),
-            "Received frame with body of len {}: \"{} {}\"\n",
-            body_len,
-            core::str::from_utf8(text).unwrap_or("-- error decoding utf8 string --"),
-            counter,
-        )
-        .unwrap();
+        writeln!(Console::writer(), "Received frame ({frame_len} bytes)").unwrap();
+        print_frame(&frame.body[..frame_len]);
     }
 }

--- a/examples/ieee802154_rx_raw.rs
+++ b/examples/ieee802154_rx_raw.rs
@@ -67,12 +67,16 @@ fn frame_version_name(frame_version: u8) -> &'static str {
     }
 }
 
+/// Reads a little-endian `u16` at `offset`, advancing the offset on success.
 fn read_u16(bytes: &[u8], offset: &mut usize) -> Option<u16> {
     let value = bytes.get(*offset..*offset + 2)?;
     *offset += 2;
     Some(u16::from_le_bytes([value[0], value[1]]))
 }
 
+/// Decodes and prints an address, advancing `offset` past the address bytes.
+///
+/// Returns an error if the address mode is unsupported or the address is truncated.
 fn print_address(
     label: &str,
     address_mode: u8,
@@ -104,6 +108,7 @@ fn print_address(
     }
 }
 
+/// Prints a payload in hexadecimal and, when valid, as UTF-8 text.
 fn print_payload(payload: &[u8]) {
     write!(Console::writer(), "Payload ({} bytes) hex: ", payload.len()).unwrap();
     for byte in payload {
@@ -118,6 +123,7 @@ fn print_payload(payload: &[u8]) {
     }
 }
 
+/// Decodes and prints the supported fields of an IEEE 802.15.4 frame.
 fn print_frame(frame: &[u8]) {
     if frame.len() < 2 {
         writeln!(

--- a/examples/ieee802154_rx_raw.rs
+++ b/examples/ieee802154_rx_raw.rs
@@ -21,35 +21,49 @@ set_main! {main}
 stack_size! {0x600}
 
 const FRAME_TYPE_DATA: u8 = 1;
+const ADDRESS_MODE_NONE: u8 = 0;
+const ADDRESS_MODE_RESERVED: u8 = 1;
+const ADDRESS_MODE_SHORT: u8 = 2;
+const ADDRESS_MODE_EXTENDED: u8 = 3;
+const FRAME_VERSION_IEEE_802154_2003: u8 = 0;
+const FRAME_VERSION_IEEE_802154_2006: u8 = 1;
+const FRAME_VERSION_IEEE_802154: u8 = 2;
+const FRAME_VERSION_RESERVED: u8 = 3;
 
+// Ref: Section 7.2.2.2 Frame Type field (IEEE 802.15.4-2020)
 fn frame_type_name(frame_type: u8) -> &'static str {
     match frame_type {
         0 => "Beacon",
         FRAME_TYPE_DATA => "Data",
         2 => "Acknowledgment",
         3 => "MAC command",
+        4 => "Reserved",
         5 => "Multipurpose",
         6 => "Fragment",
         7 => "Extended",
-        _ => "Reserved",
+        _ => "Unknown",
     }
 }
 
+// Ref: Table 7-3 Destination Addressing Mode and Source Addressing Mode (IEEE 802.15.4-2020)
 fn address_mode_name(address_mode: u8) -> &'static str {
     match address_mode {
-        0 => "None",
-        2 => "Short",
-        3 => "Extended",
-        _ => "Reserved",
+        ADDRESS_MODE_NONE => "None",
+        ADDRESS_MODE_RESERVED => "Reserved",
+        ADDRESS_MODE_SHORT => "Short",
+        ADDRESS_MODE_EXTENDED => "Extended",
+        _ => "Unknown",
     }
 }
 
+// Ref: Table 7-4 Frame Version field (IEEE 802.15.4-2020)
 fn frame_version_name(frame_version: u8) -> &'static str {
     match frame_version {
-        0 => "IEEE 802.15.4-2003",
-        1 => "IEEE 802.15.4-2006",
-        2 => "IEEE 802.15.4",
-        _ => "Reserved",
+        FRAME_VERSION_IEEE_802154_2003 => "IEEE 802.15.4-2003",
+        FRAME_VERSION_IEEE_802154_2006 => "IEEE 802.15.4-2006",
+        FRAME_VERSION_IEEE_802154 => "IEEE 802.15.4",
+        FRAME_VERSION_RESERVED => "Reserved",
+        _ => "Unknown",
     }
 }
 
@@ -59,19 +73,24 @@ fn read_u16(bytes: &[u8], offset: &mut usize) -> Option<u16> {
     Some(u16::from_le_bytes([value[0], value[1]]))
 }
 
-fn print_address(label: &str, address_mode: u8, bytes: &[u8], offset: &mut usize) -> bool {
+fn print_address(
+    label: &str,
+    address_mode: u8,
+    bytes: &[u8],
+    offset: &mut usize,
+) -> Result<(), ()> {
     match address_mode {
-        0 => true,
-        2 => {
+        ADDRESS_MODE_NONE => Ok(()),
+        ADDRESS_MODE_SHORT => {
             let Some(address) = read_u16(bytes, offset) else {
-                return false;
+                return Err(());
             };
             writeln!(Console::writer(), "{label} address: {address:#06x}").unwrap();
-            true
+            Ok(())
         }
-        3 => {
+        ADDRESS_MODE_EXTENDED => {
             let Some(address) = bytes.get(*offset..*offset + 8) else {
-                return false;
+                return Err(());
             };
             *offset += 8;
             let address = u64::from_le_bytes([
@@ -79,9 +98,9 @@ fn print_address(label: &str, address_mode: u8, bytes: &[u8], offset: &mut usize
                 address[7],
             ]);
             writeln!(Console::writer(), "{label} address: {address:#018x}").unwrap();
-            true
+            Ok(())
         }
-        _ => false,
+        _ => Err(()),
     }
 }
 
@@ -100,21 +119,22 @@ fn print_payload(payload: &[u8]) {
 }
 
 fn print_frame(frame: &[u8]) {
-    if frame.len() < 3 {
+    if frame.len() < 2 {
         writeln!(
             Console::writer(),
-            "Malformed frame: expected at least a 3-byte MAC header\n"
+            "Malformed frame: expected at least a 2-byte frame control field"
         )
         .unwrap();
         return;
     }
-
+    // Ref: Section 7.2.2 MAC Frame Format (IEEE 802.15.4-2020)
     let frame_control = u16::from_le_bytes([frame[0], frame[1]]);
     let frame_type = (frame_control & 0x0007) as u8;
     let security_enabled = frame_control & 0x0008 != 0;
     let frame_pending = frame_control & 0x0010 != 0;
     let acknowledgment_requested = frame_control & 0x0020 != 0;
     let pan_id_compression = frame_control & 0x0040 != 0;
+    // Bit 7 is reserved and should be set to 0
     let sequence_number_suppressed = frame_control & 0x0100 != 0;
     let information_elements_present = frame_control & 0x0200 != 0;
     let destination_address_mode = ((frame_control >> 10) & 0x0003) as u8;
@@ -169,25 +189,36 @@ fn print_frame(frame: &[u8]) {
     )
     .unwrap();
 
-    // The transmitter uses the IEEE 802.15.4-2006 header format, in which the
-    // sequence number is always present and PAN ID compression means that the
-    // source PAN ID is the same as the destination PAN ID.
-    if frame_version > 1 {
+    if frame_version > FRAME_VERSION_IEEE_802154 {
         writeln!(
             Console::writer(),
-            "Address decoding for this frame version is not supported\n"
+            "Address decoding for this frame version is not supported"
         )
         .unwrap();
         return;
     }
 
-    let sequence_number = frame[2];
-    let mut offset = 3;
-    writeln!(Console::writer(), "Sequence number: {sequence_number}").unwrap();
+    let mut offset = 2;
+    let sequence_number = if sequence_number_suppressed {
+        None
+    } else {
+        let Some(sequence_number) = frame.get(offset).copied() else {
+            writeln!(Console::writer(), "Malformed sequence number").unwrap();
+            return;
+        };
+        offset += 1;
+        Some(sequence_number)
+    };
 
-    let destination_pan = if destination_address_mode != 0 {
+    if let Some(sequence_number) = sequence_number {
+        writeln!(Console::writer(), "Sequence number: {sequence_number}").unwrap();
+    } else {
+        writeln!(Console::writer(), "Sequence number: suppressed").unwrap();
+    }
+
+    let destination_pan = if destination_address_mode != ADDRESS_MODE_NONE {
         let Some(pan) = read_u16(frame, &mut offset) else {
-            writeln!(Console::writer(), "Malformed destination PAN ID\n").unwrap();
+            writeln!(Console::writer(), "Malformed destination PAN ID").unwrap();
             return;
         };
         writeln!(Console::writer(), "Destination PAN ID: {pan:#06x}").unwrap();
@@ -196,34 +227,34 @@ fn print_frame(frame: &[u8]) {
         None
     };
 
-    if !print_address("Destination", destination_address_mode, frame, &mut offset) {
-        writeln!(Console::writer(), "Malformed destination address\n").unwrap();
+    if print_address("Destination", destination_address_mode, frame, &mut offset).is_err() {
+        writeln!(Console::writer(), "Malformed destination address").unwrap();
         return;
     }
 
-    if source_address_mode != 0 {
+    if source_address_mode != ADDRESS_MODE_NONE {
         if pan_id_compression {
             if let Some(pan) = destination_pan {
                 writeln!(Console::writer(), "Source PAN ID: {pan:#06x} (compressed)").unwrap();
             } else {
                 writeln!(
                     Console::writer(),
-                    "Malformed header: compressed source PAN ID has no destination PAN ID\n"
+                    "Malformed header: compressed source PAN ID has no destination PAN ID"
                 )
                 .unwrap();
                 return;
             }
         } else {
             let Some(pan) = read_u16(frame, &mut offset) else {
-                writeln!(Console::writer(), "Malformed source PAN ID\n").unwrap();
+                writeln!(Console::writer(), "Malformed source PAN ID").unwrap();
                 return;
             };
             writeln!(Console::writer(), "Source PAN ID: {pan:#06x}").unwrap();
         }
     }
 
-    if !print_address("Source", source_address_mode, frame, &mut offset) {
-        writeln!(Console::writer(), "Malformed source address\n").unwrap();
+    if print_address("Source", source_address_mode, frame, &mut offset).is_err() {
+        writeln!(Console::writer(), "Malformed source address").unwrap();
         return;
     }
 
@@ -233,15 +264,13 @@ fn print_frame(frame: &[u8]) {
         if security_enabled || information_elements_present {
             writeln!(
                 Console::writer(),
-                "Payload decoding for secured frames or frames with information elements is not supported\n"
+                "Payload decoding for secured frames or frames with information elements is not supported"
             )
             .unwrap();
             return;
         }
         print_payload(&frame[offset..]);
     }
-
-    writeln!(Console::writer()).unwrap();
 }
 
 fn main() {
@@ -252,35 +281,31 @@ fn main() {
     let tx_power: i8 = 4;
     let channel: u8 = 11;
 
-    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...\n").unwrap();
+    writeln!(Console::writer(), "Configuring IEEE 802.15.4 radio...").unwrap();
 
     Ieee802154::set_pan(pan);
-    writeln!(Console::writer(), "Set PAN to {pan:#06x}\n").unwrap();
+    writeln!(Console::writer(), "Set PAN to {pan:#06x}").unwrap();
 
     Ieee802154::set_address_short(addr_short);
-    writeln!(
-        Console::writer(),
-        "Set short address to {addr_short:#06x}\n"
-    )
-    .unwrap();
+    writeln!(Console::writer(), "Set short address to {addr_short:#06x}").unwrap();
 
     Ieee802154::set_address_long(addr_long);
-    writeln!(Console::writer(), "Set long address to {addr_long:#018x}\n").unwrap();
+    writeln!(Console::writer(), "Set long address to {addr_long:#018x}").unwrap();
 
     Ieee802154::set_tx_power(tx_power).unwrap();
-    writeln!(Console::writer(), "Set TX power to {tx_power}\n").unwrap();
+    writeln!(Console::writer(), "Set TX power to {tx_power}").unwrap();
 
     Ieee802154::set_channel(channel).unwrap();
-    writeln!(Console::writer(), "Set channel to {channel}\n").unwrap();
+    writeln!(Console::writer(), "Set channel to {channel}").unwrap();
 
     // Don't forget to commit the config!
     Ieee802154::commit_config();
-    writeln!(Console::writer(), "Committed radio configuration!\n").unwrap();
+    writeln!(Console::writer(), "Committed radio configuration!").unwrap();
 
     // Turn the radio on
     Ieee802154::radio_on().unwrap();
     assert!(Ieee802154::is_on());
-    writeln!(Console::writer(), "Radio is on!\n").unwrap();
+    writeln!(Console::writer(), "Radio is on!").unwrap();
 
     let mut buf = RxRingBuffer::<2>::new();
     let mut operator = RxSingleBufferOperator::new(&mut buf);
@@ -290,5 +315,6 @@ fn main() {
 
         writeln!(Console::writer(), "Received frame ({frame_len} bytes)").unwrap();
         print_frame(&frame.body[..frame_len]);
+        writeln!(Console::writer()).unwrap(); // Print a newline to separate frames
     }
 }


### PR DESCRIPTION
# Overview
This closes #599 by modifying the existing receive example to show packets decode as data packets with appropriate frame control fields and header. My design decision for decoded receive output to be one line per decoded piece of information where the description terminated with a colon is before the value, is to make it both readable and machine decodable. The disadvantage is that it is somewhat voluminous with 20 lines per packet. I tested it by having the program decode packets from the PR #598  version of `examples/ieee802154_tx_raw.rs`. An example for sequence numbers 92 and 93 is shown below.
From the TX (`examples/ieee802154_tx_raw.rs`) output:
```
TX broadcast: src=0x1001, sequence=92, count=92
TX broadcast: src=0x1001, sequence=93, count=93
```
From the RX (`examples/ieee802154_rx_raw.rs`.) output:
```
Received frame (18 bytes)
Frame control: 0x9841
Frame type: Data (1)
Security enabled: false
Frame pending: false
Acknowledgment requested: false
PAN ID compression: true
Sequence number suppression: false
Information elements present: false
Destination address mode: Short (2)
Frame version: IEEE 802.15.4-2006 (1)
Source address mode: Short (2)
Sequence number: 92
Destination PAN ID: 0xcafe
Destination address: 0xffff
Source PAN ID: 0xcafe (compressed)
Source address: 0x1001
MAC header length: 9 bytes
Payload (9 bytes) hex: 626561636f6e20005c
Payload UTF-8: "beacon \0\\"

Received frame (18 bytes)
Frame control: 0x9841
Frame type: Data (1)
Security enabled: false
Frame pending: false
Acknowledgment requested: false
PAN ID compression: true
Sequence number suppression: false
Information elements present: false
Destination address mode: Short (2)
Frame version: IEEE 802.15.4-2006 (1)
Source address mode: Short (2)
Sequence number: 93
Destination PAN ID: 0xcafe
Destination address: 0xffff
Source PAN ID: 0xcafe (compressed)
Source address: 0x1001
MAC header length: 9 bytes
Payload (9 bytes) hex: 626561636f6e20005d
Payload UTF-8: "beacon \0]"
```
Analyzer capture was used for confirmation of over the air packets. Specifically sequence number 93 is shown below (the error is from the analyzer decoding as 6LoWPAN).

<img width="1913" height="1035" alt="image" src="https://github.com/user-attachments/assets/b4456c4f-54e3-4f7f-b1da-2d4a3f34a23c" />

# AI Usage
I used OpenAI Codex for both code generation and evaluation. I reviewed all AI generated code and compared the received decoded output from the program with the decoded packets on the Wireless Protocol Suite analyzer software.

# Testing 
`make test`  passed locally