### PR TITLE
CI: Fix QEMU runner and actually run boards in QEMU in CI (also removes the git submodule)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,14 @@ jobs:
     # we can update when we need to. This *could* break if we don't update it
     # until support for this version is dropped, but it is likely we'll have a
     # reason to update to a newer Ubuntu before then anyway.
-    runs-on: ubuntu-22.04
+    #
+    # 24.04 is the floor: the emulated boards need QEMU 8.2 or newer.
+    runs-on: ubuntu-24.04
+
+    # Nothing here should run for hours. The emulated boards carry a timeout of
+    # their own, so a board that hangs fails in seconds; this is the outer bound
+    # on everything else.
+    timeout-minutes: 60
 
     steps:
       # Clones a single commit from the libtock-rs repository. The commit cloned
@@ -41,3 +48,21 @@ jobs:
           make -j2 setup
           make -j2 test
           make demos
+
+      # Installed after the build, so that a failure in the code itself does not
+      # wait on an install it will never use.
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          # 24.04 keeps the 32-bit RISC-V emulator in qemu-system-misc. Newer
+          # Ubuntu splits it out into qemu-system-riscv, so this line needs
+          # revisiting whenever the image above moves.
+          sudo apt-get install -y qemu-system-misc
+
+      # Verify that every board we expect to work under emulation does.
+      - name: Run the examples under emulation
+        run: |
+          cd "${GITHUB_WORKSPACE}"
+          make setup-qemu
+          make qemu-examples EXAMPLE=console \
+            QEMU_EXPECT='Hello world!' QEMU_TIMEOUT=120 </dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,9 @@ jobs:
     # point at a new Ubuntu version. Instead, explicitly specify the version, so
     # we can update when we need to. This *could* break if we don't update it
     # until support for this version is dropped, but it is likely we'll have a
-    # reason to update to a newer Ubuntu before then anyway.
-    #
-    # 24.04 is the floor: the emulated boards need QEMU 8.2 or newer.
+    # reason to update to a newer Ubuntu before then anyway. Moved from 22.04 to
+    # keep the pin on a current LTS.
     runs-on: ubuntu-24.04
-
-    # Nothing here should run for hours. The emulated boards carry a timeout of
-    # their own, so a board that hangs fails in seconds; this is the outer bound
-    # on everything else.
-    timeout-minutes: 60
 
     steps:
       # Clones a single commit from the libtock-rs repository. The commit cloned
@@ -49,20 +43,28 @@ jobs:
           make -j2 test
           make demos
 
-      # Installed after the build, so that a failure in the code itself does not
-      # wait on an install it will never use.
+  # Verify that every board we expect to work under emulation does.
+  #
+  # OpenTitan needs a newer QEMU than 24.04 has available, but 26.04 is
+  # still in preview on GitHub (Sep 2026), so leave this separate for now.
+  ci-qemu:
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v7
+
       - name: Install QEMU
         run: |
           sudo apt-get update
-          # 24.04 keeps the 32-bit RISC-V emulator in qemu-system-misc. Newer
-          # Ubuntu splits it out into qemu-system-riscv, so this line needs
-          # revisiting whenever the image above moves.
-          sudo apt-get install -y qemu-system-misc
+          # 26.04 splits the 32-bit RISC-V emulator out of qemu-system-misc.
+          sudo apt-get install -y qemu-system-riscv
 
-      # Verify that every board we expect to work under emulation does.
       - name: Run the examples under emulation
         run: |
           cd "${GITHUB_WORKSPACE}"
+          make setup
           make setup-qemu
           make qemu-examples EXAMPLE=console \
             QEMU_EXPECT='Hello world!' QEMU_TIMEOUT=120 </dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,13 @@ jobs:
     # point at a new Ubuntu version. Instead, explicitly specify the version, so
     # we can update when we need to. This *could* break if we don't update it
     # until support for this version is dropped, but it is likely we'll have a
-    # reason to update to a newer Ubuntu before then anyway. Moved from 22.04 to
-    # keep the pin on a current LTS.
-    runs-on: ubuntu-24.04
+    # reason to update to a newer Ubuntu before then anyway.
+    #
+    # Sep 2026: Bumped to ubuntu-26.04 to get a new enough QEMU version
+    runs-on: ubuntu-26.04
+
+    # Sep 2026: About 3x margin over worst-case run currently
+    timeout-minutes: 30
 
     steps:
       # Clones a single commit from the libtock-rs repository. The commit cloned
@@ -43,28 +47,15 @@ jobs:
           make -j2 test
           make demos
 
-  # Verify that every board we expect to work under emulation does.
-  #
-  # OpenTitan needs a newer QEMU than 24.04 has available, but 26.04 is
-  # still in preview on GitHub (Sep 2026), so leave this separate for now.
-  ci-qemu:
-    runs-on: ubuntu-26.04
-    timeout-minutes: 30
-
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v7
-
+      # Install and run QEMU after main library build so code errors fail-fast.
       - name: Install QEMU
         run: |
           sudo apt-get update
-          # 26.04 splits the 32-bit RISC-V emulator out of qemu-system-misc.
           sudo apt-get install -y qemu-system-riscv
 
       - name: Run the examples under emulation
         run: |
           cd "${GITHUB_WORKSPACE}"
-          make setup
           make setup-qemu
           make qemu-examples EXAMPLE=console \
             QEMU_EXPECT='Hello world!' QEMU_TIMEOUT=120 </dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,8 @@ jobs:
     steps:
       # Clones a single commit from the libtock-rs repository. The commit cloned
       # is a merge commit between the PR's target branch and the PR's source.
-      # Note that we checkout submodules so that we can invoke Tock's CI setup
-      # scripts, but we do not recursively checkout submodules as we need Tock's
-      # makefile to set up the qemu submodule itself.
       - name: Clone repository
         uses: actions/checkout@v7
-        with:
-          submodules: true
 
       # The main test step. We let the makefile do most of the work because the
       # makefile can be tested locally. We experimentally determined that -j2 is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       # breaking relocation.
       - name: Build and Test
         run: |
-          sudo apt-get install ninja-build
           cd "${GITHUB_WORKSPACE}"
           echo "[target.'cfg(all())']" >> .cargo/config.toml
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config.toml

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -24,3 +24,15 @@ jobs:
             --target=thumbv7em-none-eabi
           LIBTOCK_PLATFORM=hifive1 cargo build -p libtock \
             --target=riscv32imac-unknown-none-elf
+
+      # The primary purpose of this check is verifying the QEMU infrastructure
+      # works on Mac, so we don't need to re-run every board here, just one.
+      - name: Install QEMU
+        run: brew install qemu
+
+      - name: Run an example under QEMU
+        run: |
+          cd "${GITHUB_WORKSPACE}"
+          make setup-qemu
+          make qemu-example-qemu_rv32_virt EXAMPLE=console \
+            QEMU_EXPECT='Hello world!' QEMU_TIMEOUT=120 </dev/null

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -10,6 +10,7 @@ on: pull_request
 jobs:
   ci-mac-os:
     runs-on: macos-latest
+    timeout-minutes: 30
 
     steps:
       # Clones a single commit from the libtock-rs repository. The commit cloned
@@ -33,6 +34,7 @@ jobs:
       - name: Run an example under QEMU
         run: |
           cd "${GITHUB_WORKSPACE}"
+          make setup
           make setup-qemu
           make qemu-example-qemu_rv32_virt EXAMPLE=console \
             QEMU_EXPECT='Hello world!' QEMU_TIMEOUT=120 </dev/null

--- a/.github/workflows/mac-os.yml
+++ b/.github/workflows/mac-os.yml
@@ -26,11 +26,11 @@ jobs:
           LIBTOCK_PLATFORM=hifive1 cargo build -p libtock \
             --target=riscv32imac-unknown-none-elf
 
-      # The primary purpose of this check is verifying the QEMU infrastructure
-      # works on Mac, so we don't need to re-run every board here, just one.
       - name: Install QEMU
         run: brew install qemu
 
+      # The primary purpose of this check is verifying the QEMU infrastructure
+      # works on Mac, so we don't need to re-run every board here, just one.
       - name: Run an example under QEMU
         run: |
           cd "${GITHUB_WORKSPACE}"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tock"]
-	path = tock
-	url = https://github.com/tock/tock.git

--- a/.ignore
+++ b/.ignore
@@ -3,8 +3,3 @@
 # search .cargo and .github.
 !.cargo/
 !.github/
-
-# Tell search tools to ignore the Tock submodule. Usually when someone wants to
-# search this repository they want to search libtock-rs' codebase, not the Tock
-# kernel.
-/tock/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ opt-level = "z"
 codegen-units = 1
 
 [workspace]
-exclude = ["tock"]
 members = [
     "apis/interface/buttons",
     "apis/interface/buzzer",

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,10 @@ DEMOS := demos/embedded_graphics/spin \
 
 .PHONY: demos
 demos:
-	@for demo in $(DEMOS); do $(MAKE) -C "$$demo" || exit 1; done
+	@for demo in $(DEMOS); do \
+		echo "$(MAKE) -C $$demo"; \
+		$(MAKE) -C "$$demo" || exit 1; \
+	done
 
 # clean cannot safely be invoked concurrently with other actions, so we don't
 # need to depend on toolchain. We also manually remove the nightly toolchain's

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ usage:
 	@printf " - %s\n" $(sort $(QEMU_PLATFORMS))
 	@echo
 	@echo "Run 'make qemu-example-<board> EXAMPLE=<>' to run EXAMPLE in QEMU"
+	@echo "Run 'make clean-tock-cache' to discard the Tock checkout those use"
 	@echo "Run 'make test' to test any local changes you have made"
 	@echo "Run 'make print-sizes' to print size data for the example binaries"
 

--- a/Makefile
+++ b/Makefile
@@ -53,36 +53,10 @@ toolchain:
 setup: setup-qemu toolchain
 	cargo install elf2tab
 
-# Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
-# patches to better support boards that Tock supports.
-.PHONY: setup-qemu
-setup-qemu:
-	CI=true $(MAKE) -C tock ci-setup-qemu
-
-# Builds a Tock 2.0 kernel for the HiFive board for use by QEMU tests.
-.PHONY: kernel-hifive
-kernel-hifive:
-	$(MAKE) -C tock/boards/hifive1 \
-		$(CURDIR)/tock/target/riscv32imac-unknown-none-elf/release/hifive1.elf
-
-# Builds a Tock kernel for the OpenTitan board on the cw310 FPGA for use by QEMU
-# tests.
-.PHONY: kernel-opentitan
-kernel-opentitan:
-	CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF_RUNNER="[]" \
-		$(MAKE) -C tock/boards/opentitan/earlgrey-cw310 \
-		$(CURDIR)/tock/target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.elf
-
 # Prints out the sizes of the example binaries.
 .PHONY: print-sizes
 print-sizes: examples toolchain
 	cargo run --release -p print_sizes
-
-# Runs a libtock example in QEMU on a simulated HiFive board.
-.PHONY: qemu-example
-qemu-example: kernel-hifive toolchain
-	LIBTOCK_PLATFORM="hifive1" cargo run --example "$(EXAMPLE)" -p libtock \
-		--release --target=riscv32imac-unknown-none-elf -- --deploy qemu
 
 # Build the examples on both a RISC-V target and an ARM target. We pick
 # opentitan as the RISC-V target because it lacks atomics.
@@ -127,6 +101,7 @@ test: examples
 	echo '[ SUCCESS ] libtock-rs tests pass'
 
 include Targets.mk
+include Makefile.qemu
 
 $(ELF_TARGETS): toolchain
 	LIBTOCK_LINKER_FLASH=$(F) LIBTOCK_LINKER_RAM=$(R) cargo build --example $(EXAMPLE) $(features) --target=$(T) $(release)
@@ -218,8 +193,7 @@ demos:
 # target directory, in case the user doesn't want to install the nightly
 # toolchain.
 .PHONY: clean
-clean:
+clean: clean-qemu
 	cargo clean
 	rm -fr nightly/target/
 	@for demo in $(DEMOS); do (cd "$$demo" && cargo clean) || exit 1; done
-	$(MAKE) -C tock clean

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ toolchain:
 	cargo -V
 
 .PHONY: setup
-setup: setup-qemu toolchain
+setup: toolchain
 	cargo install elf2tab
 
 # Prints out the sizes of the example binaries.

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ usage:
 	@printf " - %s\n" $(sort $(QEMU_PLATFORMS))
 	@echo
 	@echo "Run 'make qemu-example-<board> EXAMPLE=<>' to run EXAMPLE in QEMU"
+	@echo "Run 'make qemu-examples EXAMPLE=<>' to run EXAMPLE on every one of them"
 	@echo "Run 'make clean-tock-cache' to discard the Tock checkout those use"
 	@echo "Run 'make test' to test any local changes you have made"
 	@echo "Run 'make print-sizes' to print size data for the example binaries"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ usage:
 	@echo "Run 'make setup' to setup Rust to build libtock-rs."
 	@echo "Run 'make <board> EXAMPLE=<>' to build EXAMPLE for that board."
 	@echo "Run 'make flash-<board> EXAMPLE=<>' to flash EXAMPLE to a tockloader-supported board."
-	@echo "Run 'make qemu-example EXAMPLE=<>' to run EXAMPLE in QEMU"
+	@echo
+	@echo "These boards can be emulated, with no hardware, using 'make qemu-example-<board>':"
+	@printf " - %s\n" $(sort $(QEMU_PLATFORMS))
+	@echo
+	@echo "Run 'make qemu-example-<board> EXAMPLE=<>' to run EXAMPLE in QEMU"
 	@echo "Run 'make test' to test any local changes you have made"
 	@echo "Run 'make print-sizes' to print size data for the example binaries"
 

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -69,11 +69,40 @@ setup-tock: check-tock-dir
 	fi
 	@echo "Using Tock at $(TOCK_DIR) ($$(git -C "$(TOCK_DIR)" describe --always --dirty 2>/dev/null || echo 'not a git checkout'))"
 
-# Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
-# patches to better support boards that Tock supports.
+# The QEMU to run. libtock-rs uses whichever QEMU is installed on the system
+# rather than building one; set this if yours is not on your PATH.
+#
+# Exported so that it reaches `runner`, which is what actually spawns QEMU.
+LIBTOCK_QEMU ?= qemu-system-riscv32
+export LIBTOCK_QEMU
+
+# Versions we have run these boards against, and versions known not to work.
+WORKING_QEMU_VERSIONS := 10.2.1
+BROKEN_QEMU_VERSIONS  := <= 8.1.5
+
+# Checks that a usable QEMU is present, and says which one is about to be used.
+# $(1) is the QEMU machine the caller needs.
+define check_qemu
+	@command -v "$(LIBTOCK_QEMU)" >/dev/null 2>&1 || { \
+		echo "Could not find '$(LIBTOCK_QEMU)'."; \
+		echo "Install a QEMU with 32-bit RISC-V support -- qemu-system-misc on"; \
+		echo "Debian and Ubuntu, qemu-system-riscv on Fedora, qemu on Homebrew --"; \
+		echo "or set LIBTOCK_QEMU to a qemu-system-riscv32 binary."; \
+		exit 1; \
+	}
+	@"$(LIBTOCK_QEMU)" -M help | grep -q "^$(1) " || { \
+		echo "$$("$(LIBTOCK_QEMU)" --version | head -n1) does not support the '$(1)' machine."; \
+		echo "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS))"; \
+		exit 1; \
+	}
+	@echo "Running $$("$(LIBTOCK_QEMU)" --version | head -n1) with machine '$(1)'" \
+		"(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS))"
+endef
+
+# Reports whether a usable QEMU is installed, and what it is.
 .PHONY: setup-qemu
-setup-qemu: setup-tock
-	CI=true $(MAKE) -C $(TOCK_DIR) ci-setup-qemu
+setup-qemu:
+	$(call check_qemu,virt)
 
 # Builds a Tock 2.0 kernel for the HiFive board for use by QEMU tests.
 .PHONY: kernel-hifive
@@ -92,6 +121,7 @@ kernel-opentitan: setup-tock
 # Runs a libtock example in QEMU on a simulated HiFive board.
 .PHONY: qemu-example
 qemu-example: kernel-hifive toolchain
+	$(call check_qemu,sifive_e)
 	LIBTOCK_PLATFORM="hifive1" cargo run --example "$(EXAMPLE)" -p libtock \
 		--release --target=riscv32imac-unknown-none-elf -- --deploy qemu
 

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -47,17 +47,22 @@ check-tock-dir:
 # A tree the user supplied is only checked for existence. One of ours is created
 # on demand and pinned to TOCK_COMMIT; we fetch a single commit rather than
 # cloning, as Tock's history is an order of magnitude larger than its worktree.
+#
+# Every git command names the repository explicitly, because git searches parent
+# directories for one: without that, a cache directory that happens to sit
+# inside a repository -- a home directory under version control, say -- would be
+# the repository we fetched into and checked out.
 .PHONY: setup-tock
 setup-tock: check-tock-dir
 	@if [ -n "$(TOCK_DIR_IS_OURS)" ]; then \
-		if [ "$$(git -C "$(TOCK_DIR)" rev-parse HEAD 2>/dev/null)" != "$(TOCK_COMMIT)" ]; then \
+		head=""; \
+		if [ -e "$(TOCK_DIR)/.git" ]; then \
+			head="$$(git --git-dir="$(TOCK_DIR)/.git" rev-parse HEAD 2>/dev/null)"; \
+		fi; \
+		if [ "$$head" != "$(TOCK_COMMIT)" ]; then \
 			echo "Fetching Tock $(TOCK_COMMIT) into $(TOCK_DIR)"; \
-			mkdir -p "$(TOCK_DIR)"; \
-			git -C "$(TOCK_DIR)" rev-parse --git-dir >/dev/null 2>&1 || \
-				git -C "$(TOCK_DIR)" init -q; \
-			git -C "$(TOCK_DIR)" remote get-url origin >/dev/null 2>&1 || \
-				git -C "$(TOCK_DIR)" remote add origin "$(TOCK_URL)"; \
-			git -C "$(TOCK_DIR)" fetch -q --depth 1 origin "$(TOCK_COMMIT)"; \
+			git init -q "$(TOCK_DIR)" && \
+			git -C "$(TOCK_DIR)" fetch -q --depth 1 "$(TOCK_URL)" "$(TOCK_COMMIT)" && \
 			git -C "$(TOCK_DIR)" checkout -q --detach FETCH_HEAD; \
 		fi; \
 	elif [ ! -d "$(TOCK_DIR)" ]; then \
@@ -67,7 +72,11 @@ setup-tock: check-tock-dir
 		echo "TOCK_DIR to use a managed checkout under $(LIBTOCK_CACHE_DIR)."; \
 		exit 1; \
 	fi
-	@echo "Using Tock at $(TOCK_DIR) ($$(git -C "$(TOCK_DIR)" describe --always --dirty 2>/dev/null || echo 'not a git checkout'))"
+	@if [ -e "$(TOCK_DIR)/.git" ]; then \
+		echo "Using Tock at $(TOCK_DIR) ($$(git -C "$(TOCK_DIR)" describe --always --dirty))"; \
+	else \
+		echo "Using Tock at $(TOCK_DIR) (not a git checkout)"; \
+	fi
 
 # The QEMU to run. libtock-rs uses whichever QEMU is installed on the system
 # rather than building one; set this if yours is not on your PATH.

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -99,7 +99,10 @@ QEMU_EXPECT ?=
 # against a run that hangs, so that it fails rather than waiting forever.
 QEMU_TIMEOUT ?=
 
-qemu_run_args = $(if $(QEMU_EXPECT),--expect '$(QEMU_EXPECT)',) \
+# Passed through the environment rather than interpolated into the recipe, so
+# that the text can contain whatever the board prints, quotes included.
+export QEMU_EXPECT
+qemu_run_args = $(if $(QEMU_EXPECT),--expect "$$QEMU_EXPECT",) \
 	$(if $(QEMU_TIMEOUT),--timeout $(QEMU_TIMEOUT),)
 
 # Versions we have run these boards against, and versions known not to work.
@@ -107,7 +110,7 @@ WORKING_QEMU_VERSIONS := 10.2.1
 BROKEN_QEMU_VERSIONS  := <= 8.1.5
 
 # Checks that a usable QEMU is present, and says which one is about to be used.
-# $(1) is the QEMU machine the caller needs.
+# $(1) is the QEMU machine, or the machines, the caller needs.
 define check_qemu
 	@command -v "$(LIBTOCK_QEMU)" >/dev/null 2>&1 || { \
 		echo "Could not find '$(LIBTOCK_QEMU)'."; \
@@ -116,19 +119,23 @@ define check_qemu
 		echo "or set LIBTOCK_QEMU to a qemu-system-riscv32 binary."; \
 		exit 1; \
 	}
-	@"$(LIBTOCK_QEMU)" -M help | grep -q "^$(1) " || { \
-		echo "$$("$(LIBTOCK_QEMU)" --version | head -n1) does not support the '$(1)' machine."; \
-		echo "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS))"; \
-		exit 1; \
-	}
-	@echo "Running $$("$(LIBTOCK_QEMU)" --version | head -n1) with machine '$(1)'" \
+	@for machine in $(1); do \
+		"$(LIBTOCK_QEMU)" -M help | grep -q "^$$machine " || { \
+			echo "$$("$(LIBTOCK_QEMU)" --version | head -n1) does not support the" \
+				"'$$machine' machine."; \
+			echo "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS))"; \
+			exit 1; \
+		}; \
+	done
+	@echo "Running $$("$(LIBTOCK_QEMU)" --version | head -n1) with machine(s) '$(1)'" \
 		"(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS))"
 endef
 
-# Reports whether a usable QEMU is installed, and what it is.
+# Reports whether a usable QEMU is installed, and what it is. Every machine is
+# checked, as this is the answer to "will the QEMU I have run these boards?".
 .PHONY: setup-qemu
 setup-qemu:
-	$(call check_qemu,virt)
+	$(call check_qemu,$(sort $(QEMU_MACHINES)))
 
 # Creates the `make kernel-<PLATFORM>` and `make qemu-example-<PLATFORM>`
 # targets for a board that QEMU can emulate. Arguments:
@@ -136,11 +143,12 @@ setup-qemu:
 #  2) The rust target the platform uses.
 #  3) The board's directory under the Tock tree's boards/.
 #  4) The name of the kernel binary that board produces.
-#  5) The QEMU machine the board runs on, checked before we build anything.
+#  5) The QEMU machine the board runs on, checked before the board is started.
 #
 # Each platform is added to QEMU_PLATFORMS, which the `usage` target prints.
 define qemu_platform
 QEMU_PLATFORMS += $(1)
+QEMU_MACHINES += $(5)
 
 .PHONY: kernel-$(1)
 kernel-$(1): setup-tock

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -1,0 +1,36 @@
+# Rules for building Tock kernels and running libtock-rs examples under QEMU.
+#
+# Everything that knows about a Tock kernel source tree or about QEMU lives in
+# this file; the main Makefile just includes it.
+
+# Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
+# patches to better support boards that Tock supports.
+.PHONY: setup-qemu
+setup-qemu:
+	CI=true $(MAKE) -C tock ci-setup-qemu
+
+# Builds a Tock 2.0 kernel for the HiFive board for use by QEMU tests.
+.PHONY: kernel-hifive
+kernel-hifive:
+	$(MAKE) -C tock/boards/hifive1 \
+		$(CURDIR)/tock/target/riscv32imac-unknown-none-elf/release/hifive1.elf
+
+# Builds a Tock kernel for the OpenTitan board on the cw310 FPGA for use by QEMU
+# tests.
+.PHONY: kernel-opentitan
+kernel-opentitan:
+	CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF_RUNNER="[]" \
+		$(MAKE) -C tock/boards/opentitan/earlgrey-cw310 \
+		$(CURDIR)/tock/target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.elf
+
+# Runs a libtock example in QEMU on a simulated HiFive board.
+.PHONY: qemu-example
+qemu-example: kernel-hifive toolchain
+	LIBTOCK_PLATFORM="hifive1" cargo run --example "$(EXAMPLE)" -p libtock \
+		--release --target=riscv32imac-unknown-none-elf -- --deploy qemu
+
+# Removes the build artifacts in the Tock source tree. Invoked by the main
+# Makefile's `clean` target.
+.PHONY: clean-qemu
+clean-qemu:
+	$(MAKE) -C tock clean

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -3,25 +3,91 @@
 # Everything that knows about a Tock kernel source tree or about QEMU lives in
 # this file; the main Makefile just includes it.
 
+# Where we keep a Tock checkout when the user hasn't pointed us at one.
+ifeq ($(shell uname -s),Darwin)
+LIBTOCK_CACHE_DIR ?= $(HOME)/Library/Caches/libtock-rs
+else
+LIBTOCK_CACHE_DIR ?= $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/libtock-rs
+endif
+
+# The Tock revision we build kernels from.
+# Pinned to a recent master (2026-09-01).
+TOCK_URL ?= https://github.com/tock/tock.git
+TOCK_COMMIT ?= 0aca6dae5307c35ff19856449891d5cb10342061
+
+# A Tock source tree to build kernels from.
+#
+# If you set this, libtock-rs treats the tree as yours: it is used exactly as it
+# is, and is never fetched, checked out, or cleaned. That is the way to test
+# against a Tock branch you are working on. If you don't set it, we maintain a
+# checkout pinned to TOCK_COMMIT under LIBTOCK_CACHE_DIR.
+TOCK_DIR ?= $(LIBTOCK_CACHE_DIR)/tock
+TOCK_DIR_IS_OURS := $(if $(filter $(LIBTOCK_CACHE_DIR)/tock,$(TOCK_DIR)),true,)
+
+# Tock's board build scripts require the rustflags from Tock's own cargo
+# configuration, including a sentinel cfg that their build.rs asserts on. A
+# `target.'cfg(...)'.rustflags` entry replaces rather than merges with a
+# `build.rustflags` entry, so libtock-rs' .cargo/config.toml silently displaces
+# Tock's flags for any tree underneath this repository, and the kernel build
+# fails with "Incorrect build configuration". Catch that here, where we can
+# explain it, rather than letting it surface from a build script.
+.PHONY: check-tock-dir
+check-tock-dir:
+	@case "$$(cd "$(dir $(TOCK_DIR))" 2>/dev/null && pwd -P)/" in \
+		"$(CURDIR)"/*) \
+			echo "TOCK_DIR ($(TOCK_DIR)) is inside the libtock-rs repository."; \
+			echo "Tock kernels cannot be built there: libtock-rs' .cargo/config.toml"; \
+			echo "applies to every tree beneath it and displaces the rustflags Tock's"; \
+			echo "boards require. Point TOCK_DIR somewhere outside $(CURDIR)."; \
+			exit 1;; \
+	esac
+
+# Makes sure a Tock source tree is available at TOCK_DIR.
+#
+# A tree the user supplied is only checked for existence. One of ours is created
+# on demand and pinned to TOCK_COMMIT; we fetch a single commit rather than
+# cloning, as Tock's history is an order of magnitude larger than its worktree.
+.PHONY: setup-tock
+setup-tock: check-tock-dir
+	@if [ -n "$(TOCK_DIR_IS_OURS)" ]; then \
+		if [ "$$(git -C "$(TOCK_DIR)" rev-parse HEAD 2>/dev/null)" != "$(TOCK_COMMIT)" ]; then \
+			echo "Fetching Tock $(TOCK_COMMIT) into $(TOCK_DIR)"; \
+			mkdir -p "$(TOCK_DIR)"; \
+			git -C "$(TOCK_DIR)" rev-parse --git-dir >/dev/null 2>&1 || \
+				git -C "$(TOCK_DIR)" init -q; \
+			git -C "$(TOCK_DIR)" remote get-url origin >/dev/null 2>&1 || \
+				git -C "$(TOCK_DIR)" remote add origin "$(TOCK_URL)"; \
+			git -C "$(TOCK_DIR)" fetch -q --depth 1 origin "$(TOCK_COMMIT)"; \
+			git -C "$(TOCK_DIR)" checkout -q --detach FETCH_HEAD; \
+		fi; \
+	elif [ ! -d "$(TOCK_DIR)" ]; then \
+		echo "TOCK_DIR ($(TOCK_DIR)) does not exist."; \
+		echo "TOCK_DIR names a Tock checkout to build kernels from. libtock-rs does"; \
+		echo "not create or modify a tree you provide. Either create it, or unset"; \
+		echo "TOCK_DIR to use a managed checkout under $(LIBTOCK_CACHE_DIR)."; \
+		exit 1; \
+	fi
+	@echo "Using Tock at $(TOCK_DIR) ($$(git -C "$(TOCK_DIR)" describe --always --dirty 2>/dev/null || echo 'not a git checkout'))"
+
 # Sets up QEMU in the tock/ directory. We use Tock's QEMU which may contain
 # patches to better support boards that Tock supports.
 .PHONY: setup-qemu
-setup-qemu:
-	CI=true $(MAKE) -C tock ci-setup-qemu
+setup-qemu: setup-tock
+	CI=true $(MAKE) -C $(TOCK_DIR) ci-setup-qemu
 
 # Builds a Tock 2.0 kernel for the HiFive board for use by QEMU tests.
 .PHONY: kernel-hifive
-kernel-hifive:
-	$(MAKE) -C tock/boards/hifive1 \
-		$(CURDIR)/tock/target/riscv32imac-unknown-none-elf/release/hifive1.elf
+kernel-hifive: setup-tock
+	$(MAKE) -C $(TOCK_DIR)/boards/hifive1 \
+		$(TOCK_DIR)/target/riscv32imac-unknown-none-elf/release/hifive1.elf
 
 # Builds a Tock kernel for the OpenTitan board on the cw310 FPGA for use by QEMU
 # tests.
 .PHONY: kernel-opentitan
-kernel-opentitan:
+kernel-opentitan: setup-tock
 	CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF_RUNNER="[]" \
-		$(MAKE) -C tock/boards/opentitan/earlgrey-cw310 \
-		$(CURDIR)/tock/target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.elf
+		$(MAKE) -C $(TOCK_DIR)/boards/opentitan/earlgrey-cw310 \
+		$(TOCK_DIR)/target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.elf
 
 # Runs a libtock example in QEMU on a simulated HiFive board.
 .PHONY: qemu-example
@@ -29,8 +95,16 @@ qemu-example: kernel-hifive toolchain
 	LIBTOCK_PLATFORM="hifive1" cargo run --example "$(EXAMPLE)" -p libtock \
 		--release --target=riscv32imac-unknown-none-elf -- --deploy qemu
 
-# Removes the build artifacts in the Tock source tree. Invoked by the main
-# Makefile's `clean` target.
+# Removes the build artifacts in a Tock source tree we manage. A tree the user
+# supplied is left alone; its build artifacts are theirs, not ours.
 .PHONY: clean-qemu
 clean-qemu:
-	$(MAKE) -C tock clean
+	@if [ -n "$(TOCK_DIR_IS_OURS)" ] && [ -f "$(TOCK_DIR)/Makefile" ]; then \
+		$(MAKE) -C "$(TOCK_DIR)" clean; \
+	fi
+
+# Removes the managed Tock checkout entirely. Not part of `clean`, as refetching
+# it is far more expensive than rebuilding it.
+.PHONY: clean-tock-cache
+clean-tock-cache:
+	rm -rf "$(LIBTOCK_CACHE_DIR)/tock"

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -71,10 +71,7 @@ setup-tock: check-tock-dir
 
 # The QEMU to run. libtock-rs uses whichever QEMU is installed on the system
 # rather than building one; set this if yours is not on your PATH.
-#
-# Exported so that it reaches `runner`, which is what actually spawns QEMU.
 LIBTOCK_QEMU ?= qemu-system-riscv32
-export LIBTOCK_QEMU
 
 # Versions we have run these boards against, and versions known not to work.
 WORKING_QEMU_VERSIONS := 10.2.1
@@ -104,26 +101,37 @@ endef
 setup-qemu:
 	$(call check_qemu,virt)
 
-# Builds a Tock 2.0 kernel for the HiFive board for use by QEMU tests.
-.PHONY: kernel-hifive
-kernel-hifive: setup-tock
-	$(MAKE) -C $(TOCK_DIR)/boards/hifive1 \
-		$(TOCK_DIR)/target/riscv32imac-unknown-none-elf/release/hifive1.elf
+# Creates the `make kernel-<PLATFORM>` and `make qemu-example-<PLATFORM>`
+# targets for a board that QEMU can emulate. Arguments:
+#  1) The libtock-rs platform name.
+#  2) The rust target the platform uses.
+#  3) The board's directory under the Tock tree's boards/.
+#  4) The name of the kernel binary that board produces.
+#  5) The QEMU machine the board runs on, checked before we build anything.
+#
+# Each platform is added to QEMU_PLATFORMS, which the `usage` target prints.
+define qemu_platform
+QEMU_PLATFORMS += $(1)
 
-# Builds a Tock kernel for the OpenTitan board on the cw310 FPGA for use by QEMU
-# tests.
-.PHONY: kernel-opentitan
-kernel-opentitan: setup-tock
-	CARGO_TARGET_RISCV32IMC_UNKNOWN_NONE_ELF_RUNNER="[]" \
-		$(MAKE) -C $(TOCK_DIR)/boards/opentitan/earlgrey-cw310 \
-		$(TOCK_DIR)/target/riscv32imc-unknown-none-elf/release/earlgrey-cw310.elf
+.PHONY: kernel-$(1)
+kernel-$(1): setup-tock
+	CARGO_TARGET_$(shell echo $(2) | tr 'a-z-' 'A-Z_')_RUNNER="[]" \
+		$$(MAKE) -C $$(TOCK_DIR)/boards/$(3) \
+		$$(TOCK_DIR)/target/$(2)/release/$(4).elf
 
-# Runs a libtock example in QEMU on a simulated HiFive board.
-.PHONY: qemu-example
-qemu-example: kernel-hifive toolchain
-	$(call check_qemu,sifive_e)
-	LIBTOCK_PLATFORM="hifive1" cargo run --example "$(EXAMPLE)" -p libtock \
-		--release --target=riscv32imac-unknown-none-elf -- --deploy qemu
+.PHONY: qemu-example-$(1)
+qemu-example-$(1): kernel-$(1) toolchain
+	$$(call check_qemu,$(5))
+	LIBTOCK_PLATFORM="$(1)" cargo run --example "$$(EXAMPLE)" -p libtock \
+		--release --target=$(2) --target-dir=target/qemu-$(1) -- --deploy qemu \
+		--qemu "$$(LIBTOCK_QEMU)" \
+		--kernel $$(TOCK_DIR)/target/$(2)/release/$(4).elf
+endef
+
+$(eval $(call qemu_platform,hifive1,riscv32imac-unknown-none-elf,hifive1,hifive1,sifive_e))
+$(eval $(call qemu_platform,opentitan,riscv32imc-unknown-none-elf,opentitan/earlgrey-cw310,earlgrey-cw310,opentitan))
+$(eval $(call qemu_platform,qemu_rv32_virt,riscv32imac-unknown-none-elf,qemu_rv32_virt,qemu_rv32_virt,virt))
+
 
 # Removes the build artifacts in a Tock source tree we manage. A tree the user
 # supplied is left alone; its build artifacts are theirs, not ours.

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -108,12 +108,17 @@ export QEMU_EXPECT
 qemu_run_args = $(if $(QEMU_EXPECT),--expect "$$QEMU_EXPECT",) \
 	$(if $(QEMU_TIMEOUT),--timeout $(QEMU_TIMEOUT),)
 
-# Versions we have run these boards against, and versions known not to work.
+# QEMU version(s) we have tested and know work. Non-exhaustive.
 WORKING_QEMU_VERSIONS := 10.2.1
-BROKEN_QEMU_VERSIONS  := <= 8.1.5
 
 # Checks that a usable QEMU is present, and says which one is about to be used.
-# $(1) is the QEMU machine, or the machines, the caller needs.
+# $(1) is the QEMU machine, or the machines, the caller needs. $(2) is the
+# oldest QEMU those machines are known to work on.
+#
+# Supporting a machine is not the same as running the board on it: an emulated
+# board whose model is older than the kernel expects can start, execute, and
+# print nothing at all, which from the outside is indistinguishable from a
+# hang. Checking the version is what turns that into an answer.
 define check_qemu
 	@command -v "$(LIBTOCK_QEMU)" >/dev/null 2>&1 || { \
 		echo "Could not find '$(LIBTOCK_QEMU)'."; \
@@ -125,20 +130,28 @@ define check_qemu
 	@for machine in $(1); do \
 		"$(LIBTOCK_QEMU)" -M help | grep -q "^$$machine " || { \
 			echo "$$("$(LIBTOCK_QEMU)" --version | head -n1) does not support the" \
-				"'$$machine' machine."; \
-			echo "(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS))"; \
+				"'$$machine' machine. (tested: $(WORKING_QEMU_VERSIONS))"; \
 			exit 1; \
 		}; \
 	done
+	@have="$$("$(LIBTOCK_QEMU)" --version | sed -n '1s/.*version \([0-9][0-9.]*\).*/\1/p')"; \
+	[ -n "$$have" ] || have="0"; \
+	[ "$$(printf '%s\n%s\n' "$(2)" "$$have" | sort -V | head -n1)" = "$(2)" ] || { \
+		echo "$$("$(LIBTOCK_QEMU)" --version | head -n1) is older than the oldest"; \
+		echo "QEMU that runs '$(1)': $(2). Older ones can start the board and"; \
+		echo "print nothing, so this stops here rather than looking like a hang."; \
+		echo "(tested: $(WORKING_QEMU_VERSIONS))"; \
+		exit 1; \
+	}
 	@echo "Running $$("$(LIBTOCK_QEMU)" --version | head -n1) with machine(s) '$(1)'" \
-		"(tested: $(WORKING_QEMU_VERSIONS); known broken: $(BROKEN_QEMU_VERSIONS))"
+		"(needs $(2) or newer; tested: $(WORKING_QEMU_VERSIONS))"
 endef
 
 # Reports whether a usable QEMU is installed, and what it is. Every machine is
 # checked, as this is the answer to "will the QEMU I have run these boards?".
 .PHONY: setup-qemu
 setup-qemu:
-	$(call check_qemu,$(sort $(QEMU_MACHINES)))
+	$(call check_qemu,$(sort $(QEMU_MACHINES)),$(QEMU_MIN_VERSION))
 
 # Creates the `make kernel-<PLATFORM>` and `make qemu-example-<PLATFORM>`
 # targets for a board that QEMU can emulate. Arguments:
@@ -147,11 +160,13 @@ setup-qemu:
 #  3) The board's directory under the Tock tree's boards/.
 #  4) The name of the kernel binary that board produces.
 #  5) The QEMU machine the board runs on, checked before the board is started.
+#  6) The oldest QEMU known to run this board, checked along with the machine.
 #
 # Each platform is added to QEMU_PLATFORMS, which the `usage` target prints.
 define qemu_platform
 QEMU_PLATFORMS += $(1)
 QEMU_MACHINES += $(5)
+QEMU_MIN_VERSIONS += $(6)
 
 .PHONY: kernel-$(1)
 kernel-$(1): setup-tock
@@ -161,16 +176,25 @@ kernel-$(1): setup-tock
 
 .PHONY: qemu-example-$(1)
 qemu-example-$(1): kernel-$(1) toolchain
-	$$(call check_qemu,$(5))
+	$$(call check_qemu,$(5),$(6))
 	LIBTOCK_PLATFORM="$(1)" cargo run --example "$$(EXAMPLE)" -p libtock \
 		--release --target=$(2) --target-dir=target/qemu-$(1) -- --deploy qemu \
 		--qemu "$$(LIBTOCK_QEMU)" \
 		--kernel $$(TOCK_DIR)/target/$(2)/release/$(4).elf $$(qemu_run_args)
 endef
 
-$(eval $(call qemu_platform,hifive1,riscv32imac-unknown-none-elf,hifive1,hifive1,sifive_e))
-$(eval $(call qemu_platform,opentitan,riscv32imc-unknown-none-elf,opentitan/earlgrey-cw310,earlgrey-cw310,opentitan))
-$(eval $(call qemu_platform,qemu_rv32_virt,riscv32imac-unknown-none-elf,qemu_rv32_virt,qemu_rv32_virt,virt))
+# The minimums below are the oldest QEMU each board is known to run on, not the
+# oldest that works. hifive1 is what CI has run on 8.2.2. Tock's own
+# qemu_rv32_virt README records 8.2.7. opentitan is the one that needs a recent
+# QEMU: 8.2.2 boots it to silence, and Tock's CI builds QEMU from a commit in
+# the 9.2 development cycle to run this board, so 9.2 is the floor we can point
+# at. All three have been run here on 10.2.1.
+$(eval $(call qemu_platform,hifive1,riscv32imac-unknown-none-elf,hifive1,hifive1,sifive_e,8.2))
+$(eval $(call qemu_platform,opentitan,riscv32imc-unknown-none-elf,opentitan/earlgrey-cw310,earlgrey-cw310,opentitan,9.2))
+$(eval $(call qemu_platform,qemu_rv32_virt,riscv32imac-unknown-none-elf,qemu_rv32_virt,qemu_rv32_virt,virt,8.2))
+
+# The oldest QEMU that runs every board, for the checks that cover all of them.
+QEMU_MIN_VERSION := $(lastword $(shell printf '%s\n' $(QEMU_MIN_VERSIONS) | sort -V))
 
 # Runs EXAMPLE on every board QEMU can emulate.
 .PHONY: qemu-examples

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -11,7 +11,8 @@ LIBTOCK_CACHE_DIR ?= $(if $(XDG_CACHE_HOME),$(XDG_CACHE_HOME),$(HOME)/.cache)/li
 endif
 
 # The Tock revision we build kernels from.
-# Pinned to a recent master (2026-09-01).
+# Pinned to a recent master (2026-09-01). To move it, change TOCK_COMMIT; the
+# next build refetches, and `make clean-tock-cache` discards the old tree.
 TOCK_URL ?= https://github.com/tock/tock.git
 TOCK_COMMIT ?= 0aca6dae5307c35ff19856449891d5cb10342061
 
@@ -95,8 +96,10 @@ LIBTOCK_QEMU ?= qemu-system-riscv32
 # which is what you want interactively.
 QEMU_EXPECT ?=
 
-# Give up on an emulated board after this many seconds, and fail. A backstop
-# against a run that hangs, so that it fails rather than waiting forever.
+# Give up on an emulated board after this many seconds, and fail. A backstop for
+# a QEMU_EXPECT that never arrives, so that the run fails rather than waiting
+# forever. On its own it only bounds a board that would otherwise run until it
+# is interrupted, which every emulated board does.
 QEMU_TIMEOUT ?=
 
 # Passed through the environment rather than interpolated into the recipe, so

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -172,6 +172,10 @@ $(eval $(call qemu_platform,hifive1,riscv32imac-unknown-none-elf,hifive1,hifive1
 $(eval $(call qemu_platform,opentitan,riscv32imc-unknown-none-elf,opentitan/earlgrey-cw310,earlgrey-cw310,opentitan))
 $(eval $(call qemu_platform,qemu_rv32_virt,riscv32imac-unknown-none-elf,qemu_rv32_virt,qemu_rv32_virt,virt))
 
+# Runs EXAMPLE on every board QEMU can emulate.
+.PHONY: qemu-examples
+qemu-examples: $(foreach platform,$(QEMU_PLATFORMS),qemu-example-$(platform))
+
 # Removes the build artifacts in a Tock source tree we manage. A tree the user
 # supplied is left alone; its build artifacts are theirs, not ours.
 .PHONY: clean-qemu

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -31,9 +31,15 @@ TOCK_DIR_IS_OURS := $(if $(filter $(LIBTOCK_CACHE_DIR)/tock,$(TOCK_DIR)),true,)
 # Tock's flags for any tree underneath this repository, and the kernel build
 # fails with "Incorrect build configuration". Catch that here, where we can
 # explain it, rather than letting it surface from a build script.
+#
+# TOCK_DIR need not exist yet, so resolve it lexically when it is not there to
+# be resolved for real. That does not follow symlinks, but it is better than
+# having no path to compare at all.
 .PHONY: check-tock-dir
 check-tock-dir:
-	@case "$$(cd "$(dir $(TOCK_DIR))" 2>/dev/null && pwd -P)/" in \
+	@if [ -d "$(TOCK_DIR)" ]; then dir="$$(cd "$(TOCK_DIR)" && pwd -P)"; \
+	else dir="$(abspath $(TOCK_DIR))"; fi; \
+	case "$$dir/" in \
 		"$(CURDIR)"/*) \
 			echo "TOCK_DIR ($(TOCK_DIR)) is inside the libtock-rs repository."; \
 			echo "Tock kernels cannot be built there: libtock-rs' .cargo/config.toml"; \
@@ -167,4 +173,4 @@ clean-qemu:
 # it is far more expensive than rebuilding it.
 .PHONY: clean-tock-cache
 clean-tock-cache:
-	rm -rf "$(LIBTOCK_CACHE_DIR)/tock"
+	@[ -z "$(LIBTOCK_CACHE_DIR)" ] || rm -rf "$(LIBTOCK_CACHE_DIR)/tock"

--- a/Makefile.qemu
+++ b/Makefile.qemu
@@ -73,6 +73,20 @@ setup-tock: check-tock-dir
 # rather than building one; set this if yours is not on your PATH.
 LIBTOCK_QEMU ?= qemu-system-riscv32
 
+# What an emulated board is expected to print. An emulated board runs until it
+# is interrupted, so a run with nobody at the keyboard -- a script, or a CI job
+# -- has to say what it came to see; the board is shut down and the run reported
+# as a success as soon as that text appears. Unset means run until interrupted,
+# which is what you want interactively.
+QEMU_EXPECT ?=
+
+# Give up on an emulated board after this many seconds, and fail. A backstop
+# against a run that hangs, so that it fails rather than waiting forever.
+QEMU_TIMEOUT ?=
+
+qemu_run_args = $(if $(QEMU_EXPECT),--expect '$(QEMU_EXPECT)',) \
+	$(if $(QEMU_TIMEOUT),--timeout $(QEMU_TIMEOUT),)
+
 # Versions we have run these boards against, and versions known not to work.
 WORKING_QEMU_VERSIONS := 10.2.1
 BROKEN_QEMU_VERSIONS  := <= 8.1.5
@@ -125,13 +139,12 @@ qemu-example-$(1): kernel-$(1) toolchain
 	LIBTOCK_PLATFORM="$(1)" cargo run --example "$$(EXAMPLE)" -p libtock \
 		--release --target=$(2) --target-dir=target/qemu-$(1) -- --deploy qemu \
 		--qemu "$$(LIBTOCK_QEMU)" \
-		--kernel $$(TOCK_DIR)/target/$(2)/release/$(4).elf
+		--kernel $$(TOCK_DIR)/target/$(2)/release/$(4).elf $$(qemu_run_args)
 endef
 
 $(eval $(call qemu_platform,hifive1,riscv32imac-unknown-none-elf,hifive1,hifive1,sifive_e))
 $(eval $(call qemu_platform,opentitan,riscv32imc-unknown-none-elf,opentitan/earlgrey-cw310,earlgrey-cw310,opentitan))
 $(eval $(call qemu_platform,qemu_rv32_virt,riscv32imac-unknown-none-elf,qemu_rv32_virt,qemu_rv32_virt,virt))
-
 
 # Removes the build artifacts in a Tock source tree we manage. A tree the user
 # supplied is left alone; its build artifacts are theirs, not ours.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ build against a Tock tree of your own instead — a branch you are working on,
 say — point `TOCK_DIR` at it:
 
 ```shell
-make qemu-example-qemu_rv32_virt EXAMPLE=console TOCK_DIR=~/src/tock
+make qemu-example-qemu_rv32_virt EXAMPLE=console TOCK_DIR=$HOME/src/tock
 ```
 
 A tree you supply this way is used exactly as it is: libtock-rs never fetches

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ builds examples for a series of likely useful flash and RAM addresses.
     make setup
     ```
 
+1.  If you want to run examples under emulation, install a QEMU with 32-bit
+    RISC-V support: `qemu-system-misc` on Debian and Ubuntu,
+    `qemu-system-riscv` on Fedora, `qemu` on Homebrew. `make setup-qemu`
+    reports whether the one you have will do.
+
 1.  Use `make` to build examples
 
     ```shell
@@ -75,6 +80,29 @@ FEATURES=rust_embedded
 
 If using libtock-rs or a sub-crate as a cargo dependency the `rust_embedded`
 can also be enabled via Cargo.
+
+### Running an example under emulation
+
+Some of the supported boards can be emulated, so an example can be run with no
+hardware at all. Run `make` to list them, then run one:
+
+```shell
+make qemu-example-qemu_rv32_virt EXAMPLE=console
+```
+
+This builds a Tock kernel, which needs Tock's source. By default libtock-rs
+fetches a pinned revision into a cache directory and manages it for you. To
+build against a Tock tree of your own instead — a branch you are working on,
+say — point `TOCK_DIR` at it:
+
+```shell
+make qemu-example-qemu_rv32_virt EXAMPLE=console TOCK_DIR=~/src/tock
+```
+
+A tree you supply this way is used exactly as it is: libtock-rs never fetches
+into it, checks anything out in it, or cleans it.
+
+An emulated board runs until you interrupt it with Ctrl+C.
 
 ### Building a generic TAB (Tock Application Bundle) file
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 Rust userland library for Tock
 
-Generally this library was tested with Tock [Release
-2.1.1](https://github.com/tock/tock/releases/tag/release-2.1.1).
+Generally this library tracks recent Tock master; the kernels it builds to run
+examples under emulation are pinned to a specific commit (`TOCK_COMMIT` in
+`Makefile.qemu`).
 
 The library should work on all Tock boards, but currently apps must be compiled
 for the flash and RAM address they are executed at. See [Fix

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ builds examples for a series of likely useful flash and RAM addresses.
     ```
 
 1.  If you want to run examples under emulation, install a QEMU with 32-bit
-    RISC-V support: `qemu-system-misc` on Debian and Ubuntu,
-    `qemu-system-riscv` on Fedora, `qemu` on Homebrew. `make setup-qemu`
-    reports whether the one you have will do.
+    RISC-V support: `qemu-system-misc` or, on newer releases, `qemu-system-riscv`
+    on Debian and Ubuntu; `qemu-system-riscv` on Fedora; `qemu` on Homebrew.
+    `make setup-qemu` reports whether the one you have will do.
 
 1.  Use `make` to build examples
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ builds examples for a series of likely useful flash and RAM addresses.
 1.  Clone the repository:
 
     ```shell
-    git clone --recursive https://github.com/tock/libtock-rs
+    git clone https://github.com/tock/libtock-rs
     cd libtock-rs
     ```
 

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -12,5 +12,4 @@ version = "0.1.0"
 [dependencies]
 clap = { features = ["derive"], version = "3.2.6" }
 elf = "0.0.10"
-libc = "0.2.113"
 termion = "1.5.6"

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -63,6 +63,9 @@ fn main() {
     if cli.verbose {
         println!("Detected platform {platform}");
     }
+    if matches!(cli.deploy, Some(Deploy::Qemu)) {
+        output_processor::check_run_can_end(&cli);
+    }
     let paths = elf2tab::convert_elf(&cli, &platform);
     let deploy = match cli.deploy {
         None => return,

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -3,6 +3,7 @@ mod output_processor;
 mod qemu;
 mod tockloader;
 
+use clap::builder::NonEmptyStringValueParser;
 use clap::{Parser, ValueEnum};
 use std::env::{var, VarError};
 use std::path::PathBuf;
@@ -20,6 +21,11 @@ pub struct Cli {
     #[clap(action)]
     elf: PathBuf,
 
+    /// Shut the system down and report success as soon as this string
+    /// appears in its output.
+    #[clap(action, long, value_parser = NonEmptyStringValueParser::new())]
+    expect: Option<String>,
+
     /// The Tock kernel to boot, when deploying to QEMU.
     #[clap(action, long, required_if_eq("deploy", "qemu"))]
     kernel: Option<PathBuf>,
@@ -27,6 +33,10 @@ pub struct Cli {
     /// The QEMU binary to run, when deploying to QEMU.
     #[clap(action, long, required_if_eq("deploy", "qemu"))]
     qemu: Option<PathBuf>,
+
+    /// Terminate and fail if the system has not exited after this many seconds.
+    #[clap(action, long)]
+    timeout: Option<u64>,
 
     /// Whether to output verbose debugging information to the console.
     #[clap(long, short, action)]

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -20,6 +20,14 @@ pub struct Cli {
     #[clap(action)]
     elf: PathBuf,
 
+    /// The Tock kernel to boot, when deploying to QEMU.
+    #[clap(action, long, required_if_eq("deploy", "qemu"))]
+    kernel: Option<PathBuf>,
+
+    /// The QEMU binary to run, when deploying to QEMU.
+    #[clap(action, long, required_if_eq("deploy", "qemu"))]
+    qemu: Option<PathBuf>,
+
     /// Whether to output verbose debugging information to the console.
     #[clap(long, short, action)]
     verbose: bool,

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -4,7 +4,8 @@ use std::os::unix::process::ExitStatusExt;
 use std::process::{Child, ChildStderr, ChildStdin};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::thread::spawn;
+use std::thread::{sleep, spawn};
+use std::time::Duration;
 use termion::is_tty;
 use termion::raw::{IntoRawMode, RawTerminal};
 
@@ -24,8 +25,31 @@ pub fn process(cli: &Cli, mut child: Child) {
     let shutdown_requested = Arc::new(AtomicBool::new(false));
     let child = Arc::new(Mutex::new(child));
 
-    let raw_mode = forward_stdin_if_piped(child_stdin, child.clone(), shutdown_requested.clone());
+    // Set when the timeout elapses, so that we can tell a run we cut short apart
+    // from one that ended the way it was asked to.
+    let timed_out = Arc::new(AtomicBool::new(false));
+    // A run that says how it ends -- with --expect, or at worst with --timeout
+    // -- does not need a person at the keyboard, and must not be cut short when
+    // our stdin turns out to be empty.
+    let ends_on_its_own = cli.expect.is_some() || cli.timeout.is_some();
+
+    let raw_mode = forward_stdin_if_piped(
+        child_stdin,
+        child.clone(),
+        shutdown_requested.clone(),
+        ends_on_its_own,
+    );
+    if let Some(timeout) = cli.timeout {
+        shut_down_after_timeout(
+            child.clone(),
+            shutdown_requested.clone(),
+            timed_out.clone(),
+            timeout,
+        );
+    }
     forward_stderr_if_piped(child_stderr, raw_mode.is_some());
+    let mut expected = cli.expect.as_deref().map(Expected::new);
+    let mut expectation_met = false;
     let mut to_print = Vec::new();
     let mut reader = BufReader::new(child_stdout);
     loop {
@@ -52,6 +76,15 @@ pub fn process(cli: &Cli, mut child: Child) {
         drop(lock);
         to_print.clear();
 
+        // The output we were waiting for has arrived. Stop the run.
+        if let Some(expected) = &mut expected {
+            if expected.seen_in(buffer) {
+                expectation_met = true;
+                request_shutdown(&child, &shutdown_requested);
+                break;
+            }
+        }
+
         let buffer_len = buffer.len();
         reader.consume(buffer_len);
     }
@@ -62,6 +95,12 @@ pub fn process(cli: &Cli, mut child: Child) {
         .wait()
         .expect("Unable to wait for child process");
     drop(raw_mode);
+    if let Some(timeout) = cli.timeout {
+        assert!(
+            !timed_out.load(Ordering::SeqCst),
+            "Child process did not finish within {timeout} seconds."
+        );
+    }
     // Being killed by the signal we sent is how a shutdown we asked for looks,
     // not a failure. Without this, pressing Ctrl+C -- the exit path this module
     // goes out of its way to support -- ended every session with a panic.
@@ -71,6 +110,12 @@ pub fn process(cli: &Cli, mut child: Child) {
         status.success() || shut_down_on_request,
         "Child process did not exit successfully. {status}"
     );
+    if let Some(expect) = &cli.expect {
+        assert!(
+            expectation_met,
+            "Child process exited without printing {expect:?}."
+        );
+    }
 }
 
 // Asks the child to exit, and records that we were the ones who asked. An error
@@ -92,6 +137,7 @@ fn forward_stdin_if_piped(
     child_stdin: Option<ChildStdin>,
     child: Arc<Mutex<Child>>,
     shutdown_requested: Arc<AtomicBool>,
+    ends_on_its_own: bool,
 ) -> Option<RawTerminal<Stdout>> {
     let mut child_stdin = child_stdin?;
     spawn(move || {
@@ -102,7 +148,13 @@ fn forward_stdin_if_piped(
             if buffer.is_empty() {
                 // Our stdin was closed. We interpret this as a signal to exit,
                 // because pressing Ctrl+C to trigger an exit is no longer
-                // possible.
+                // possible. Unless the run already knows how it ends: then a
+                // closed stdin just means nobody is typing at us -- the normal
+                // case for a script, whose stdin is /dev/null and which would
+                // otherwise be cut short before the board had finished booting.
+                if ends_on_its_own {
+                    return;
+                }
                 break;
             }
             // In raw mode, pressing Ctrl+C will send a '3' byte to stdin ("end
@@ -140,6 +192,55 @@ fn forward_stdin_if_piped(
             .into_raw_mode()
             .expect("Failed to set terminal to raw mode."),
     )
+}
+
+// Spawns a thread that shuts the child down once it elapses, recording that the
+// run was cut short rather than ending on its own terms.
+fn shut_down_after_timeout(
+    child: Arc<Mutex<Child>>,
+    shutdown_requested: Arc<AtomicBool>,
+    timed_out: Arc<AtomicBool>,
+    timeout: u64,
+) {
+    spawn(move || {
+        sleep(Duration::from_secs(timeout));
+        timed_out.store(true, Ordering::SeqCst);
+        request_shutdown(&child, &shutdown_requested);
+    });
+}
+
+// A string to watch for in the child's output. The child's output arrives in
+// whatever sized pieces the pipe hands us, so this keeps the tail of what it
+// has seen: without it, a match that straddles two reads would be missed.
+struct Expected {
+    string: Vec<u8>,
+    tail: Vec<u8>,
+}
+
+impl Expected {
+    fn new(string: &str) -> Self {
+        Self {
+            string: string.into(),
+            tail: Vec::new(),
+        }
+    }
+
+    // Returns true if the string appears in the child's output, once buffer is
+    // added to what we have already seen.
+    fn seen_in(&mut self, buffer: &[u8]) -> bool {
+        self.tail.extend_from_slice(buffer);
+        let found = self
+            .tail
+            .windows(self.string.len())
+            .any(|window| window == self.string);
+        // Everything before the last string.len() - 1 bytes is too far back to
+        // be part of a future match.
+        let keep = self.string.len() - 1;
+        if self.tail.len() > keep {
+            self.tail.drain(..self.tail.len() - keep);
+        }
+        found
+    }
 }
 
 // Forwards child's stderr to our stderr if child's stderr is piped, converting

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -1,17 +1,33 @@
 use super::Cli;
-use libc::{kill, pid_t, SIGINT};
 use std::io::{stderr, stdin, stdout, BufRead, BufReader, ErrorKind, Stdout, Write};
-use std::process::Child;
+use std::os::unix::process::ExitStatusExt;
+use std::process::{Child, ChildStderr, ChildStdin};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::thread::spawn;
+use termion::is_tty;
 use termion::raw::{IntoRawMode, RawTerminal};
 
-/// Reads the console messages from `child`'s standard output, sending SIGTERM
-/// to the child when the process is terminated.
+/// Reads the console messages from `child`'s standard output, shutting the
+/// child down when the process is terminated.
 pub fn process(cli: &Cli, mut child: Child) {
-    let raw_mode = forward_stdin_if_piped(&mut child);
-    forward_stderr_if_piped(&mut child, raw_mode.is_some());
+    // The child's pipes are taken up front, so that reading them does not
+    // require the lock below. The threads that shut the child down need the
+    // Child itself, and the main loop spends nearly all of its time blocked
+    // reading the child's output, so sharing the Child through a mutex it does
+    // not hold while reading is what lets a shutdown arrive at any time.
+    let child_stdin = child.stdin.take();
+    let child_stdout = child.stdout.take().expect("Child's stdout not piped.");
+    let child_stderr = child.stderr.take();
+    // Set when we ask the child to shut down, so that we can tell the shutdown
+    // we asked for apart from the child dying on its own.
+    let shutdown_requested = Arc::new(AtomicBool::new(false));
+    let child = Arc::new(Mutex::new(child));
+
+    let raw_mode = forward_stdin_if_piped(child_stdin, child.clone(), shutdown_requested.clone());
+    forward_stderr_if_piped(child_stderr, raw_mode.is_some());
     let mut to_print = Vec::new();
-    let mut reader = BufReader::new(child.stdout.as_mut().expect("Child's stdout not piped."));
+    let mut reader = BufReader::new(child_stdout);
     loop {
         let buffer = reader
             .fill_buf()
@@ -42,21 +58,42 @@ pub fn process(cli: &Cli, mut child: Child) {
     if cli.verbose {
         println!("Waiting for child process.\r");
     }
-    let status = child.wait().expect("Unable to wait for child process");
+    let status = lock_child(&child)
+        .wait()
+        .expect("Unable to wait for child process");
     drop(raw_mode);
+    // Being killed by the signal we sent is how a shutdown we asked for looks,
+    // not a failure. Without this, pressing Ctrl+C -- the exit path this module
+    // goes out of its way to support -- ended every session with a panic.
+    let shut_down_on_request =
+        shutdown_requested.load(Ordering::SeqCst) && status.signal().is_some();
     assert!(
-        status.success(),
+        status.success() || shut_down_on_request,
         "Child process did not exit successfully. {status}"
     );
 }
 
+// Asks the child to exit, and records that we were the ones who asked. An error
+// from kill means the child has already exited, which is the outcome we wanted.
+fn request_shutdown(child: &Mutex<Child>, shutdown_requested: &AtomicBool) {
+    shutdown_requested.store(true, Ordering::SeqCst);
+    let _ = lock_child(child).kill();
+}
+
+fn lock_child(child: &Mutex<Child>) -> std::sync::MutexGuard<'_, Child> {
+    child.lock().expect("Child mutex was poisoned")
+}
+
 // If child's stdin is piped, this sets the terminal to raw mode and spawns a
-// thread that forwards our stdin to child's stdin. The thread sends SIGINT to
-// the child if Ctrl+C is pressed. Returns a RawTerminal, which reverts the
-// terminal to its previous configuration on drop.
-fn forward_stdin_if_piped(child: &mut Child) -> Option<RawTerminal<Stdout>> {
-    let mut child_stdin = child.stdin.take()?;
-    let child_id = child.id();
+// thread that forwards our stdin to child's stdin. The thread shuts the child
+// down if Ctrl+C is pressed. Returns a RawTerminal, which reverts the terminal
+// to its previous configuration on drop.
+fn forward_stdin_if_piped(
+    child_stdin: Option<ChildStdin>,
+    child: Arc<Mutex<Child>>,
+    shutdown_requested: Arc<AtomicBool>,
+) -> Option<RawTerminal<Stdout>> {
+    let mut child_stdin = child_stdin?;
     spawn(move || {
         let our_stdin = stdin();
         let mut our_stdin = our_stdin.lock();
@@ -76,24 +113,30 @@ fn forward_stdin_if_piped(child: &mut Child) -> Option<RawTerminal<Stdout>> {
             }
             match child_stdin.write(buffer) {
                 // A BrokenPipe error occurs when the child has exited. Exit
-                // without sending SIGINT.
+                // without shutting it down.
                 Err(error) if error.kind() == ErrorKind::BrokenPipe => return,
 
                 Err(error) => panic!("Failed to forward stdin: {error}"),
                 Ok(bytes) => our_stdin.consume(bytes),
             }
         }
-        // Send SIGINT to the child, telling it to exit. After the child exits,
-        // the main loop will detect the exit and we will shut down cleanly.
-        //
-        // Safety: Sending SIGINT to a process is a safe operation -- kill is
-        // marked unsafe because it is a FFI function.
-        unsafe {
-            kill(child_id as pid_t, SIGINT);
-        }
+        // Tell the child to exit. Once it does, the main loop will detect the
+        // exit and we will shut down cleanly.
+        request_shutdown(&child, &shutdown_requested);
     });
+    // Raw mode is what lets Ctrl+C reach us rather than the child, but it is
+    // only available on a terminal. When our output has been redirected to a
+    // file or a pipe -- a CI job, or a `make qemu-example-... | tee` -- there is
+    // no terminal to configure, and asking for one fails with ENOTTY. Run
+    // without it in that case: there is no interactive user to serve, and
+    // skipping raw mode also skips the CRLF rewriting that only a raw terminal
+    // needs.
+    let stdout = stdout();
+    if !is_tty(&stdout) {
+        return None;
+    }
     Some(
-        stdout()
+        stdout
             .into_raw_mode()
             .expect("Failed to set terminal to raw mode."),
     )
@@ -101,10 +144,9 @@ fn forward_stdin_if_piped(child: &mut Child) -> Option<RawTerminal<Stdout>> {
 
 // Forwards child's stderr to our stderr if child's stderr is piped, converting
 // line endings to CRLF if raw_mode is true.
-fn forward_stderr_if_piped(child: &mut Child, raw_mode: bool) {
-    let child_stderr = match child.stderr.take() {
-        None => return,
-        Some(child_stderr) => child_stderr,
+fn forward_stderr_if_piped(child_stderr: Option<ChildStderr>, raw_mode: bool) {
+    let Some(child_stderr) = child_stderr else {
+        return;
     };
     spawn(move || {
         let mut to_print = Vec::new();

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -1,13 +1,43 @@
 use super::Cli;
 use std::io::{stderr, stdin, stdout, BufRead, BufReader, ErrorKind, Stdout, Write};
 use std::os::unix::process::ExitStatusExt;
-use std::process::{Child, ChildStderr, ChildStdin};
+use std::process::{exit, Child, ChildStderr, ChildStdin};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{sleep, spawn};
 use std::time::Duration;
 use termion::is_tty;
 use termion::raw::{IntoRawMode, RawTerminal};
+
+// The signal Child::kill sends. Rather than depend on libc for one constant, we
+// name the number POSIX fixes it at.
+const SIGKILL: i32 = 9;
+
+// How long the timeout thread gives the rest of the runner to finish reporting
+// the timeout before it ends the process itself.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Panics unless something would eventually end an emulated run.
+///
+/// An emulated board runs until it is interrupted, and the only thing that
+/// interrupts one is a person pressing Ctrl+C. Without a terminal there is no
+/// such person, so the run needs --expect or --timeout to say when it is over.
+/// Deciding this before the board is started keeps a misconfigured run from
+/// booting one only to shut it down before it has printed anything -- which,
+/// being a shutdown we asked for, would be reported as a success.
+pub fn check_run_can_end(cli: &Cli) {
+    assert!(
+        interactive() || cli.expect.is_some() || cli.timeout.is_some(),
+        "Nothing would end this run: it has no terminal to interrupt it, and \
+         neither --expect nor --timeout was given."
+    );
+}
+
+// Whether there is a person at both ends of this run: a terminal we can
+// configure, and a stdin they can type at.
+fn interactive() -> bool {
+    is_tty(&stdin()) && is_tty(&stdout())
+}
 
 /// Reads the console messages from `child`'s standard output, shutting the
 /// child down when the process is terminated.
@@ -91,21 +121,37 @@ pub fn process(cli: &Cli, mut child: Child) {
     if cli.verbose {
         println!("Waiting for child process.\r");
     }
-    let status = lock_child(&child)
-        .wait()
-        .expect("Unable to wait for child process");
+    // wait() would hold the child mutex for as long as the child runs, which
+    // would block the threads whose whole job is to end it. Poll instead, so
+    // that the lock is only ever held for the length of one try_wait.
+    let status = loop {
+        let waited = lock_child(&child)
+            .try_wait()
+            .expect("Unable to wait for child process");
+        match waited {
+            Some(status) => break status,
+            None => sleep(Duration::from_millis(50)),
+        }
+    };
     drop(raw_mode);
-    if let Some(timeout) = cli.timeout {
-        assert!(
-            !timed_out.load(Ordering::SeqCst),
-            "Child process did not finish within {timeout} seconds."
-        );
+    // Seeing what we came for is the run succeeding, even if the timeout fired
+    // in the same instant, so the timeout is only a failure when the run had
+    // nothing else to end it.
+    if !expectation_met {
+        if let Some(timeout) = cli.timeout {
+            assert!(
+                !timed_out.load(Ordering::SeqCst),
+                "Child process did not finish within {timeout} seconds."
+            );
+        }
     }
     // Being killed by the signal we sent is how a shutdown we asked for looks,
     // not a failure. Without this, pressing Ctrl+C -- the exit path this module
-    // goes out of its way to support -- ended every session with a panic.
+    // goes out of its way to support -- ended every session with a panic. Any
+    // other signal is the child dying of something we did not ask for, which is
+    // still a failure.
     let shut_down_on_request =
-        shutdown_requested.load(Ordering::SeqCst) && status.signal().is_some();
+        shutdown_requested.load(Ordering::SeqCst) && status.signal() == Some(SIGKILL);
     assert!(
         status.success() || shut_down_on_request,
         "Child process did not exit successfully. {status}"
@@ -177,18 +223,19 @@ fn forward_stdin_if_piped(
         request_shutdown(&child, &shutdown_requested);
     });
     // Raw mode is what lets Ctrl+C reach us rather than the child, but it is
-    // only available on a terminal. When our output has been redirected to a
-    // file or a pipe -- a CI job, or a `make qemu-example-... | tee` -- there is
-    // no terminal to configure, and asking for one fails with ENOTTY. Run
-    // without it in that case: there is no interactive user to serve, and
-    // skipping raw mode also skips the CRLF rewriting that only a raw terminal
-    // needs.
-    let stdout = stdout();
-    if !is_tty(&stdout) {
+    // only available on a terminal, and it is only any use when the thread
+    // above is reading stdin to receive what it delivers. When either end has
+    // been redirected -- a CI job, or a `make qemu-example-... </dev/null` --
+    // leave the terminal alone. Asking for raw mode without a terminal fails
+    // with ENOTTY; asking for it without a stdin to read turns off the
+    // terminal's own Ctrl+C while nothing is left to notice the byte it sends
+    // instead, leaving no way at all to interrupt the run. Skipping raw mode
+    // also skips the CRLF rewriting that only a raw terminal needs.
+    if !interactive() {
         return None;
     }
     Some(
-        stdout
+        stdout()
             .into_raw_mode()
             .expect("Failed to set terminal to raw mode."),
     )
@@ -206,6 +253,16 @@ fn shut_down_after_timeout(
         sleep(Duration::from_secs(timeout));
         timed_out.store(true, Ordering::SeqCst);
         request_shutdown(&child, &shutdown_requested);
+        // Killing the child normally ends the run: the main thread sees its
+        // stdout close, and reports the timeout. It does not if anything else
+        // is holding that pipe open -- a process the child spawned, say -- in
+        // which case the main thread stays blocked reading a pipe nothing will
+        // ever write to again, and a timeout that cannot end the run is not a
+        // backstop. Give the rest of the runner a moment to report this
+        // properly, and end the process ourselves if it does not.
+        sleep(SHUTDOWN_GRACE);
+        eprintln!("Child process did not finish within {timeout} seconds.");
+        exit(1);
     });
 }
 

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -219,6 +219,10 @@ struct Expected {
 
 impl Expected {
     fn new(string: &str) -> Self {
+        // An empty string has nothing to look for and would make the
+        // bookkeeping below underflow. --expect rejects one, so this only has
+        // to catch a future caller that does not.
+        assert!(!string.is_empty(), "Expected string is empty.");
         Self {
             string: string.into(),
             tail: Vec::new(),
@@ -320,6 +324,12 @@ mod tests {
             assert!(!expected.seen_in(b"Hello world!\n"));
         }
         assert_eq!(expected.tail.len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Expected string is empty.")]
+    fn empty_string_rejected() {
+        Expected::new("");
     }
 
     // Output the child produced before the string does not become part of it.

--- a/runner/src/output_processor.rs
+++ b/runner/src/output_processor.rs
@@ -272,3 +272,61 @@ fn forward_stderr_if_piped(child_stderr: Option<ChildStderr>, raw_mode: bool) {
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Expected;
+
+    #[test]
+    fn match_within_one_read() {
+        let mut expected = Expected::new("world");
+        assert!(!expected.seen_in(b"Entering main loop.\n"));
+        assert!(expected.seen_in(b"Hello world!\n"));
+    }
+
+    // The child's output arrives in whatever sized pieces the pipe hands us, so
+    // a match is not guaranteed to fall inside a single read.
+    #[test]
+    fn match_split_across_reads() {
+        let mut expected = Expected::new("Hello world!");
+        assert!(!expected.seen_in(b"He"));
+        assert!(!expected.seen_in(b"llo wor"));
+        assert!(expected.seen_in(b"ld! tock$ "));
+    }
+
+    #[test]
+    fn match_longer_than_any_one_read() {
+        let mut expected = Expected::new("abcdef");
+        assert!(!expected.seen_in(b"ab"));
+        assert!(!expected.seen_in(b"cd"));
+        assert!(expected.seen_in(b"ef"));
+    }
+
+    // A one-byte string has no tail to keep, which is the boundary case of the
+    // bookkeeping in seen_in.
+    #[test]
+    fn single_byte_string() {
+        let mut expected = Expected::new("$");
+        assert!(!expected.seen_in(b"Hello world!\n"));
+        assert!(expected.seen_in(b"tock$ "));
+    }
+
+    // A board that never prints what we are waiting for can produce arbitrarily
+    // much output, so what we retain of it must stay bounded.
+    #[test]
+    fn tail_does_not_grow() {
+        let mut expected = Expected::new("xyz");
+        for _ in 0..1000 {
+            assert!(!expected.seen_in(b"Hello world!\n"));
+        }
+        assert_eq!(expected.tail.len(), 2);
+    }
+
+    // Output the child produced before the string does not become part of it.
+    #[test]
+    fn no_match_across_a_gap() {
+        let mut expected = Expected::new("ab");
+        assert!(!expected.seen_in(b"a"));
+        assert!(!expected.seen_in(b"cb"));
+    }
+}

--- a/runner/src/qemu.rs
+++ b/runner/src/qemu.rs
@@ -5,7 +5,10 @@ use std::process::{Child, Command, Stdio};
 // Spawns a QEMU VM with a simulated Tock system and the process binary. Returns
 // the handle for the spawned QEMU process.
 pub fn deploy(cli: &Cli, platform: String, tbf_path: PathBuf) -> Child {
-    let platform_args = get_platform_args(platform);
+    let platform_args = get_platform_args(&platform);
+    // clap requires both of these when --deploy is qemu.
+    let kernel = cli.kernel.as_ref().expect("--kernel not provided");
+    let binary = cli.qemu.as_ref().expect("--qemu not provided");
     let device = format!(
         "loader,file={},addr={}",
         tbf_path
@@ -14,9 +17,12 @@ pub fn deploy(cli: &Cli, platform: String, tbf_path: PathBuf) -> Child {
             .expect("Non-UTF-8 path"),
         platform_args.process_binary_load_address,
     );
-    let mut qemu = Command::new("tock/tools/qemu/build/qemu-system-riscv32");
+    let mut qemu = Command::new(binary);
     qemu.args(["-device", &device, "-nographic", "-serial", "mon:stdio"]);
     qemu.args(platform_args.fixed_args);
+    // How the kernel is handed to QEMU differs by board: the virt machine boots
+    // the kernel as its firmware, while the others are loaded as a kernel image.
+    qemu.args([platform_args.kernel_flag, &kernel.to_string_lossy()]);
     // If we let QEMU inherit its stdin from us, it will set it to raw mode,
     // which prevents Ctrl+C from generating SIGINT. QEMU will not exit when
     // Ctrl+C is entered, making our runner hard to close. Instead, we forward
@@ -32,29 +38,56 @@ pub fn deploy(cli: &Cli, platform: String, tbf_path: PathBuf) -> Child {
         println!("QEMU command: {qemu:?}");
         println!("Spawning QEMU")
     }
-    qemu.spawn().expect("failed to spawn QEMU")
+    qemu.spawn().unwrap_or_else(|error| {
+        panic!(
+            "failed to spawn QEMU ({}): {error}\n\
+             Install a QEMU with 32-bit RISC-V support (qemu-system-misc on Debian and \
+             Ubuntu, qemu-system-riscv on Fedora, qemu on Homebrew), or set LIBTOCK_QEMU \
+             to a qemu-system-riscv32 binary.",
+            binary.display()
+        )
+    })
 }
 
 // Returns the command line arguments for the given platform to qemu. Panics if
 // an unknown platform is passed.
-fn get_platform_args(platform: String) -> PlatformConfig {
-    match platform.as_str() {
+//
+// The arguments for each board mirror that board's `qemu` or `run-app` target in
+// the Tock tree, which is the authority on how to boot it.
+fn get_platform_args(platform: &str) -> PlatformConfig {
+    match platform {
         "hifive1" => PlatformConfig {
-            #[rustfmt::skip]
-            fixed_args: &[
-                "-kernel", "tock/target/riscv32imac-unknown-none-elf/release/hifive1",
-                "-M", "sifive_e,revb=true",
-            ],
+            fixed_args: &["-M", "sifive_e,revb=true"],
+            kernel_flag: "-kernel",
             process_binary_load_address: "0x20040000",
         },
         "opentitan" => PlatformConfig {
+            // The earlgrey-cw310 kernel starts at ORIGIN(rom) plus the size of
+            // the manifest, so the Ibex has to be told to reset there rather
+            // than at the start of the ROM. This replaces a
+            // `-bios tock/tools/qemu-runner/opentitan-boot-rom.elf` argument
+            // that named a file which does not exist anywhere in Tock.
             #[rustfmt::skip]
             fixed_args: &[
-                "-bios", "tock/tools/qemu-runner/opentitan-boot-rom.elf",
-                "-kernel", "tock/target/riscv32imc-unknown-none-elf/release/earlgrey-cw310",
                 "-M", "opentitan",
+                "-global", "driver=riscv.lowrisc.ibex.soc,property=resetvec,value=0x20000400",
             ],
+            kernel_flag: "-kernel",
             process_binary_load_address: "0x20030000",
+        },
+        "qemu_rv32_virt" => PlatformConfig {
+            // The virt board runs the kernel as the machine's firmware, in
+            // RISC-V machine mode, rather than as a loaded kernel image.
+            #[rustfmt::skip]
+            fixed_args: &[
+                "-M", "virt",
+                "-semihosting",
+                "-global", "driver=riscv-cpu,property=smepmp,value=true",
+                "-global", "virtio-mmio.force-legacy=false",
+                "-device", "virtio-rng-device",
+            ],
+            kernel_flag: "-bios",
+            process_binary_load_address: "0x80100000",
         },
         _ => panic!("Cannot deploy to platform {platform} via QEMU."),
     }
@@ -63,5 +96,8 @@ fn get_platform_args(platform: String) -> PlatformConfig {
 // QEMU configuration information that is specific to each platform.
 struct PlatformConfig {
     fixed_args: &'static [&'static str],
+    // Whether QEMU takes this board's kernel as a firmware image or a kernel
+    // image.
+    kernel_flag: &'static str,
     process_binary_load_address: &'static str,
 }


### PR DESCRIPTION
***DRAFT While I do live CI checks***

**Disclaimer:** Claude did a lot of the mechanical work, but I've manually reviewed and cherry-pick/merged the changes that actually land here.

This does a few things:
 - It moves all the QEMU stuff to a dedicated `Makefile.qemu` that the main `Makefile` just includes.
 - It fixes up the QEMU runner to better handle headless operation, most notably by adding `--timeout` and `--expect` flags.
 - It updates CI to actually run QEMU now: all boards in linux, just one PoC on mac.
    - Note: This requires bumping the runner image to a newer ubuntu to pick up a newer qemu.
 - It replaces the submodule with a QEMU-Makefile-managed `TOCK_DIR` checkout.
    - This one bears some more explanation: We only ever had a submodule so that QEMU had a way to get a kernel image to run things on. We still need that, but now we just (by default) do a checkout of Tock into platform-reasonable tock directory. As a convenience feature though, you can also set `TOCK_DIR` to an actual tock checkout, and it'll use that (for e.g. co-development when needed).

<details><summary>Extra summary stuff claude thinks should have been added to the list above.</summary>
Seven?? Seven more things claude? You really don't get the idea of a **summary**, but I'll paste it in case:

  1. Emulation was partly broken, not just unexercised. The opentitan config passed -bios tock/tools/qemu-runner/opentitan-boot-rom.elf — a path that exists in no Tock tree. So of the
  two boards the runner claimed to support, one could not have worked. It's replaced with a resetvec override (-global driver=riscv.lowrisc.ibex.soc,property=resetvec,value=0x20000400),
  because the earlgrey-cw310 kernel starts at ORIGIN(rom) plus the manifest size. Worth leading with — it reframes the PR from "add CI" to "fix emulation, then add CI so it stays
  fixed."

  2. A third board is new. Before: hifive1 and opentitan. qemu_rv32_virt is added, and it's the reason the kernel flag became per-board — virt runs the kernel as firmware (-bios) rather
  than loading it (-kernel).

  3. The runner no longer hardcodes paths. New --kernel and --qemu flags, supplied by the Makefile. That's the actual mechanism decoupling the runner from the submodule, and it's a CLI
  surface change alongside --expect/--timeout.

  4. New targets and a new on-disk footprint. make setup-qemu, make clean-tock-cache, make qemu-examples. The managed checkout lands in $XDG_CACHE_HOME/libtock-rs
  (~/Library/Caches/libtock-rs on macOS) — outside the repo, and not small. People will want to know where it went and how to remove it.

  5. TOCK_COMMIT is a new maintenance obligation. Somebody has to bump the pin. Related: the README no longer claims the library is tested against a specific Tock release, since that
  claim was already stale. That's a maintainer policy call, better surfaced than buried.

  6. Existing clones keep a dead tock/ directory. Git doesn't remove a submodule's working tree when the submodule goes away, so every current contributor ends up with a multi-GB
  directory nothing references. One line saves some confused reports.

  7. One behavior change beyond headless support. A QEMU run with no terminal and neither --expect nor --timeout now fails immediately rather than hanging — deliberate, but anyone
  scripting make qemu-example-<board> today sees a new error. And separately from headless: Ctrl+C used to end every interactive session with a panic (clean shutdown reported as
  failure). That's a bug fix current users hit, and "better handles headless operation" undersells it.
</details>