### PR TITLE
Remove the tock submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tock"]
-	path = tock
-	url = https://github.com/tock/tock.git


### PR DESCRIPTION
The only thing this submodule was used for was QEMU-based testing, which was removed years ago. I've kept this submodule around in the hopes of resurrecting that test logic, but it never happened. There are a few reasons to remove it:

1. Submodules are confusing, and everyone else dislikes them.
2. I'm switching to jujutsu, which doesn't support git submodules yet.
3. This submodule has bitrotted; it hasn't been updated in years.

When we eventually add QEMU tests back (or add Tock's license checker), we'll probably find an alternative solution rather than bringing back the submodule.