### PR TITLE
CI: Remove assumptions about GitHub infra

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -16,27 +16,27 @@ jobs:
 
       - name: Build LEDs
         run: |
-          make -j2 EXAMPLE=leds apollo3
-          make -j2 EXAMPLE=leds hail
-          make -j2 EXAMPLE=leds imix
-          make -j2 EXAMPLE=leds nucleo_f429zi
-          make -j2 EXAMPLE=leds nucleo_f446re
-          make -j2 EXAMPLE=leds nrf52840
-          make -j2 EXAMPLE=leds opentitan
-          make -j2 EXAMPLE=leds hifive1
-          make -j2 EXAMPLE=leds nrf52
+          make -j$(nproc) EXAMPLE=leds apollo3
+          make -j$(nproc) EXAMPLE=leds hail
+          make -j$(nproc) EXAMPLE=leds imix
+          make -j$(nproc) EXAMPLE=leds nucleo_f429zi
+          make -j$(nproc) EXAMPLE=leds nucleo_f446re
+          make -j$(nproc) EXAMPLE=leds nrf52840
+          make -j$(nproc) EXAMPLE=leds opentitan
+          make -j$(nproc) EXAMPLE=leds hifive1
+          make -j$(nproc) EXAMPLE=leds nrf52
 
       - name: Build Low Level Debug
         run: |
-          make -j2 EXAMPLE=low_level_debug apollo3
-          make -j2 EXAMPLE=low_level_debug hail
-          make -j2 EXAMPLE=low_level_debug imix
-          make -j2 EXAMPLE=low_level_debug nucleo_f429zi
-          make -j2 EXAMPLE=low_level_debug nucleo_f446re
-          make -j2 EXAMPLE=low_level_debug nrf52840
-          make -j2 EXAMPLE=low_level_debug opentitan
-          make -j2 EXAMPLE=low_level_debug hifive1
-          make -j2 EXAMPLE=low_level_debug nrf52
+          make -j$(nproc) EXAMPLE=low_level_debug apollo3
+          make -j$(nproc) EXAMPLE=low_level_debug hail
+          make -j$(nproc) EXAMPLE=low_level_debug imix
+          make -j$(nproc) EXAMPLE=low_level_debug nucleo_f429zi
+          make -j$(nproc) EXAMPLE=low_level_debug nucleo_f446re
+          make -j$(nproc) EXAMPLE=low_level_debug nrf52840
+          make -j$(nproc) EXAMPLE=low_level_debug opentitan
+          make -j$(nproc) EXAMPLE=low_level_debug hifive1
+          make -j$(nproc) EXAMPLE=low_level_debug nrf52
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,7 @@ jobs:
           submodules: true
 
       # The main test step. We let the makefile do most of the work because the
-      # makefile can be tested locally. We experimentally determined that -j2 is
-      # optimal for the Azure Standard_DS2_v2 VM, which is the VM type used by
-      # GitHub Actions at the time of this writing.
+      # makefile can be tested locally.
       #
       # We have to append the "-D warnings" flag to .cargo/config.toml rather
       # than using the RUSTFLAGS environment variable because if we set
@@ -44,6 +42,6 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           echo "[target.'cfg(all())']" >> .cargo/config.toml
           echo 'rustflags = ["-D", "warnings"]' >> .cargo/config.toml
-          make -j2 setup
-          make -j2 test
+          make -j$(nproc) setup
+          make -j$(nproc) test
           make demos

--- a/.github/workflows/size-diff.yml
+++ b/.github/workflows/size-diff.yml
@@ -31,21 +31,20 @@ jobs:
       # the merge commit and the target branch. We display the diff in a
       # separate step to make it easy to navigate to in the GitHub Actions UI.
       #
-      # If the build on master doesn't work (`make -j2 examples` fails), we
-      # output a warning message and ignore the error. Ignoring the error
-      # prevents this workflow from blocking PRs that fix a broken build in
-      # master.
+      # If the build on master doesn't work (`make examples` fails), we output
+      # a warning message and ignore the error. Ignoring the error prevents
+      # this workflow from blocking PRs that fix a broken build in master.
       - name: Compute sizes
         run: |
           UPSTREAM_REMOTE_NAME="${UPSTREAM_REMOTE_NAME:-origin}"
           GITHUB_BASE_REF="${GITHUB_BASE_REF:-master}"
           cd "${GITHUB_WORKSPACE}"
-          make -j2 examples  # The VM this runs on has 2 logical cores.
+          make -j$(nproc) examples
           cargo run --release -p print_sizes >'${{runner.temp}}/merge-sizes'
           git remote set-branches "${UPSTREAM_REMOTE_NAME}" "${GITHUB_BASE_REF}"
           git fetch --depth=1 "${UPSTREAM_REMOTE_NAME}" "${GITHUB_BASE_REF}"
           git checkout "${UPSTREAM_REMOTE_NAME}/${GITHUB_BASE_REF}"
-          make -j2 examples && \
+          make -j$(nproc) examples && \
             cargo run --release -p print_sizes >'${{runner.temp}}/base-sizes' || \
             echo 'Broken build on the master branch.'
 


### PR DESCRIPTION
Remove claims about the exact infra that GitHub runs on, and just extract the number of logical cores at runtime (i.e. `-j2` --> `-j$(nproc)`) — fully acknowledging that this does still currently expand to `2`.