### PR TITLE
ci: bump checkout action to latest version

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       # scripts, but we do not recursively checkout submodules as we need Tock's
       # makefile to set up the qemu submodule itself.
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: true
 

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -15,7 +15,7 @@ jobs:
       # Clones a single commit from the libtock-rs repository. The commit cloned
       # is a merge commit between the PR's target branch and the PR's source.
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Build and Test
         run: |

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -25,7 +25,7 @@ jobs:
       # We'll later add another commit (the pre-merge target branch) to the
       # repository.
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       # The main diff script. Stores the sizes of the example binaries for both
       # the merge commit and the target branch. We display the diff in a


### PR DESCRIPTION
Just bumps the version used in the workflows to the latest.

The internet tells me it's for security.